### PR TITLE
fix: restore UGC submission UI and artist page interactivity

### DIFF
--- a/src/app/_components/AutoRefresh.tsx
+++ b/src/app/_components/AutoRefresh.tsx
@@ -1,4 +1,106 @@
-// Stub for deleted Auto Refresh component
-export default function AutoRefresh() {
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import { useSession } from "next-auth/react";
+
+/**
+ * Universal auto-refresh component that triggers a page refresh when the user signs in
+ * to ensure server components pick up the new session data immediately.
+ * Uses sessionStorage to prevent multiple refreshes.
+ *
+ * @param sessionStorageKey - Optional custom key for sessionStorage (defaults to "autoRefreshSkipReload")
+ * @param showLoading - Whether to show loading state (defaults to true)
+ */
+export default function AutoRefresh({
+  sessionStorageKey = "autoRefreshSkipReload",
+  showLoading = true
+}: {
+  sessionStorageKey?: string;
+  showLoading?: boolean;
+} = {}) {
+  const { data: session, status } = useSession();
+  const [isLoading, setIsLoading] = useState(true);
+  const hasTriggeredRefresh = useRef(false);
+  const [isClient, setIsClient] = useState(false);
+  const prevStatus = useRef<string | null>(null);
+
+  // Ensure we're on the client side
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  // Show loading state while session is being determined
+  useEffect(() => {
+    if (showLoading) {
+      if (status === "loading") {
+        setIsLoading(true);
+      } else {
+        setIsLoading(false);
+      }
+    } else {
+      setIsLoading(false);
+    }
+  }, [status, showLoading]);
+
+  // Handle authentication state changes - immediate refresh
+  useEffect(() => {
+    // Skip if not on client side or if we've already triggered a refresh
+    if (!isClient || hasTriggeredRefresh.current) {
+      return;
+    }
+
+    // Check if we've transitioned to authenticated state
+    const hasTransitionedToAuthenticated =
+      prevStatus.current &&
+      prevStatus.current !== "authenticated" &&
+      status === "authenticated" &&
+      session?.user?.id;
+
+    // If we have a session and we're authenticated, trigger refresh
+    if (session && status === "authenticated" && session.user?.id) {
+      try {
+        const skipRefresh = sessionStorage.getItem(sessionStorageKey) === "true";
+
+        if (!skipRefresh || hasTransitionedToAuthenticated) {
+          // Mark that we've triggered a refresh immediately
+          hasTriggeredRefresh.current = true;
+          sessionStorage.setItem(sessionStorageKey, "true");
+
+          // Immediate refresh
+          window.location.reload();
+        }
+      } catch (error) {
+        console.error("[AutoRefresh] Error accessing sessionStorage:", error);
+      }
+    }
+
+    // Update previous status
+    prevStatus.current = status;
+  }, [session, status, sessionStorageKey, isClient]);
+
+  // Clear the skip flag when component unmounts
+  useEffect(() => {
+    if (!isClient) return;
+
+    return () => {
+      try {
+        sessionStorage.removeItem(sessionStorageKey);
+      } catch (error) {
+        console.error("[AutoRefresh] Error clearing sessionStorage:", error);
+      }
+    };
+  }, [sessionStorageKey, isClient]);
+
+  if (isLoading || status === "loading") {
+    return (
+      <div className="fixed inset-0 bg-white/80 backdrop-blur-sm z-[9999] flex flex-col items-center justify-center gap-4">
+        <div className="bg-white p-8 rounded-xl shadow-lg flex flex-col items-center gap-4">
+          <img className="h-12" src="/spinner.svg" alt="Loading" />
+          <div className="text-xl text-black">Loading...</div>
+        </div>
+      </div>
+    );
+  }
+
   return null;
 }

--- a/src/app/artist/[id]/_components/AddArtistData.tsx
+++ b/src/app/artist/[id]/_components/AddArtistData.tsx
@@ -1,18 +1,276 @@
-// Stub component - authentication disabled
-import { Artist, UrlMap } from "@/server/db/DbTypes";
+"use client"
+import { Button } from "@/components/ui/button"
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input"
+import { useState, useEffect } from "react";
+import { Artist } from "@/server/db/DbTypes";
+import { AspectRatio } from "@radix-ui/react-aspect-ratio";
+import { Label } from "@radix-ui/react-label";
+import { useSession } from "next-auth/react";
+import { UrlMap } from "@/server/db/DbTypes";
+import AddArtistDataOptions from "./AddArtistDataOptions";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormMessage,
+} from "@/components/ui/form";
+import { addArtistDataAction as addArtistData, type AddArtistDataResp } from "@/app/actions/serverActions";
+import { useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/hooks/use-toast";
+import { Plus } from "lucide-react";
+import Link from "next/link";
 
-export default function AddArtistData({
-  label,
-  artist,
-  spotifyImg,
-  availableLinks,
-  isOpenOnLoad,
-}: {
-  label: string;
-  artist: Artist;
-  spotifyImg: string;
-  availableLinks: UrlMap[];
-  isOpenOnLoad: boolean;
-}) {
-  return null;
+export default function AddArtistData({ artist, spotifyImg, availableLinks, isOpenOnLoad = false, label }: { artist: Artist, spotifyImg: string, availableLinks: UrlMap[], isOpenOnLoad: boolean, label?: string }) {
+    const { data: session } = useSession();
+    const [isModalOpen, setIsModalOpen] = useState(isOpenOnLoad);
+    const [selectedOption, setSelectedOption] = useState("");
+    const [isLoading, setIsLoading] = useState(false);
+    const [addArtistResp, setAddArtistResp] = useState<AddArtistDataResp | null>(null);
+    const router = useRouter();
+    const { toast } = useToast();
+
+    // State to hold platform regexes from the backend
+    const [platformRegexes, setPlatformRegexes] = useState<{ siteName: string, regex: string }[]>([]);
+
+    // Fetch regexes from the backend on mount
+    useEffect(() => {
+        fetch('/api/platformRegexes')
+            .then(res => res.json())
+            .then(data => setPlatformRegexes(data))
+            .catch(e => console.error('Failed to fetch platform regexes:', e));
+    }, []);
+
+    const formSchema = useMemo(() => z.object({
+        artistDataUrl: z.string()
+    }), [availableLinks])
+
+    const form = useForm<z.infer<typeof formSchema>>({
+        resolver: zodResolver(formSchema),
+        mode: "onSubmit",
+        defaultValues: {
+            artistDataUrl: "",
+        },
+    })
+
+    // Filter out ENS and wallets from display, but keep them in availableLinks for add options
+    const displayLinks = availableLinks.filter(link => link.siteName !== 'ens' && link.siteName !== 'wallets');
+
+    async function validateTwitterLink(url: string): Promise<boolean> {
+        try {
+            const twitterRegex = /^https?:\/\/(www\.)?(twitter|x)\.com\/[A-Za-z0-9_]{1,15}$/;
+            if (!twitterRegex.test(url)) return true; // Not a Twitter/X link, skip validation
+
+            const response = await fetch(url, { method: "GET" });
+            // Only fail if status is 404 (profile does not exist)
+            if (response.status === 404) return false;
+            return true; // Any other status (including redirects, 403, 429, etc.) is considered valid
+        } catch (e) {
+            return true; // Network/CORS errors are considered valid
+        }
+    }
+
+    // Add a function to call the backend validator
+    async function validatePlatformLinkBackend(url: string): Promise<boolean> {
+        // Determine which platform regex matches this URL
+        let matchedPlatform: string | null = null;
+        for (const { siteName, regex } of platformRegexes) {
+            try {
+                if (new RegExp(regex.trim()).test(url)) {
+                    matchedPlatform = siteName;
+                    break;
+                }
+            } catch (e) {
+                console.debug(`[${siteName}] Regex error:`, e);
+            }
+        }
+
+        if (!matchedPlatform) {
+            console.debug('No platform regex matched for URL:', url);
+            return false; // Reject invalid URLs
+        }
+
+        // Platforms that have backend validation implemented
+        const backendPlatforms = [
+            'youtube',
+            'soundcloud',
+            'bandcamp',
+            'audius',
+            'lastfm',
+            'opensea',
+            'zora',
+            'catalog',
+            'supercollector',
+            'mintsongs'
+        ];
+
+        // If the matched platform is not backend-validated, accept it based on regex
+        if (!backendPlatforms.includes(matchedPlatform)) {
+            return true;
+        }
+
+        try {
+            const response = await fetch('/api/validateLink', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ url }),
+            });
+            const data = await response.json();
+            console.debug('Backend validation response:', data);
+            return data.valid;
+        } catch (e) {
+            console.debug('Backend validation error:', e);
+            return true; // If the backend fails, don't block the user
+        }
+    }
+
+    async function onSubmit(values: z.infer<typeof formSchema>) {
+        setAddArtistResp(null);
+        setIsLoading(true);
+        let formattedUrl = values.artistDataUrl.trim();
+        if (!/^https?:\/\//i.test(formattedUrl)) {
+            formattedUrl = `https://${formattedUrl}`;
+        }
+
+        const isTwitterValid = await validateTwitterLink(formattedUrl);
+        if (!isTwitterValid) {
+            setAddArtistResp({ status: "error", message: "This link is invalid. Please enter a valid Twitter/X profile URL." });
+            setIsLoading(false);
+            return;
+        }
+        const isPlatformValid = await validatePlatformLinkBackend(formattedUrl);
+        if (!isPlatformValid) {
+            setAddArtistResp({ status: "error", message: "This link is invalid or not supported." });
+            setIsLoading(false);
+            return;
+        }
+        const resp = await addArtistData(formattedUrl, artist);
+        if (resp.status === "success") {
+            toast({
+                title: `${artist.name}'s ${resp.siteName ?? "data"} added`,
+            })
+        }
+        setAddArtistResp(resp);
+        setIsLoading(false);
+    }
+
+    function handleClose(isOpen: boolean) {
+        if (!isOpen && addArtistResp && addArtistResp.status === "success") {
+            router.refresh();
+        }
+        if (!isOpen) {
+            setAddArtistResp(null);
+            setSelectedOption("");
+        }
+        setIsModalOpen(isOpen);
+        form.reset();
+    }
+
+    function checkInput() {
+        if (addArtistResp?.status === "success") {
+            form.reset();
+            setAddArtistResp(null);
+        }
+    }
+
+    function handleClick() {
+        if (session) {
+            setIsModalOpen(true);
+        }
+    }
+
+    return (
+        <>
+            <Button
+                size={label ? "sm" : "icon"}
+                className={label
+                    ? "text-white bg-pastypink flex items-center justify-center px-4 min-w-[60px]"
+                    : "text-white bg-pastypink rounded-lg hover:bg-pastypink/90 w-8 h-8 p-0 flex items-center justify-center"}
+                onClick={handleClick}
+            >
+                {label ? <span className="whitespace-nowrap">{label}</span> : <Plus color="white" size={24} />}
+            </Button>
+            <Dialog open={isModalOpen} onOpenChange={handleClose}>
+                <DialogContent className="sm:max-w-[425px] max-h-screen overflow-auto scrollbar-hide text-black">
+                    <Form {...form}>
+                        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                            <div>
+                                <AspectRatio ratio={1 / 1} className="flex items-center place-content-center bg-muted rounded-md overflow-hidden w-full">
+                                    {(spotifyImg) &&
+                                        <img src={spotifyImg} alt="Artist Image" className="object-cover" />
+                                    }
+                                </AspectRatio>
+                            </div>
+                            <DialogHeader>
+                                <DialogTitle>
+                                    <p>
+                                        Add a place where {artist.name} can be found
+                                    </p>
+                                </DialogTitle>
+                            </DialogHeader>
+                            <div className="grid gap-4 text-black">
+                                <FormField
+                                    control={form.control}
+                                    name="artistDataUrl"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <div className="flex gap-4">
+                                                <FormControl>
+                                                    <div className="flex-grow px-3 py-0 bg-gray-100 rounded-lg flex items-center gap-2 h-12 hover:bg-gray-200 transition-colors duration-300">
+                                                        <Input
+                                                            placeholder={selectedOption}
+                                                            onClick={checkInput}
+                                                            id="name"
+                                                            className="w-full p-0 bg-transparent focus:outline-none text-md"
+                                                            {...field}
+                                                        />
+                                                    </div>
+                                                </FormControl>
+                                                <AddArtistDataOptions availableLinks={displayLinks} setOption={(option) => setSelectedOption(option)} />
+                                            </div>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                            </div>
+                            <p>
+                                Once you submit the link we&apos;ll look it over to make sure it all checks out!
+                            </p>
+                            <DialogFooter className="flex sm:flex-col gap-4">
+                                {addArtistResp && addArtistResp.status === "error" ?
+                                    <Label className="text-red-600">{addArtistResp.message}</Label> : null
+                                }
+                                <Button type="submit" className="bg-pastyblue hover:bg-gray-400 text-white">
+                                    {isLoading ?
+                                        <img className="max-h-6" src="/spinner.svg" alt="whyyyyy" />
+                                        : <span>Add Artist Data</span>
+                                    }
+                                </Button>
+                                {addArtistResp && addArtistResp.status === "success" ?
+                                    <div className="flex flex-col items-center">
+                                        <h2 className="text-green-600">{addArtistResp.message}</h2>
+                                        <Link href="/leaderboard" className="text-blue-600 underline hover:underline mt-1">
+                                            View Leaderboard
+                                        </Link>
+                                    </div>
+                                    : null
+                                }
+                            </DialogFooter>
+                        </form>
+                    </Form>
+                </DialogContent>
+            </Dialog>
+        </>
+    )
 }

