### PR TITLE
fix: disable Solana wallet connectors in Privy config

### DIFF
--- a/src/app/_components/PrivyProviderWrapper.tsx
+++ b/src/app/_components/PrivyProviderWrapper.tsx
@@ -41,6 +41,16 @@ export function PrivyProviderWrapper({ children }: PrivyProviderWrapperProps) {
             createOnLogin: 'off',
           },
         },
+        // Disable Solana wallet connectors — not used, suppresses console warning
+        externalWallets: {
+          solana: {
+            connectors: {
+              onMount: () => {},
+              onUnmount: () => {},
+              get: () => [],
+            },
+          },
+        },
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- Explicitly provides no-op Solana wallet connectors to the `PrivyProvider` config to suppress the console warning about missing Solana connectors
- The issue's suggested `connectors: () => []` didn't match Privy's `SolanaWalletConnectorsConfig` type, so the fix uses the correct shape with `onMount`, `onUnmount`, and `get` methods

## Test plan
- [ ] Verify no Solana wallet console warning appears in dev/production
- [ ] Verify Ethereum wallet linking still works for legacy account migration

Closes #972

🤖 Generated with [Claude Code](https://claude.com/claude-code)