### PR TITLE
feat: Restore admin route auth checks (Phase 1)

### DIFF
--- a/e2e/admin-auth.spec.ts
+++ b/e2e/admin-auth.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { login, fetchAsUser } from './helpers/auth';
+
+const ADMIN_EMAIL = 'test-3256@privy.io';
+const ADMIN_OTP = '207862';
+const USER_EMAIL = 'test-4473@privy.io';
+const USER_OTP = '676856';
+
+test.describe('Admin auth routes', () => {
+  test('admin can update user whitelist status', async ({ page }) => {
+    await login(page, ADMIN_EMAIL, ADMIN_OTP);
+    // Actual test would need a real user ID to update
+    // This is a smoke test to verify auth flow works
+    const res = await fetchAsUser(page, '/api/admin/whitelist-user/nonexistent-id', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isWhiteListed: true }),
+    });
+    // Should get 400 (user not found / no fields) rather than 401/403
+    expect([200, 400]).toContain(res.status);
+  });
+
+  test('regular user gets 403 on admin operations', async ({ page }) => {
+    await login(page, USER_EMAIL, USER_OTP);
+    const res = await fetchAsUser(page, '/api/admin/whitelist-user/some-id', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ isWhiteListed: true }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test('unauthenticated request gets 401', async ({ page }) => {
+    const res = await page.request.put('/api/admin/whitelist-user/some-id', {
+      data: { isWhiteListed: true },
+    });
+    expect(res.status()).toBe(401);
+  });
+});

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -38,7 +38,7 @@ const customJestConfig: Config = {
     transformIgnorePatterns: [
         'node_modules/(?!(jose|@radix-ui|@panva|@tanstack|@tanstack/react-query|@tanstack/query-core)/)'
     ],
-    testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/.next/'],
+    testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/.next/', '<rootDir>/e2e/'],
     moduleDirectories: ['node_modules', '<rootDir>/'],
     testMatch: [
         '**/__tests__/**/*.[jt]s?(x)',

--- a/src/app/api/admin/whitelist-user/[id]/__tests__/route.test.ts
+++ b/src/app/api/admin/whitelist-user/[id]/__tests__/route.test.ts
@@ -1,0 +1,97 @@
+// @ts-nocheck
+import { jest } from '@jest/globals';
+
+jest.mock('@/lib/auth-helpers', () => ({ requireAdmin: jest.fn() }));
+jest.mock('@/server/utils/queries/userQueries', () => ({ updateWhitelistedUser: jest.fn() }));
+
+if (!('json' in Response)) {
+  Response.json = (data, init) =>
+    new Response(JSON.stringify(data), {
+      headers: { 'Content-Type': 'application/json', ...(init?.headers || {}) },
+      status: init?.status || 200,
+    });
+}
+
+const createRequest = (body) =>
+  new Request('http://localhost/api/admin/whitelist-user/test-user-id', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+const adminAuth = {
+  authenticated: true,
+  session: { user: { id: 'admin-uuid', email: 'admin@test.com' }, expires: '2025-12-31' },
+  userId: 'admin-uuid',
+};
+
+describe('PUT /api/admin/whitelist-user/[id]', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  async function setup() {
+    const { requireAdmin } = await import('@/lib/auth-helpers');
+    const { updateWhitelistedUser } = await import('@/server/utils/queries/userQueries');
+    const { PUT } = await import('../route');
+    return { PUT, mockRequireAdmin: requireAdmin, mockUpdateWhitelistedUser: updateWhitelistedUser };
+  }
+
+  it('returns 401 when not authenticated', async () => {
+    const { PUT, mockRequireAdmin } = await setup();
+    mockRequireAdmin.mockResolvedValue({
+      authenticated: false,
+      response: Response.json({ error: 'Not authenticated' }, { status: 401 }),
+    });
+
+    const response = await PUT(createRequest({ isAdmin: true }), { params: Promise.resolve({ id: 'user-1' }) });
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 403 when non-admin tries to update', async () => {
+    const { PUT, mockRequireAdmin } = await setup();
+    mockRequireAdmin.mockResolvedValue({
+      authenticated: false,
+      response: Response.json({ error: 'Forbidden' }, { status: 403 }),
+    });
+
+    const response = await PUT(createRequest({ isAdmin: true }), { params: Promise.resolve({ id: 'user-1' }) });
+    expect(response.status).toBe(403);
+  });
+
+  it('returns 200 on successful update', async () => {
+    const { PUT, mockRequireAdmin, mockUpdateWhitelistedUser } = await setup();
+    mockRequireAdmin.mockResolvedValue(adminAuth);
+    mockUpdateWhitelistedUser.mockResolvedValue({ status: 'success', message: 'User updated successfully' });
+
+    const response = await PUT(
+      createRequest({ username: 'newname', isWhiteListed: true }),
+      { params: Promise.resolve({ id: 'user-1' }) }
+    );
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.status).toBe('success');
+  });
+
+  it('returns 400 when updateWhitelistedUser returns error', async () => {
+    const { PUT, mockRequireAdmin, mockUpdateWhitelistedUser } = await setup();
+    mockRequireAdmin.mockResolvedValue(adminAuth);
+    mockUpdateWhitelistedUser.mockResolvedValue({ status: 'error', message: 'No fields to update' });
+
+    const response = await PUT(
+      createRequest({}),
+      { params: Promise.resolve({ id: 'user-1' }) }
+    );
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.status).toBe('error');
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    const { PUT, mockRequireAdmin } = await setup();
+    mockRequireAdmin.mockRejectedValue(new Error('DB exploded'));
+
+    const response = await PUT(createRequest({ isAdmin: true }), { params: Promise.resolve({ id: 'user-1' }) });
+    expect(response.status).toBe(500);
+  });
+});

