### PR TITLE
Fix case-sensitive wallet lookup preventing account merge

### DIFF
--- a/src/server/utils/queries/userQueries.ts
+++ b/src/server/utils/queries/userQueries.ts
@@ -7,7 +7,7 @@ export async function getUserByWallet(wallet: string) {
     try {
         // Normalize wallet address to lowercase for consistent lookups
         const normalizedWallet = wallet.toLowerCase();
-        const result = await withDbRetry(() => db.query.users.findFirst({ where: eq(users.wallet, normalizedWallet) }));
+        const result = await withDbRetry(() => db.query.users.findFirst({ where: ilike(users.wallet, normalizedWallet) }));
         return result;
     } catch (error) {
         console.error("error getting user by wallet", error);


### PR DESCRIPTION
## Summary
- `getUserByWallet` uses `eq()` (case-sensitive in PostgreSQL) but legacy wallets are stored with mixed-case checksummed addresses (e.g. `0x9Ea38c...`)
- The lookup normalizes input to lowercase, so `eq()` never matches the mixed-case stored value
- This caused the link-wallet endpoint to skip the merge path entirely, just linking the wallet to the placeholder instead
- Fix: change `eq` to `ilike` for case-insensitive matching

## Test plan
- [x] All 48 existing tests pass (userQueriesPrivy: 18, link-wallet: 13, auth: 17)
- [ ] Reset devdb, re-test merge flow — should see "Account Merged" toast instead of "Wallet Linked"

🤖 Generated with [Claude Code](https://claude.com/claude-code)