### PR TITLE
Fix 'View on Spotify' link in search results

### DIFF
--- a/src/app/_components/nav/components/SearchBar.tsx
+++ b/src/app/_components/nav/components/SearchBar.tsx
@@ -380,8 +380,11 @@ const WalletSearchBar = forwardRef(
                                                         <div className="text-xs text-gray-500 flex items-center gap-1">
                                                             <span className="cursor-pointer hover:text-gray-600 hover:underline">Add to MusicNerd</span>
                                                             <span className="text-pink-400">|</span>
-                                                            <div 
+                                                            <div
                                                                 className="flex items-center gap-1 text-xs text-gray-500 cursor-pointer hover:text-gray-600"
+                                                                onMouseDown={(e) => {
+                                                                    e.stopPropagation();
+                                                                }}
                                                                 onClick={(e) => {
                                                                     e.stopPropagation();
                                                                     window.open(`https://open.spotify.com/artist/${result.spotify}`, '_blank');
@@ -832,8 +835,11 @@ const NoWalletSearchBar = forwardRef(
                                                         <div className="text-xs text-gray-500 flex items-center gap-1">
                                                             <span className="cursor-pointer hover:text-gray-600 hover:underline">Add to MusicNerd</span>
                                                             <span className="text-gray-300">|</span>
-                                                            <div 
+                                                            <div
                                                                 className="flex items-center gap-1 text-xs text-gray-500 cursor-pointer hover:text-gray-600"
+                                                                onMouseDown={(e) => {
+                                                                    e.stopPropagation();
+                                                                }}
                                                                 onClick={(e) => {
                                                                     e.stopPropagation();
                                                                     window.open(`https://open.spotify.com/artist/${result.spotify}`, '_blank');


### PR DESCRIPTION
## Summary
Fixes #911 - The "View on Spotify" link in search results was not working due to an event handling conflict.

## Root Cause
- Parent `<div>` uses `onMouseDown` with `e.preventDefault()` to handle artist navigation
- Child "View on Spotify" `<div>` uses `onClick` to open Spotify links
- `onMouseDown` fires before `onClick`, so the parent's handler prevents the child's from executing properly

## Solution
Added `onMouseDown={(e) => e.stopPropagation()}` to the "View on Spotify" divs in both implementations:
- **WalletSearchBar** (line 383)
- **NoWalletSearchBar** (line 835)

This prevents the parent's `onMouseDown` handler from firing when clicking the Spotify link, allowing the `onClick` handler to execute properly and open the link in a new tab.

## Testing
- ✅ All 372 tests pass
- ✅ Type checking passes
- ✅ Linting passes
- ✅ Build successful

## Manual Testing Required
- [ ] Click "View on Spotify" in search results → should open Spotify in new tab
- [ ] Click other parts of search result → should still navigate to artist page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops parent onMouseDown from intercepting clicks so "View on Spotify" in search results opens Spotify correctly.
> 
> - **Search results (SearchBar.tsx)**:
>   - Add `onMouseDown={(e) => e.stopPropagation()}` to "View on Spotify" link containers in both `WalletSearchBar` and `NoWalletSearchBar` to prevent parent `onMouseDown` from blocking the link's `onClick`.
>   - Ensures Spotify artist links open in a new tab without triggering parent navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d9135ddc4475ff0d4ad8f60d0d4b306b5b5e66d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->