### PR TITLE
fix: return 500 instead of 403 for artistBio PUT errors (#968)

### DIFF
--- a/src/app/api/artistBio/[id]/__tests__/route.test.ts
+++ b/src/app/api/artistBio/[id]/__tests__/route.test.ts
@@ -157,6 +157,48 @@ describe('/api/artistBio/[id]', () => {
       const data = await response.json();
       expect(data.message).toBe('Invalid bio');
     });
+
+    it('returns 500 when updateArtistBio returns error', async () => {
+      const { PUT, mockGetSession, mockGetUserById, mockUpdateArtistBio } =
+        await setup();
+      mockGetSession.mockResolvedValue(adminSession);
+      mockGetUserById.mockResolvedValue({ id: 'admin-uuid', isAdmin: true });
+      mockUpdateArtistBio.mockResolvedValue({
+        status: 'error',
+        message: 'Failed to generate bio',
+      });
+
+      const response = await PUT(
+        createPutRequest({ bio: 'Some bio text' }),
+        { params: paramsPromise }
+      );
+
+      expect(response.status).toBe(500);
+      const data = await response.json();
+      expect(data.message).toBe('Failed to generate bio');
+    });
+
+    it('returns 200 with regenerated bio when regenerate flag is set', async () => {
+      const { PUT, mockGetSession, mockGetUserById, mockUpdateArtistBio } =
+        await setup();
+      mockGetSession.mockResolvedValue(adminSession);
+      mockGetUserById.mockResolvedValue({ id: 'admin-uuid', isAdmin: true });
+      mockUpdateArtistBio.mockResolvedValue({
+        status: 'success',
+        message: 'Bio regenerated',
+        data: 'A newly generated bio from AI',
+      });
+
+      const response = await PUT(
+        createPutRequest({ regenerate: true }),
+        { params: paramsPromise }
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.message).toBe('Bio regenerated');
+      expect(data.bio).toBe('A newly generated bio from AI');
+    });
   });
 
   describe('GET', () => {

--- a/src/app/api/artistBio/[id]/route.ts
+++ b/src/app/api/artistBio/[id]/route.ts
@@ -115,7 +115,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
       }, { headers: CORS_HEADERS });
     }
 
-    return NextResponse.json({ message: result.message }, { status: 403, headers: CORS_HEADERS });
+    return NextResponse.json({ message: result.message }, { status: 500, headers: CORS_HEADERS });
   } catch (e) {
     console.error("[artistBio] PUT error", e);
     return NextResponse.json({ message: "Error updating bio" }, { status: 500, headers: CORS_HEADERS });

--- a/src/server/utils/queries/artistQueries.ts
+++ b/src/server/utils/queries/artistQueries.ts
@@ -665,23 +665,6 @@ export async function removeArtistData(artistId: string, siteName: string): Prom
 // Bio update helper
 // ----------------------------------
 export async function updateArtistBio(artistId: string, bio: string, regenerate: boolean = false): Promise<RemoveArtistDataResp> {
-    const session = await getServerAuthSession();
-    if (!session) {
-        throw new Error("Not authenticated");
-    }
-
-    const user = session?.user?.id ? await getUserById(session.user.id) : null;
-
-    // Only admins can edit bios
-    if (!user?.isAdmin) {
-        return { status: "error", message: "Unauthorized" };
-    }
-
-    // For regeneration, only admins can do it
-    if (regenerate && !user?.isAdmin) {
-        return { status: "error", message: "Only admins can regenerate bios" };
-    }
-
     try {
         if (regenerate) {
             // Generate new bio using OpenAI


### PR DESCRIPTION
## Summary
- Remove redundant auth checks from `updateArtistBio()` — the route handler already calls `requireAdmin()`, so the function-level `getServerAuthSession()` + admin check was dead code
- Change non-success status code from 403 to 500 in the PUT handler, since all remaining error paths are server errors (failed bio generation, DB write failures), not permission issues
- Add test coverage for error and regeneration paths

Closes #968

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (508 tests, 2 new)
- [x] `npm run build` passes
- [ ] Manual: PUT `/api/artistBio/[id]` with invalid artist returns 500
- [ ] Manual: PUT with `regenerate: true` returns 200 with generated bio

🤖 Generated with [Claude Code](https://claude.com/claude-code)