### PR TITLE
Ensure pg_trgm similarity threshold is awaited in artist search

### DIFF
--- a/src/server/utils/queries/artistQueries.ts
+++ b/src/server/utils/queries/artistQueries.ts
@@ -139,7 +139,12 @@ export async function searchForArtistByName(name: string) {
         // Normalise the incoming query (lower-case, accents & punctuation removed)
         const normalisedQuery = normaliseText(name);
 
-        db.execute(sql`SET LOCAL pg_trgm.similarity_threshold = 0.3;`);
+        try {
+            await db.execute(sql`SET LOCAL pg_trgm.similarity_threshold = 0.3;`);
+        } catch (err) {
+            console.error("Error setting pg_trgm similarity threshold", err);
+            throw err;
+        }
         const result = await db.execute<Artist>(sql`
             SELECT
             id, name, spotify, bandcamp, youtube, youtubechannel,


### PR DESCRIPTION
## Summary
- await pg_trgm similarity threshold setup and handle failures in artist search

## Testing
- `NEXT_PUBLIC_SPOTIFY_WEB_CLIENT_ID=abc NEXT_PUBLIC_SPOTIFY_WEB_CLIENT_SECRET=abc SUPABASE_DB_CONNECTION=postgresql://user:pass@localhost:5432/db NEXTAUTH_URL=http://localhost NEXTAUTH_SECRET=secret OPENAI_API_KEY=sk-abc npm run build`
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a37c788fc88324b7756230525e88a0