--- a/src/app/artist/[id]/page.tsx
+++ b/src/app/artist/[id]/page.tsx
@@ -2,13 +2,18 @@ import { getArtistById, getAllLinks } from "@/server/utils/queries/artistQueries
 import { getSpotifyImage, getSpotifyHeaders, getNumberOfSpotifyReleases } from "@/server/utils/queries/externalApiQueries";
 import { AspectRatio } from "@radix-ui/react-aspect-ratio";
 import ArtistLinks from "@/app/_components/ArtistLinks";
+import BookmarkButton from "@/app/_components/BookmarkButton";
 import { getArtistDetailsText } from "@/server/utils/services";
+import { getServerAuthSession } from "@/server/auth";
 import { notFound } from "next/navigation";
 import { EditModeProvider } from "@/app/_components/EditModeContext";
+import EditModeToggle from "@/app/_components/EditModeToggle";
 import BlurbSection from "./_components/BlurbSection";
+import AddArtistData from "@/app/artist/[id]/_components/AddArtistData";
 import FunFactsMobile from "./_components/FunFactsMobile";
 import FunFactsDesktop from "./_components/FunFactsDesktop";
 import GrapevineIframe from "./_components/GrapevineIframe";
+import AutoRefresh from "@/app/_components/AutoRefresh";
 import type { Metadata } from "next";
 import SeoArtistLinks from "./_components/SeoArtistLinks";
 
