### PR TITLE
feat: refresh session after login

### DIFF
--- a/src/app/_components/AutoRefresh.tsx
+++ b/src/app/_components/AutoRefresh.tsx
@@ -39,16 +39,25 @@ export default function AutoRefresh({
 
   useEffect(() => {
     const skip = sessionStorage.getItem(sessionStorageKey) === "true";
+    console.debug("[AutoRefresh] effect", {
+      status,
+      prevStatus: prevStatus.current,
+      skip
+    });
 
     // Check if we need to refresh on initial load or status change
     if (!skip && status !== "loading") {
       // On initial load, prevStatus.current will be null, so we check if we're authenticated
       // On subsequent loads, we check if status changed from unauthenticated to authenticated
-      const shouldRefresh = 
+      const shouldRefresh =
         (prevStatus.current === null && status === "authenticated") || // Initial load with auth
         (prevStatus.current && prevStatus.current !== status && status === "authenticated"); // Status change to auth
-      
+
       if (shouldRefresh) {
+        console.debug("[AutoRefresh] refreshing", {
+          from: prevStatus.current,
+          to: status
+        });
         sessionStorage.setItem(sessionStorageKey, "true");
         // Soft refresh so server components pick up the new session instantly
         if (typeof router.refresh === "function") {
@@ -59,6 +68,7 @@ export default function AutoRefresh({
 
     if (skip && status !== "loading") {
       // Clear flag once the page has stabilized
+      console.debug("[AutoRefresh] clearing flag");
       sessionStorage.removeItem(sessionStorageKey);
     }
 

--- a/src/app/_components/AutoRefresh.tsx
+++ b/src/app/_components/AutoRefresh.tsx
@@ -2,23 +2,25 @@
 
 import { useEffect, useState, useRef } from "react";
 import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
 
 /**
- * Universal auto-refresh component that triggers a page reload when the user signs in
+ * Universal auto-refresh component that triggers a soft refresh when the user signs in
  * to ensure server components pick up the new session data immediately.
  * Uses sessionStorage to prevent multiple refreshes.
  * 
  * @param sessionStorageKey - Optional custom key for sessionStorage (defaults to "autoRefreshSkipReload")
  * @param showLoading - Whether to show loading state (defaults to true)
  */
-export default function AutoRefresh({ 
-  sessionStorageKey = "autoRefreshSkipReload", 
-  showLoading = true 
-}: { 
-  sessionStorageKey?: string; 
-  showLoading?: boolean; 
+export default function AutoRefresh({
+  sessionStorageKey = "autoRefreshSkipReload",
+  showLoading = true
+}: {
+  sessionStorageKey?: string;
+  showLoading?: boolean;
 } = {}) {
   const { status } = useSession();
+  const router = useRouter();
   const [isLoading, setIsLoading] = useState(true);
   const prevStatus = useRef<typeof status | null>(null);
 
@@ -48,8 +50,10 @@ export default function AutoRefresh({
       
       if (shouldRefresh) {
         sessionStorage.setItem(sessionStorageKey, "true");
-        // Full reload so server components pick up the new session instantly
-        window.location.reload();
+        // Soft refresh so server components pick up the new session instantly
+        if (typeof router.refresh === "function") {
+          router.refresh();
+        }
       }
     }
 

--- a/src/app/_components/nav/components/Login.tsx
+++ b/src/app/_components/nav/components/Login.tsx
@@ -71,6 +71,7 @@ const WalletLogin = forwardRef<HTMLButtonElement, LoginProps>(
         if (isConnected && session) {
             // Ensure we only refresh once per connection
             if (!hasRefreshed.current) {
+                console.debug("[Login] refreshing after wallet connection");
                 hasRefreshed.current = true;
                 router.refresh();
             }
@@ -101,6 +102,9 @@ const WalletLogin = forwardRef<HTMLButtonElement, LoginProps>(
         // Handle initial login or reconnection
         if (!isConnected && !session && status === "unauthenticated") {
             // Reset refresh state when fully logged out
+            if (hasRefreshed.current) {
+                console.debug("[Login] resetting refresh state after logout");
+            }
             hasRefreshed.current = false;
             const loginInitiator = sessionStorage.getItem('loginInitiator');
             const isSearchFlow = sessionStorage.getItem('searchFlow');

--- a/src/app/_components/nav/components/Login.tsx
+++ b/src/app/_components/nav/components/Login.tsx
@@ -41,6 +41,7 @@ const WalletLogin = forwardRef<HTMLButtonElement, LoginProps>(
     const [ugcCount, setUgcCount] = useState<number>(0);
     const [hasNewUGC, setHasNewUGC] = useState(false);
     const shouldPromptRef = useRef(false);
+    const hasRefreshed = useRef(false);
 
     const { isConnected, address } = useAccount();
     const { disconnect } = useDisconnect();
@@ -68,14 +69,20 @@ const WalletLogin = forwardRef<HTMLButtonElement, LoginProps>(
 
         // Handle successful authentication
         if (isConnected && session) {
+            // Ensure we only refresh once per connection
+            if (!hasRefreshed.current) {
+                hasRefreshed.current = true;
+                router.refresh();
+            }
+
             // Reset prompt flag
             shouldPromptRef.current = false;
-            
+
             // Clear loading state if it was set
             if (searchBarRef?.current) {
                 searchBarRef.current.clearLoading();
             }
-            
+
             if (sessionStorage.getItem('searchFlow')) {
                 // Show success toast once
                 toast({
@@ -93,6 +100,8 @@ const WalletLogin = forwardRef<HTMLButtonElement, LoginProps>(
 
         // Handle initial login or reconnection
         if (!isConnected && !session && status === "unauthenticated") {
+            // Reset refresh state when fully logged out
+            hasRefreshed.current = false;
             const loginInitiator = sessionStorage.getItem('loginInitiator');
             const isSearchFlow = sessionStorage.getItem('searchFlow');
             const isSearchFlowPrompted = sessionStorage.getItem('searchFlowPrompted');


### PR DESCRIPTION
## Summary
- use Next.js router.refresh to revalidate session after sign in
- add guard for refresh in non-NexJS environments

## Testing
- `npm run build`
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a75662a3388324a7fbe3e7de6efa08