### PR TITLE
Release: getUserDisplayName helper for Discord messages

### DIFF
--- a/src/app/actions/addArtist.ts
+++ b/src/app/actions/addArtist.ts
@@ -2,7 +2,7 @@
 
 import { getServerAuthSession } from "@/server/auth";
 import { getSpotifyHeaders, getSpotifyArtist } from '@/server/utils/queries/externalApiQueries';
-import { getUserById } from '@/server/utils/queries/userQueries';
+import { getUserById, getUserDisplayName } from '@/server/utils/queries/userQueries';
 import { sendDiscordMessage } from '@/server/utils/queries/discord';
 import { addArtist as dbAddArtist, type AddArtistResp } from "@/server/utils/queries/artistQueries";
 
@@ -35,8 +35,7 @@ export async function addArtist(spotifyId: string): Promise<AddArtistResp> {
         const result = await dbAddArtist(spotifyId);
 
         if (result.status === "success" && user) {
-            const userLabel = user.wallet || user.email || user.id || 'unknown';
-            await sendDiscordMessage(`${userLabel} added new artist named: ${result.artistName} (Submitted SpotifyId: ${spotifyId})`);
+            await sendDiscordMessage(`${getUserDisplayName(user)} added new artist named: ${result.artistName} (Submitted SpotifyId: ${spotifyId})`);
         }
 
         return result;

--- a/src/server/utils/queries/__tests__/addArtistData-discord.test.ts
+++ b/src/server/utils/queries/__tests__/addArtistData-discord.test.ts
@@ -7,6 +7,7 @@ jest.mock("@/server/auth", () => ({
 }));
 
 jest.mock("@/server/utils/queries/userQueries", () => ({
+    ...jest.requireActual("@/server/utils/queries/userQueries"),
     getUserById: jest.fn(),
 }));
 

--- a/src/server/utils/queries/__tests__/getUserDisplayName.test.ts
+++ b/src/server/utils/queries/__tests__/getUserDisplayName.test.ts
@@ -1,0 +1,37 @@
+import { getUserDisplayName } from "../userQueries";
+
+describe("getUserDisplayName", () => {
+    it("prefers username when all fields are present", () => {
+        expect(getUserDisplayName({ username: "alice", email: "a@b.com", wallet: "0x1" }))
+            .toBe("alice");
+    });
+
+    it("falls back to email prefix when username is null", () => {
+        expect(getUserDisplayName({ username: null, email: "fan@example.com", wallet: "0x1" }))
+            .toBe("fan");
+    });
+
+    it("falls back to wallet when username and email are null", () => {
+        expect(getUserDisplayName({ username: null, email: null, wallet: "0xABC" }))
+            .toBe("0xABC");
+    });
+
+    it('falls back to "Anonymous" when all fields are null', () => {
+        expect(getUserDisplayName({ username: null, email: null, wallet: null }))
+            .toBe("Anonymous");
+    });
+
+    it("extracts prefix before @ from email", () => {
+        expect(getUserDisplayName({ username: null, email: "hello.world@gmail.com", wallet: null }))
+            .toBe("hello.world");
+    });
+
+    it("treats empty-string username as falsy", () => {
+        expect(getUserDisplayName({ username: "", email: "fb@test.com", wallet: null }))
+            .toBe("fb");
+    });
+
+    it("handles undefined fields", () => {
+        expect(getUserDisplayName({})).toBe("Anonymous");
+    });
+});

--- a/src/server/utils/queries/artistQueries.ts
+++ b/src/server/utils/queries/artistQueries.ts
@@ -9,7 +9,7 @@ import { PgColumn } from "drizzle-orm/pg-core";
 import { headers } from "next/headers";
 import { openai } from "@/server/lib/openai";
 
-import { getUserById } from "@/server/utils/queries/userQueries";
+import { getUserById, getUserDisplayName } from "@/server/utils/queries/userQueries";
 import { sendDiscordMessage } from "@/server/utils/queries/discord";
 import { maybePingDiscordForPendingUGC } from "@/server/utils/ugcDiscordNotifier";
 
@@ -369,7 +369,7 @@ export async function addArtist(spotifyId: string): Promise<AddArtistResp> {
             const user = await getUserById(session.user.id);
             if (user) {
                 await sendDiscordMessage(
-                    `${user.wallet || "Anonymous"} added new artist named: ${newArtist.name} (Submitted SpotifyId: ${spotifyId}) ${newArtist.createdAt}`
+                    `${getUserDisplayName(user)} added new artist named: ${newArtist.name} (Submitted SpotifyId: ${spotifyId}) ${newArtist.createdAt}`
                 );
             }
         }
@@ -554,10 +554,8 @@ export async function addArtistData(artistUrl: string, artist: Artist): Promise<
         }
 
         if (user) {
-            const displayName =
-                user.username || user.email?.split("@")[0] || user.wallet || "Anonymous";
             await sendDiscordMessage(
-                `${displayName} added ${artist.name}'s ${artistIdFromUrl.cardPlatformName}: ${artistIdFromUrl.id} (Submitted URL: ${artistUrl}) ${newUGC.createdAt}`
+                `${getUserDisplayName(user)} added ${artist.name}'s ${artistIdFromUrl.cardPlatformName}: ${artistIdFromUrl.id} (Submitted URL: ${artistUrl}) ${newUGC.createdAt}`
             );
         }
 

--- a/src/server/utils/queries/userQueries.ts
+++ b/src/server/utils/queries/userQueries.ts
@@ -117,6 +117,12 @@ export async function searchForUsersByWallet(wallet: string) {
     }
 }
 
+/** Resolve a user's display name for Discord notifications.
+ *  Priority: username → email prefix → wallet → "Anonymous" */
+export function getUserDisplayName(user: { username?: string | null; email?: string | null; wallet?: string | null }): string {
+    return user.username || user.email?.split("@")[0] || user.wallet || "Anonymous";
+}
+
 // Uniqueness is not enforced — duplicate usernames are allowed by design.
 export async function updateUsername(userId: string, username: string) {
     await db.update(users).set({ username }).where(eq(users.id, userId));


### PR DESCRIPTION
## Summary
- Extracted `getUserDisplayName()` helper in `userQueries.ts` — single source of truth for display name resolution (username → email prefix → wallet → "Anonymous")
- Fixed two additional Discord notification sites in `addArtist.ts` and `artistQueries.ts` that were still using wallet-first fallback
- All three Discord message call sites now use the same function

## Included PRs
- #1013

## Test plan
- [x] 7 unit tests for `getUserDisplayName` helper
- [x] 8 existing Discord message integration tests still pass
- [x] Full CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)