### PR TITLE
chore: add baseline performance instrumentation

### DIFF
--- a/src/app/api/approvedUGCCount/route.ts
+++ b/src/app/api/approvedUGCCount/route.ts
@@ -7,6 +7,7 @@ import { eq, and } from "drizzle-orm";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
+  const start = performance.now();
   try {
     const session = await getServerAuthSession();
 
@@ -27,5 +28,8 @@ export async function GET() {
   } catch (e) {
     console.error("[approvedUGCCount] error", e);
     return NextResponse.json({ count: 0 }, { status: 500 });
+  } finally {
+    const end = performance.now();
+    console.debug(`[approvedUGCCount] GET took ${end - start}ms`);
   }
-} 
+}

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -6,6 +6,7 @@ export const dynamic = "force-dynamic";
 export const revalidate = 60; // cache for 1 minute
 
 export async function GET(request: NextRequest | Request) {
+    const start = performance.now();
     try {
         // Check if walletless mode is enabled
         const walletlessEnabled = process.env.NEXT_PUBLIC_DISABLE_WALLET_REQUIREMENT === 'true' && process.env.NODE_ENV !== 'production';
@@ -49,5 +50,8 @@ export async function GET(request: NextRequest | Request) {
             { error: "Failed to fetch leaderboard", details: error instanceof Error ? error.message : "Unknown error" },
             { status: 500 }
         );
+    } finally {
+        const end = performance.now();
+        console.debug(`[leaderboard] GET took ${end - start}ms`);
     }
-} 
+}

--- a/src/app/api/pendingUGCCount/route.ts
+++ b/src/app/api/pendingUGCCount/route.ts
@@ -6,6 +6,7 @@ import { getUserById } from "@/server/utils/queries/userQueries";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
+  const start = performance.now();
   try {
     const session = await getServerAuthSession();
     if (!session || !session.user?.id) {
@@ -24,5 +25,8 @@ export async function GET() {
   } catch (e) {
     console.error("[pendingUGCCount] error", e);
     return NextResponse.json({ count: 0 }, { status: 500 });
+  } finally {
+    const end = performance.now();
+    console.debug(`[pendingUGCCount] GET took ${end - start}ms`);
   }
-} 
+}

--- a/src/app/api/platformRegexes/route.ts
+++ b/src/app/api/platformRegexes/route.ts
@@ -4,13 +4,17 @@ import { getAllLinks } from '@/server/utils/queries/artistQueries';
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
+  const start = performance.now();
   const allLinks = await getAllLinks();
   // Only include platforms that are not 'ens' or 'wallets'
   const regexes = allLinks
     .filter(link => link.siteName !== 'ens' && link.siteName !== 'wallets')
     .map(link => ({ siteName: link.siteName, regex: link.regex }));
-  return new Response(JSON.stringify(regexes), {
+  const response = new Response(JSON.stringify(regexes), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
   });
-} 
+  const end = performance.now();
+  console.debug(`[platformRegexes] GET took ${end - start}ms`);
+  return response;
+}

