### PR TITLE
Enable wallet connectors for legacy account linking

### DIFF
--- a/src/app/_components/PrivyProviderWrapper.tsx
+++ b/src/app/_components/PrivyProviderWrapper.tsx
@@ -25,6 +25,13 @@ export function PrivyProviderWrapper({ children }: PrivyProviderWrapperProps) {
           theme: 'dark',
           accentColor: '#E91E8C', // MusicNerd pink
           logo: '/musicNerdLogo.png',
+          walletList: [
+            'detected_ethereum_wallets',
+            'metamask',
+            'coinbase_wallet',
+            'rainbow',
+            'wallet_connect',
+          ],
         },
         // Login methods - email only
         loginMethods: ['email'],


### PR DESCRIPTION
## Summary
- Add `walletList` config to PrivyProvider so the wallet selector modal appears when users click "Connect Wallet" in LegacyAccountModal
- Includes MetaMask, Coinbase Wallet, Rainbow, WalletConnect, and auto-detected browser extensions
- Requires "External wallets" to be enabled in the Privy dashboard (already done)

## Test plan
- [x] Wallet selector modal appears with configured wallets
- [ ] End-to-end wallet linking flow on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication-adjacent wallet linking behavior; while it’s mostly configuration, it can change which wallets users can connect and may affect account-linking flows in production.
> 
> **Overview**
> Enables Privy’s external wallet selector by adding an explicit `walletList` to `PrivyProviderWrapper`, offering detected browser wallets plus MetaMask, Coinbase Wallet, Rainbow, and WalletConnect.
> 
> This changes the wallet connection UX/behavior for flows that invoke Privy wallet linking (e.g., legacy account linking) without altering embedded wallet creation settings or login methods.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c682db080f9bb0c8f42305a52ee1d76b3425f204. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->