--- a/src/app/api/admin/whitelist-user/[id]/route.ts
+++ b/src/app/api/admin/whitelist-user/[id]/route.ts
@@ -1,5 +1,24 @@
-import { unauthorizedResponse } from '@/lib/apiErrors';
+import { NextRequest, NextResponse } from "next/server";
+import { updateWhitelistedUser } from "@/server/utils/queries/userQueries";
+import { requireAdmin } from "@/lib/auth-helpers";
 
-export async function PUT() {
-  return unauthorizedResponse();
-} 
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const { wallet, email, username, isAdmin, isWhiteListed, isHidden } = body ?? {};
+
+    // Require admin for role changes
+    const auth = await requireAdmin();
+    if (!auth.authenticated) {
+      return auth.response;
+    }
+
+    const resp = await updateWhitelistedUser(id, { wallet, email, username, isAdmin, isWhiteListed, isHidden });
+    const statusCode = resp.status === "success" ? 200 : 400;
+    return NextResponse.json(resp, { status: statusCode });
+  } catch (e) {
+    console.error("update whitelist user error", e);
+    return NextResponse.json({ status: "error", message: "Server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/artistBio/[id]/__tests__/route.test.ts
+++ b/src/app/api/artistBio/[id]/__tests__/route.test.ts
@@ -1,0 +1,92 @@
+// @ts-nocheck
+import { jest } from '@jest/globals';
+
+jest.mock('@/lib/auth-helpers', () => ({ requireAdmin: jest.fn() }));
+jest.mock('@/server/utils/queries/artistQueries', () => ({
+  getArtistById: jest.fn(),
+  updateArtistBio: jest.fn(),
+}));
+jest.mock('@/server/utils/queries/artistBioQuery', () => ({ getOpenAIBio: jest.fn() }));
+
+if (!('json' in Response)) {
+  Response.json = (data, init) =>
+    new Response(JSON.stringify(data), {
+      headers: { 'Content-Type': 'application/json', ...(init?.headers || {}) },
+      status: init?.status || 200,
+    });
+}
+
+const adminAuth = {
+  authenticated: true,
+  session: { user: { id: 'admin-uuid' }, expires: '2025-12-31' },
+  userId: 'admin-uuid',
+};
+
+const createPutRequest = (body) =>
+  new Request('http://localhost/api/artistBio/artist-1', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+describe('PUT /api/artistBio/[id]', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  async function setup() {
+    const { requireAdmin } = await import('@/lib/auth-helpers');
+    const { updateArtistBio } = await import('@/server/utils/queries/artistQueries');
+    const { PUT } = await import('../route');
+    return { PUT, mockRequireAdmin: requireAdmin, mockUpdateArtistBio: updateArtistBio };
+  }
+
+  it('returns 401 when not authenticated', async () => {
+    const { PUT, mockRequireAdmin } = await setup();
+    mockRequireAdmin.mockResolvedValue({
+      authenticated: false,
+      response: Response.json({ error: 'Not authenticated' }, { status: 401 }),
+    });
+
+    const response = await PUT(createPutRequest({ bio: 'test' }), { params: Promise.resolve({ id: 'a1' }) });
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 403 when non-admin', async () => {
+    const { PUT, mockRequireAdmin } = await setup();
+    mockRequireAdmin.mockResolvedValue({
+      authenticated: false,
+      response: Response.json({ error: 'Forbidden' }, { status: 403 }),
+    });
+
+    const response = await PUT(createPutRequest({ bio: 'test' }), { params: Promise.resolve({ id: 'a1' }) });
+    expect(response.status).toBe(403);
+  });
+
+  it('returns 200 for admin with valid bio', async () => {
+    const { PUT, mockRequireAdmin, mockUpdateArtistBio } = await setup();
+    mockRequireAdmin.mockResolvedValue(adminAuth);
+    mockUpdateArtistBio.mockResolvedValue({ status: 'success', message: 'Bio updated', data: null });
+
+    const response = await PUT(createPutRequest({ bio: 'A great artist.' }), { params: Promise.resolve({ id: 'a1' }) });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.message).toBe('Bio updated');
+  });
+
+  it('returns 400 for invalid bio (empty)', async () => {
+    const { PUT, mockRequireAdmin } = await setup();
+    mockRequireAdmin.mockResolvedValue(adminAuth);
+
+    const response = await PUT(createPutRequest({ bio: '' }), { params: Promise.resolve({ id: 'a1' }) });
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 for invalid bio (non-string)', async () => {
+    const { PUT, mockRequireAdmin } = await setup();
+    mockRequireAdmin.mockResolvedValue(adminAuth);
+
+    const response = await PUT(createPutRequest({ bio: 42 }), { params: Promise.resolve({ id: 'a1' }) });
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/app/api/artistBio/[id]/route.ts
+++ b/src/app/api/artistBio/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getArtistById } from "@/server/utils/queries/artistQueries";
 import { getOpenAIBio } from "@/server/utils/queries/artistBioQuery";
+import { requireAdmin } from "@/lib/auth-helpers";
 
 // CORS configuration for this route
 const ALLOWED_ORIGIN = process.env.NEXT_PUBLIC_ALLOWED_ORIGIN || "*";
@@ -81,6 +82,12 @@ export async function GET(_: Request, { params }: { params: Promise<{ id: string
 // ----------------------------------
 export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
+    // Require admin for bio updates
+    const auth = await requireAdmin();
+    if (!auth.authenticated) {
+      return auth.response;
+    }
+
     const { id } = await params;
     const body = await request.json();
     const bio: string = body?.bio;


### PR DESCRIPTION
## Summary
- Restores auth checks on `PUT /api/admin/whitelist-user/[id]` using `requireAdmin()` helper
- Adds `requireAdmin()` guard to `PUT /api/artistBio/[id]` (previously had no route-level auth)
- Adds Jest e2e exclusion to `jest.config.ts`

## Changes
| Route | Auth pattern | Tests |
|-------|-------------|-------|
| `PUT /api/admin/whitelist-user/[id]` | `requireAdmin()` → 401/403 | 5 unit tests |
| `PUT /api/artistBio/[id]` | `requireAdmin()` → 401/403 | 5 unit tests |

## Test plan
- [x] All 465 unit tests pass (`npm run test`)
- [x] Build succeeds (`npm run build`)
- [ ] Playwright e2e skeleton in `e2e/admin-auth.spec.ts` (run against staging after deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)