### PR TITLE
Fix LegacyAccountModal dark mode styling

### DIFF
--- a/src/app/_components/nav/components/LegacyAccountModal.tsx
+++ b/src/app/_components/nav/components/LegacyAccountModal.tsx
@@ -87,7 +87,7 @@ export function LegacyAccountModal({ open, onClose }: LegacyAccountModalProps) {
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Welcome to Music Nerd!</DialogTitle>
+          <DialogTitle className="dark:text-white">Welcome to Music Nerd!</DialogTitle>
           <DialogDescription className="text-sm text-muted-foreground">
             Have an existing Music Nerd wallet-based account? Connect your
             wallet to link your old account and restore your contribution history.


### PR DESCRIPTION
## Summary
- Fix near-invisible buttons in the LegacyAccountModal when using dark mode
- Add explicit dark mode classes to the "Skip for now" button (border, text, hover)
- Add `text-black` to the "Connect Wallet" button for readability on the pink background
- Make the dialog title visible in dark mode with `dark:text-white`

## Test plan
- [x] Visually verified dark mode styling via Playwright
- [ ] Confirm buttons and title are clearly visible in both light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational Tailwind class changes scoped to a single modal; no behavioral, data, or auth logic changes.
> 
> **Overview**
> Improves `LegacyAccountModal` dark-mode readability by explicitly styling the dialog title and action buttons.
> 
> Adds `dark:text-white` to the title, dark-mode border/text/hover classes to the outlined “Skip for now” button, and `text-black` to the pink “Connect Wallet” button so controls aren’t near-invisible in dark theme.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7055682b326987c8a084bb3e94dde1d2fe0afb63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->