### PR TITLE
docs: add auth plans

### DIFF
--- a/plans/jwt-bearer-token-auth-plan.md
+++ b/plans/jwt-bearer-token-auth-plan.md
@@ -1,0 +1,29 @@
+# JWT Bearer Token Authentication Plan
+
+## Goal
+Secure public API routes with short‑lived bearer tokens signed using the existing NextAuth JWT secret.
+
+## Integration Notes
+NextAuth already issues JWTs for sessions. We can reuse its `NEXTAUTH_SECRET` and helper utilities to sign and verify client tokens so that token handling stays consistent.
+
+## Tasks
+1. **Token issuance endpoint**
+   - Create `/api/auth/client-token` that authenticates callers (e.g., via admin session or static provisioning key).
+   - Use `next-auth/jwt` helpers to sign a JWT containing client identifier and expiration.
+2. **Verification middleware**
+   - Parse `Authorization: Bearer <token>` header.
+   - Validate token signature and expiry with `next-auth/jwt`'s `getToken` or `jwtVerify` using `NEXTAUTH_SECRET`.
+   - Attach decoded client info to request context.
+3. **Protect OpenAI routes**
+   - Wrap `funFacts`, `artistBio`, and other OpenAI routes with the middleware.
+   - Deny access when token is invalid, expired, or missing.
+4. **Revocation & logging**
+   - Maintain allow‑list/deny‑list for issued tokens (e.g., DB table of token IDs or jti claims).
+   - Log token usage for auditing and detect abuse.
+5. **Client documentation**
+   - Describe how to obtain tokens and include them in `Authorization` header.
+   - Include expiry, renewal, and rotation guidance.
+
+## Verification
+- Unit tests for token issuance and verification logic.
+- Integration tests ensuring protected routes reject requests without valid tokens.

--- a/plans/static-api-key-auth-plan.md
+++ b/plans/static-api-key-auth-plan.md
@@ -1,0 +1,26 @@
+# Static API Key Authentication Plan
+
+## Goal
+Protect public OpenAI-powered API routes by requiring clients to supply a valid static API key.
+
+## Tasks
+1. **Design key storage**
+   - Decide on persistence: environment variable list for simple setups or new `api_keys` table with hashed keys for per-client management.
+   - Provide utility script to generate keys and hashes.
+2. **Create validation middleware**
+   - Read `X-API-Key` header.
+   - Compare hashed value against allow‑list.
+   - Return `401 Unauthorized` when missing/invalid.
+3. **Apply middleware to sensitive routes**
+   - Wrap existing OpenAI routes such as `funFacts` and `artistBio`.
+   - Ensure early exit before contacting OpenAI.
+4. **Add rate limiting & logging hooks**
+   - Track requests per API key.
+   - Surface suspicious activity in logs.
+5. **Document client usage**
+   - Explain header format and rotation procedure.
+   - Note that keys should be kept secret and rotated periodically.
+
+## Verification
+- Unit tests for middleware accepting/denying requests.
+- Integration tests hitting protected routes with valid/invalid keys.


### PR DESCRIPTION
## Summary
- outline static API key authentication approach for protecting OpenAI routes
- draft JWT bearer token plan reusing NextAuth's JWT utilities

## Testing
- `npm run build` *(fails: NEXT_PUBLIC_SPOTIFY_WEB_CLIENT_ID environment variable is required)*
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3a8d3aa6c8324b9db93b9a195f2df