@@ -60,7 +65,8 @@ export async function generateMetadata({ params }: ArtistProfileProps): Promise<
 
 export default async function ArtistProfile({ params }: ArtistProfileProps) {
     const { id } = await params;
-    const canEdit = false; // Authentication disabled - read-only mode
+    const session = await getServerAuthSession();
+    const canEdit = !!session;
 
     const artist = await getArtistById(id);
     if (!artist) {
@@ -79,6 +85,7 @@ export default async function ArtistProfile({ params }: ArtistProfileProps) {
     return (
         <>
             <EditModeProvider canEdit={canEdit}>
+            <AutoRefresh sessionStorageKey="artistSkipReload" showLoading={false} />
             <div className="gap-4 px-4 flex flex-col md:flex-row max-w-[1000px] mx-auto">
                 {/* Artist Info Box */}
                 <div className="bg-white rounded-lg md:w-2/3 gap-y-4 shadow-2xl px-5 py-5 md:py-10 md:px-10 space-y-8">
@@ -95,6 +102,17 @@ export default async function ArtistProfile({ params }: ArtistProfileProps) {
                                 <strong className="text-black text-2xl mr-2">
                                     {artist.name}
                                 </strong>
+                                <div className="flex items-center gap-2">
+                                    {session && (
+                                        <BookmarkButton
+                                            artistId={artist.id}
+                                            artistName={artist.name ?? ''}
+                                            imageUrl={spotifyImg.artistImage ?? ''}
+                                            userId={session.user.id}
+                                        />
+                                    )}
+                                    {canEdit && <EditModeToggle />}
+                                </div>
                             </div>
                             <div className="text-black pt-0 mb-4">
                                 {(artist) && getArtistDetailsText(artist, numReleases)}
@@ -116,6 +134,14 @@ export default async function ArtistProfile({ params }: ArtistProfileProps) {
                                     <strong className="text-black text-2xl">
                                         Social Media Links
                                     </strong>
+                                    <div className="mt-2 md:mt-0 md:ml-2">
+                                        <AddArtistData
+                                            artist={artist}
+                                            spotifyImg={spotifyImg.artistImage ?? ""}
+                                            availableLinks={urlMapList}
+                                            isOpenOnLoad={false}
+                                        />
+                                    </div>
                                 </div>
                                 <div className="space-y-4">
                                     {(artist) &&
@@ -130,6 +156,14 @@ export default async function ArtistProfile({ params }: ArtistProfileProps) {
                                     <strong className="text-black text-2xl">
                                         Support the Artist
                                     </strong>
+                                    <div className="mt-2 md:mt-0 md:ml-2">
+                                        <AddArtistData
+                                            artist={artist}
+                                            spotifyImg={spotifyImg.artistImage ?? ""}
+                                            availableLinks={urlMapList}
+                                            isOpenOnLoad={false}
+                                        />
+                                    </div>
                                 </div>
                                 <div className="space-y-4">
                                     {(artist) &&


### PR DESCRIPTION
## Summary
- Restores `AddArtistData.tsx` from stub — fully functional UGC link submission dialog, with RainbowKit/wallet dependency removed (uses session-only auth check)
- Restores `AutoRefresh.tsx` from stub — auto-refreshes server components when user signs in
- Re-enables `canEdit = !!session` on artist page (was hardcoded to `false`)
- Restores `BookmarkButton`, `EditModeToggle`, and `AddArtistData` "+" buttons on artist pages

## Changes
| File | Change |
|------|--------|
| `src/app/artist/[id]/_components/AddArtistData.tsx` | Restored from stub. Removed `useConnectModal` (RainbowKit), `isWalletRequired` check. `handleClick` now simply checks `session` |
| `src/app/artist/[id]/page.tsx` | Added session check, `canEdit = !!session`, restored imports for BookmarkButton/EditModeToggle/AddArtistData/AutoRefresh |
| `src/app/_components/AutoRefresh.tsx` | Restored from stub with original props interface |

## Test plan
- [ ] Visit an artist page while logged out — read-only, no "+" buttons visible (AddArtistData renders but button is inert without session)
- [ ] Log in → artist page shows BookmarkButton, EditModeToggle, and "+" buttons
- [ ] Click "+" → UGC submission dialog opens with URL input and platform selector
- [ ] Submit a valid link → success toast + leaderboard link
- [ ] Submit invalid link → error message in dialog
- [ ] `npm run type-check && npm run lint && npm run test && npm run build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)