### PR TITLE
fix: invalidate stale Privy session before login

### DIFF
--- a/src/app/_components/nav/components/PrivyLogin.tsx
+++ b/src/app/_components/nav/components/PrivyLogin.tsx
@@ -214,13 +214,20 @@ const PrivyLogin = forwardRef<HTMLButtonElement, PrivyLoginProps>(
           if (isDev) {
             console.log('[PrivyLogin] Privy logout error during reset:', e);
           }
+          setIsLoggingIn(false);
+          toast({
+            title: 'Login Error',
+            description: 'Could not reset session. Please refresh the page.',
+            variant: 'destructive',
+          });
+          return;
         }
         setIsLoggingIn(false);
         login();
       } else {
         login();
       }
-    }, [authenticated, status, login, privyLogout]);
+    }, [authenticated, status, login, privyLogout, toast]);
 
     // Show legacy account modal for new users (once per login session)
     useEffect(() => {
@@ -333,7 +340,7 @@ const PrivyLogin = forwardRef<HTMLButtonElement, PrivyLoginProps>(
               size="lg"
               type="button"
               className={`hover:bg-gray-200 transition-colors duration-300 text-white px-0 w-12 h-12 bg-pastypink ${buttonStyles}`}
-              onClick={() => handleLogin()}
+              onClick={handleLogin}
             >
               <LogIn color="white" size={20} />
             </Button>
@@ -349,7 +356,7 @@ const PrivyLogin = forwardRef<HTMLButtonElement, PrivyLoginProps>(
                 User Profile
               </Link>
             </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => handleLogin()}>Log In</DropdownMenuItem>
+            <DropdownMenuItem onSelect={handleLogin}>Log In</DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       );


### PR DESCRIPTION
## Summary
- When Privy has a leftover session but NextAuth doesn't, clicking login failed with "user is already logged in"
- Now detects the split state and logs out of Privy first, then shows a fresh login dialog

## Test plan
- [x] Type-check passes
- [x] 18 PrivyLogin tests pass
- [ ] Verify on staging: clear NextAuth cookie, confirm login button shows fresh Privy dialog

> **Note:** Use regular merge (not squash) to preserve the merge base between staging and main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)