--- a/src/app/api/searchArtists/route.ts
+++ b/src/app/api/searchArtists/route.ts
@@ -102,6 +102,7 @@ function getMatchScore(name: string, query: string) {
 // Returns:
 //      Response with combined and sorted search results or error message
 export async function POST(req: Request) {
+  const start = performance.now();
   try {
     const { query, bookmarkedArtistIds = [] } = await req.json();
     
@@ -224,7 +225,7 @@ export async function POST(req: Request) {
 
     // Race between the search operation and timeout
     return await Promise.race([searchOperation(), timeoutPromise]);
-    
+
   } catch (error) {
     console.error('Error in search artists:', error);
     
@@ -239,5 +240,8 @@ export async function POST(req: Request) {
       { error: "Internal server error" },
       { status: 500 }
     );
+  } finally {
+    const end = performance.now();
+    console.debug(`[searchArtists] POST took ${end - start}ms`);
   }
 }

--- a/src/app/api/ugcCount/route.ts
+++ b/src/app/api/ugcCount/route.ts
@@ -7,6 +7,7 @@ import { eq } from "drizzle-orm";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
+  const start = performance.now();
   try {
     const session = await getServerAuthSession();
     if (!session || !session.user?.id) {
@@ -23,5 +24,8 @@ export async function GET() {
   } catch (e) {
     console.error("[ugcCount] error", e);
     return NextResponse.json({ count: 0 }, { status: 500 });
+  } finally {
+    const end = performance.now();
+    console.debug(`[ugcCount] GET took ${end - start}ms`);
   }
-} 
+}

--- a/src/app/api/userEntries/route.ts
+++ b/src/app/api/userEntries/route.ts
@@ -9,6 +9,7 @@ export const dynamic = "force-dynamic";
 const PER_PAGE = 10;
 
 export async function GET(request: Request) {
+  const start = performance.now();
   try {
     const { searchParams } = new URL(request.url);
     const pageParam = parseInt(searchParams.get("page") ?? "1", 10);
@@ -69,5 +70,8 @@ export async function GET(request: Request) {
   } catch (e) {
     console.error("[userEntries] error", e);
     return NextResponse.json({ entries: [], total: 0, pageCount: 0 }, { status: 500 });
+  } finally {
+    const end = performance.now();
+    console.debug(`[userEntries] GET took ${end - start}ms`);
   }
-} 
+}

--- a/src/app/api/validateLink/route.ts
+++ b/src/app/api/validateLink/route.ts
@@ -124,6 +124,7 @@ const platforms = [
 ];
 
 export async function POST(req: NextRequest) {
+  const start = performance.now();
   const { url } = await req.json();
   if (!url || typeof url !== 'string') {
     return new Response(JSON.stringify({ valid: false, reason: 'No URL provided' }), {
@@ -205,5 +206,8 @@ export async function POST(req: NextRequest) {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     });
+  } finally {
+    const end = performance.now();
+    console.debug(`[validateLink] POST took ${end - start}ms`);
   }
-} 
+}

--- a/src/server/utils/queries/artistQueries.ts
+++ b/src/server/utils/queries/artistQueries.ts
@@ -195,7 +195,13 @@ export async function getArtistById(id: string) {
 // ----------------------------------
 
 export async function getAllLinks() {
-    return await db.query.urlmap.findMany();
+    const start = performance.now();
+    try {
+        return await db.query.urlmap.findMany();
+    } finally {
+        const end = performance.now();
+        console.debug(`[getAllLinks] took ${end - start}ms`);
+    }
 }
 
 export async function getArtistLinks(artist: Artist): Promise<ArtistLink[]> {
@@ -547,6 +553,7 @@ export async function addArtistData(artistUrl: string, artist: Artist): Promise<
 // ----------------------------------
 
 export async function getPendingUGC() {
+    const start = performance.now();
     try {
         const result = await db.query.ugcresearch.findMany({ where: eq(ugcresearch.accepted, false), with: { ugcUser: true } });
         return result.map((obj) => {
@@ -556,6 +563,9 @@ export async function getPendingUGC() {
     } catch (e) {
         console.error("error getting pending ugc", e);
         throw new Error("Error finding pending UGC");
+    } finally {
+        const end = performance.now();
+        console.debug(`[getPendingUGC] took ${end - start}ms`);
     }
 }
 

--- a/src/server/utils/queries/leaderboardQueries.ts
+++ b/src/server/utils/queries/leaderboardQueries.ts
@@ -17,9 +17,10 @@ export type LeaderboardEntry = {
 };
 
 export async function getLeaderboard(): Promise<LeaderboardEntry[]> {
+    const start = performance.now();
     try {
         const result = await db.execute<LeaderboardEntry>(sql`
-            SELECT 
+            SELECT
                 u.id   AS "userId",
                 u.wallet,
                 u.username,
@@ -41,14 +42,18 @@ export async function getLeaderboard(): Promise<LeaderboardEntry[]> {
     } catch (e) {
         console.error("error getting leaderboard", e);
         throw new Error("Error getting leaderboard");
+    } finally {
+        const end = performance.now();
+        console.debug(`[getLeaderboard] took ${end - start}ms`);
     }
 }
 
 // Get leaderboard stats within a date range (inclusive)
 export async function getLeaderboardInRange(fromIso: string, toIso: string): Promise<LeaderboardEntry[]> {
+    const start = performance.now();
     try {
         const result = await db.execute<LeaderboardEntry>(sql`
-            SELECT 
+            SELECT
                 u.id   AS "userId",
                 u.wallet,
                 u.username,
@@ -74,8 +79,11 @@ export async function getLeaderboardInRange(fromIso: string, toIso: string): Pro
     } catch (e) {
         console.error("error getting leaderboard in range", e);
         throw new Error("Error getting leaderboard in range");
+    } finally {
+        const end = performance.now();
+        console.debug(`[getLeaderboardInRange] took ${end - start}ms`);
     }
-} 
+}
 
 export async function getUgcStats() {
     const user = await getServerAuthSession();


### PR DESCRIPTION
## Summary
- log execution time for UGC, leaderboard, search, and validation API routes
- instrument helper queries for links, pending UGC, and leaderboard stats

## Testing
- `npm run build` *(fails: NEXT_PUBLIC_SPOTIFY_WEB_CLIENT_ID environment variable is required)*
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d57dc4edc832498c21e7f0b8fea5f