### PR TITLE
Fix unique constraint violation in account merge

### DIFF
--- a/src/server/utils/queries/userQueries.ts
+++ b/src/server/utils/queries/userQueries.ts
@@ -362,6 +362,10 @@ export async function mergeAccounts(
                 return { success: false as const, error: 'User not found' };
             }
 
+            if (!currentUser.privyUserId) {
+                return { success: false as const, error: 'Current user has no Privy ID' };
+            }
+
             // Clear privyUserId from placeholder first to avoid unique constraint violation
             await tx
                 .update(users)


### PR DESCRIPTION
## Summary
- Fix `duplicate key value violates unique constraint "users_privy_user_id_key"` error during legacy account merge
- The transaction now clears `privyUserId` from the placeholder user before setting it on the legacy user

## Test plan
- [x] Existing `mergeAccounts` tests pass (16/16)
- [ ] End-to-end merge flow on staging with real wallet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches account-merge logic that mutates user records and related foreign keys; failure modes could impact user linking/identity if the transaction/order is wrong, but the change is small and covered by new unit tests.
> 
> **Overview**
> Fixes legacy account merging to avoid `users_privy_user_id_key` unique constraint violations by **clearing `privyUserId` on the placeholder/current user before assigning it to the legacy user** within the same transaction.
> 
> Adds safeguards and coverage: `mergeAccounts` now returns an explicit failure when the current user lacks a `privyUserId`, and unit tests assert both the new error case and the two-step update ordering (clear then set).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a578ff12d5bbdb45ce436329696195f6cfe301ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->