### PR TITLE
chore: add min-release-age=7 to .npmrc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         cache: 'npm'
 
     - name: Upgrade npm
-      run: npm install -g npm@latest
+      run: npm install -g npm@11.12.1
 
     - name: Install dependencies
       run: npm ci
@@ -65,7 +65,7 @@ jobs:
         cache: 'npm'
 
     - name: Upgrade npm
-      run: npm install -g npm@latest
+      run: npm install -g npm@11.12.1
 
     - name: Install dependencies
       run: npm ci
@@ -104,7 +104,7 @@ jobs:
         cache: 'npm'
 
     - name: Upgrade npm
-      run: npm install -g npm@latest
+      run: npm install -g npm@11.12.1
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
         node-version: '20'
         cache: 'npm'
 
+    - name: Upgrade npm
+      run: npm install -g npm@latest
+
     - name: Install dependencies
       run: npm ci
 
@@ -60,6 +63,9 @@ jobs:
       with:
         node-version: '20'
         cache: 'npm'
+
+    - name: Upgrade npm
+      run: npm install -g npm@latest
 
     - name: Install dependencies
       run: npm ci
@@ -96,6 +102,9 @@ jobs:
       with:
         node-version: '20'
         cache: 'npm'
+
+    - name: Upgrade npm
+      run: npm install -g npm@latest
 
     - name: Install dependencies
       run: npm ci

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 legacy-peer-deps=true
 min-release-age=7
+engine-strict=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "musicnerdweb",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=20",
+    "npm": ">=11.10.0"
+  },
   "scripts": {
     "dev": "next dev --experimental-https",
     "build": "next build",


### PR DESCRIPTION
## Summary
- Adds `min-release-age=7` to `.npmrc` so npm skips package versions published less than 7 days ago
- Reduces exposure to supply-chain attacks via newly published or hijacked packages

## Test plan
- [ ] Verify `npm install` still resolves all dependencies correctly
- [ ] Confirm new installs skip packages published <7 days ago

🤖 Generated with [Claude Code](https://claude.com/claude-code)