### PR TITLE
fix: stop showing Link Wallet dialog to new Privy users

### DIFF
--- a/src/server/__tests__/auth.test.ts
+++ b/src/server/__tests__/auth.test.ts
@@ -281,6 +281,21 @@ describe('Auth - Privy Credentials Provider', () => {
       expect(result.needsLegacyLink).toBe(true);
     });
 
+    it('defaults needsLegacyLink to true when user has malformed createdAt', async () => {
+      const { authOptions, mockVerifyPrivyToken, mockGetUserByPrivyId } = await setup();
+      mockVerifyPrivyToken.mockResolvedValue({
+        userId: 'did:privy:user123',
+        email: 'user@example.com',
+        linkedAccounts: [],
+      });
+      mockGetUserByPrivyId.mockResolvedValue({ ...mockDbUserNoWallet, createdAt: 'not-a-date' });
+
+      const authorize = getAuthorize(authOptions);
+      const result = await authorize({ authToken: 'valid-token' });
+
+      expect(result.needsLegacyLink).toBe(true);
+    });
+
     it('defaults needsLegacyLink to true when user has undefined createdAt', async () => {
       const { authOptions, mockVerifyPrivyToken, mockGetUserByPrivyId } = await setup();
       mockVerifyPrivyToken.mockResolvedValue({

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -20,7 +20,9 @@ export function isLegacyUser(createdAt: string | null | undefined): boolean {
   if (!migrationDate || !createdAt) return true;
   const migrationTime = new Date(migrationDate).getTime();
   if (isNaN(migrationTime)) return true;
-  return new Date(createdAt).getTime() < migrationTime;
+  const createdTime = new Date(createdAt).getTime();
+  if (isNaN(createdTime)) return true;
+  return createdTime < migrationTime;
 }
 
 // Define session user type for better type safety


### PR DESCRIPTION
## Summary
- Add `isLegacyUser(createdAt)` helper to `src/server/auth.ts` that checks if a user was created before `PRIVY_MIGRATION_DATE` env var
- Update `needsLegacyLink` in both `authorize()` and JWT callback to also require `isLegacyUser()` — post-migration users without a wallet no longer see the modal
- Safe fallback: if `PRIVY_MIGRATION_DATE` is unset, defaults to `true` (existing behavior preserved)

## Test plan
- [x] 4 new tests added (24 total in auth.test.ts): post-migration authorize, pre-migration authorize, missing env var fallback, JWT refresh for post-migration user
- [x] All 526 tests pass
- [x] type-check, lint, build all green
- [ ] Manual: new user login → no modal, no "Link Wallet" menu item
- [ ] Manual: existing legacy user login → modal still auto-shows
- [ ] Add `PRIVY_MIGRATION_DATE=2026-02-23` to production env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)