### PR TITLE
fix: relax session report detection in agent runner scripts

### DIFF
--- a/agents/id-mapping/check-status.sh
+++ b/agents/id-mapping/check-status.sh
@@ -13,7 +13,7 @@ if [[ ! -d "$LOG_DIR" ]]; then
 fi
 
 total_runs=$(find "$LOG_DIR" -maxdepth 1 -name '*-run-*.log' -type f | wc -l | tr -d ' ')
-successful_runs=$(find "$LOG_DIR" -maxdepth 1 -name '*-run-*.log' -type f -exec grep -l '=== ID Mapping Session Report ===' {} + 2>/dev/null | wc -l | tr -d ' ')
+successful_runs=$(find "$LOG_DIR" -maxdepth 1 -name '*-run-*.log' -type f -exec grep -l 'ID Mapping Session Report' {} + 2>/dev/null | wc -l | tr -d ' ')
 failed_runs=$((total_runs - successful_runs))
 
 # Count active workers (log files with activity in last 10 min)
@@ -54,7 +54,7 @@ if [[ $successful_runs -gt 0 ]]; then
     echo " Avg resolved/run: $rate"
 
     # Try to find remaining count from last successful run
-    last_log=$(find "$LOG_DIR" -maxdepth 1 -name '*-run-*.log' -type f -exec grep -l '=== ID Mapping Session Report ===' {} + 2>/dev/null | sort | tail -1)
+    last_log=$(find "$LOG_DIR" -maxdepth 1 -name '*-run-*.log' -type f -exec grep -l 'ID Mapping Session Report' {} + 2>/dev/null | sort | tail -1)
     if [[ -n "$last_log" ]]; then
       remaining=$(grep -oE 'totalUnmapped.*?[0-9]+' "$last_log" 2>/dev/null | grep -oE '[0-9]+' | tail -1 || true)
       if [[ -n "$remaining" && "$remaining" =~ ^[0-9]+$ && "$remaining" -gt 0 && "$rate" != "?" ]]; then
@@ -74,7 +74,7 @@ if [[ -n "$worker_ids" ]] && [[ $(echo "$worker_ids" | wc -l) -gt 1 ]]; then
   echo "--- Per-Worker Breakdown ---"
   for wid in $worker_ids; do
     w_total=$(find "$LOG_DIR" -maxdepth 1 -name "${wid}-run-*.log" -type f | wc -l | tr -d ' ')
-    w_success=$(grep -l '=== ID Mapping Session Report ===' "$LOG_DIR"/${wid}-run-*.log 2>/dev/null | wc -l | tr -d ' ' || echo 0)
+    w_success=$(grep -l 'ID Mapping Session Report' "$LOG_DIR"/${wid}-run-*.log 2>/dev/null | wc -l | tr -d ' ' || echo 0)
     w_last=$(find "$LOG_DIR" -maxdepth 1 -name "${wid}-run-*.log" -type f | sort | tail -1)
     w_time=""
     if [[ -n "$w_last" ]]; then
@@ -94,8 +94,8 @@ for wid in $(find "$LOG_DIR" -maxdepth 1 -name '*-run-*.log' -type f | xargs -I{
   if [[ -n "$last_log" ]]; then
     echo "--- Last Run ($wid): $(basename "$last_log") ---"
 
-    if grep -q '=== ID Mapping Session Report ===' "$last_log" 2>/dev/null; then
-      sed -n '/=== ID Mapping Session Report ===/,/===/p' "$last_log" | head -30
+    if grep -q 'ID Mapping Session Report' "$last_log" 2>/dev/null; then
+      sed -n '/ID Mapping Session Report/,/^$/p' "$last_log" | head -30
     else
       echo "(no session report — run may have failed)"
       tail -5 "$last_log"

--- a/agents/id-mapping/check-status.sh
+++ b/agents/id-mapping/check-status.sh
@@ -31,13 +31,13 @@ echo ""
 
 # Sum resolved across all runs (only top-level logs)
 if [[ $successful_runs -gt 0 ]]; then
-  total_resolved=$(grep -ohE '\*?\*?Resolved\*?\*?:[[:space:]]+\*?\*?[0-9]+\*?\*?[[:space:]]+total' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
-  total_excluded=$(grep -ohE '\*?\*?Excluded\*?\*?:[[:space:]]+\*?\*?[0-9]+\*?\*?[[:space:]]+total' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
+  total_resolved=$(grep -ohE '\*?\*?Resolved\*?\*?:\*?\*?[[:space:]]+\*?\*?[0-9]+\*?\*?[[:space:]]+total' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
+  total_excluded=$(grep -ohE '\*?\*?Excluded\*?\*?:\*?\*?[[:space:]]+\*?\*?[0-9]+\*?\*?[[:space:]]+total' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
   total_conflicts=$(grep -ohE 'Conflicts[^:]*:[[:space:]]+[0-9]+' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
   total_name_mismatches=$(grep -oh 'Name mismatches: [0-9]*' "$LOG_DIR"/*-run-*.log 2>/dev/null | awk -F': ' '{s+=$2} END {print s+0}')
   total_ambiguous=$(grep -oh 'Too ambiguous: [0-9]*' "$LOG_DIR"/*-run-*.log 2>/dev/null | awk -F': ' '{s+=$2} END {print s+0}')
-  total_errors=$(grep -ohE '\*?\*?Errors\*?\*?:[[:space:]]+[0-9]+' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
-  total_skipped=$(grep -ohE '\*?\*?Skipped/Unresolved[^:]*\*?\*?:[[:space:]]+[0-9]+' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+$' | awk '{s+=$1} END {print s+0}')
+  total_errors=$(grep -ohE '\*?\*?Errors\*?\*?:\*?\*?[[:space:]]+[0-9]+' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
+  total_skipped=$(grep -ohE '\*?\*?Skipped/Unresolved[^:]*\*?\*?:\*?\*?[[:space:]]+[0-9]+' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+$' | awk '{s+=$1} END {print s+0}')
 
   echo " Total resolved:  $total_resolved"
   echo " Total excluded:  $total_excluded"

--- a/agents/id-mapping/check-status.sh
+++ b/agents/id-mapping/check-status.sh
@@ -95,7 +95,7 @@ for wid in $(find "$LOG_DIR" -maxdepth 1 -name '*-run-*.log' -type f | xargs -I{
     echo "--- Last Run ($wid): $(basename "$last_log") ---"
 
     if grep -q 'ID Mapping Session Report' "$last_log" 2>/dev/null; then
-      sed -n '/ID Mapping Session Report/,/^$/p' "$last_log" | head -30
+      grep -A 30 'ID Mapping Session Report' "$last_log" | head -30
     else
       echo "(no session report — run may have failed)"
       tail -5 "$last_log"

--- a/agents/id-mapping/check-status.sh
+++ b/agents/id-mapping/check-status.sh
@@ -31,13 +31,13 @@ echo ""
 
 # Sum resolved across all runs (only top-level logs)
 if [[ $successful_runs -gt 0 ]]; then
-  total_resolved=$(grep -oh 'Resolved: [0-9]*' "$LOG_DIR"/*-run-*.log 2>/dev/null | awk -F': ' '{s+=$2} END {print s+0}')
-  total_excluded=$(grep -oh 'Excluded: [0-9]*' "$LOG_DIR"/*-run-*.log 2>/dev/null | awk -F': ' '{s+=$2} END {print s+0}')
-  total_conflicts=$(grep -oh 'Conflicts: [0-9]*' "$LOG_DIR"/*-run-*.log 2>/dev/null | awk -F': ' '{s+=$2} END {print s+0}')
+  total_resolved=$(grep -ohE '\*?\*?Resolved\*?\*?:[[:space:]]+\*?\*?[0-9]+\*?\*?[[:space:]]+total' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
+  total_excluded=$(grep -ohE '\*?\*?Excluded\*?\*?:[[:space:]]+\*?\*?[0-9]+\*?\*?[[:space:]]+total' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
+  total_conflicts=$(grep -ohE 'Conflicts[^:]*:[[:space:]]+[0-9]+' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
   total_name_mismatches=$(grep -oh 'Name mismatches: [0-9]*' "$LOG_DIR"/*-run-*.log 2>/dev/null | awk -F': ' '{s+=$2} END {print s+0}')
   total_ambiguous=$(grep -oh 'Too ambiguous: [0-9]*' "$LOG_DIR"/*-run-*.log 2>/dev/null | awk -F': ' '{s+=$2} END {print s+0}')
-  total_errors=$(grep -oh 'Errors: [0-9]*' "$LOG_DIR"/*-run-*.log 2>/dev/null | awk -F': ' '{s+=$2} END {print s+0}')
-  total_skipped=$(grep -oh 'Skipped/Unresolved[^:]*: [0-9]*' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -o '[0-9]*$' | awk '{s+=$1} END {print s+0}')
+  total_errors=$(grep -ohE '\*?\*?Errors\*?\*?:[[:space:]]+[0-9]+' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
+  total_skipped=$(grep -ohE '\*?\*?Skipped/Unresolved[^:]*\*?\*?:[[:space:]]+[0-9]+' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+$' | awk '{s+=$1} END {print s+0}')
 
   echo " Total resolved:  $total_resolved"
   echo " Total excluded:  $total_excluded"

--- a/agents/id-mapping/check-status.sh
+++ b/agents/id-mapping/check-status.sh
@@ -33,9 +33,9 @@ echo ""
 if [[ $successful_runs -gt 0 ]]; then
   total_resolved=$(grep -ohE '\*?\*?Resolved\*?\*?:\*?\*?[[:space:]]+\*?\*?[0-9]+\*?\*?[[:space:]]+total' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
   total_excluded=$(grep -ohE '\*?\*?Excluded\*?\*?:\*?\*?[[:space:]]+\*?\*?[0-9]+\*?\*?[[:space:]]+total' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
-  total_conflicts=$(grep -ohE 'Conflicts[^:]*:[[:space:]]+[0-9]+' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
-  total_name_mismatches=$(grep -oh 'Name mismatches: [0-9]*' "$LOG_DIR"/*-run-*.log 2>/dev/null | awk -F': ' '{s+=$2} END {print s+0}')
-  total_ambiguous=$(grep -oh 'Too ambiguous: [0-9]*' "$LOG_DIR"/*-run-*.log 2>/dev/null | awk -F': ' '{s+=$2} END {print s+0}')
+  total_conflicts=$(grep -ohE '\*?\*?Conflicts[^:]*\*?\*?:\*?\*?[[:space:]]+[0-9]+' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
+  total_name_mismatches=$(grep -ohE '\*?\*?Name mismatches\*?\*?:\*?\*?[[:space:]]+[0-9]+' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
+  total_ambiguous=$(grep -ohE '\*?\*?Too ambiguous\*?\*?:\*?\*?[[:space:]]+[0-9]+' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
   total_errors=$(grep -ohE '\*?\*?Errors\*?\*?:\*?\*?[[:space:]]+[0-9]+' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
   total_skipped=$(grep -ohE '\*?\*?Skipped/Unresolved[^:]*\*?\*?:\*?\*?[[:space:]]+[0-9]+' "$LOG_DIR"/*-run-*.log 2>/dev/null | grep -oE '[0-9]+$' | awk '{s+=$1} END {print s+0}')
 

--- a/agents/id-mapping/run-full-catalog.sh
+++ b/agents/id-mapping/run-full-catalog.sh
@@ -245,7 +245,7 @@ classify_failure() {
   fi
 
   # No session report (agent started but didn't finish)
-  if [[ $exit_code -eq 0 ]] && ! grep -q '=== ID Mapping Session Report ===' "$logfile" 2>/dev/null; then
+  if [[ $exit_code -eq 0 ]] && ! grep -q 'ID Mapping Session Report' "$logfile" 2>/dev/null; then
     fail_reason="no session report in output (agent didn't complete workflow)"
     fail_category="transient"
     return
@@ -288,7 +288,7 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
   # Check for success first — exit 0 + session report = success, skip failure classification
   # This prevents agent output text (e.g. "unauthenticated MCP initialization request failed")
   # from being misclassified as an auth error by the log content patterns.
-  if [[ $exit_code -eq 0 ]] && grep -q '=== ID Mapping Session Report ===' "$logfile" 2>/dev/null; then
+  if [[ $exit_code -eq 0 ]] && grep -q 'ID Mapping Session Report' "$logfile" 2>/dev/null; then
     fail_reason=""
     fail_category=""
     # Success

--- a/agents/id-mapping/run-full-catalog.sh
+++ b/agents/id-mapping/run-full-catalog.sh
@@ -107,11 +107,11 @@ report_run() {
     excluded=$(grep -ohE '\*?\*?Excluded\*?\*?:\*?\*?[[:space:]]+\*?\*?[0-9]+\*?\*?[[:space:]]+total' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
     skipped=$(grep -ohE '\*?\*?Skipped/Unresolved[^:]*\*?\*?:\*?\*?[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+$' || echo "0")
     errors=$(grep -ohE '\*?\*?Errors\*?\*?:\*?\*?[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
-    high=$(grep -ohE 'High:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
-    medium=$(grep -ohE 'Medium:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
-    conflicts=$(grep -ohE 'Conflicts[^:]*:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
-    mismatches=$(grep -ohE 'Name mismatches:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
-    ambiguous=$(grep -ohE 'Too ambiguous:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
+    high=$(grep -ohE '\*?\*?High\*?\*?:\*?\*?[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
+    medium=$(grep -ohE '\*?\*?Medium\*?\*?:\*?\*?[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
+    conflicts=$(grep -ohE '\*?\*?Conflicts[^:]*\*?\*?:\*?\*?[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
+    mismatches=$(grep -ohE '\*?\*?Name mismatches\*?\*?:\*?\*?[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
+    ambiguous=$(grep -ohE '\*?\*?Too ambiguous\*?\*?:\*?\*?[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
 
     payload="$payload,
     \"endedAt\": \"$ended_iso\""

--- a/agents/id-mapping/run-full-catalog.sh
+++ b/agents/id-mapping/run-full-catalog.sh
@@ -103,10 +103,10 @@ report_run() {
     local resolved excluded skipped errors
     local high medium conflicts mismatches ambiguous
     # Note: session report uses variable whitespace for alignment, so [[:space:]]+ not literal space
-    resolved=$(grep -ohE '\*?\*?Resolved\*?\*?:[[:space:]]+\*?\*?[0-9]+\*?\*?[[:space:]]+total' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
-    excluded=$(grep -ohE '\*?\*?Excluded\*?\*?:[[:space:]]+\*?\*?[0-9]+\*?\*?[[:space:]]+total' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
-    skipped=$(grep -ohE '\*?\*?Skipped/Unresolved[^:]*\*?\*?:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+$' || echo "0")
-    errors=$(grep -ohE '\*?\*?Errors\*?\*?:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
+    resolved=$(grep -ohE '\*?\*?Resolved\*?\*?:\*?\*?[[:space:]]+\*?\*?[0-9]+\*?\*?[[:space:]]+total' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
+    excluded=$(grep -ohE '\*?\*?Excluded\*?\*?:\*?\*?[[:space:]]+\*?\*?[0-9]+\*?\*?[[:space:]]+total' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
+    skipped=$(grep -ohE '\*?\*?Skipped/Unresolved[^:]*\*?\*?:\*?\*?[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+$' || echo "0")
+    errors=$(grep -ohE '\*?\*?Errors\*?\*?:\*?\*?[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
     high=$(grep -ohE 'High:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
     medium=$(grep -ohE 'Medium:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
     conflicts=$(grep -ohE 'Conflicts[^:]*:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")

--- a/agents/id-mapping/run-full-catalog.sh
+++ b/agents/id-mapping/run-full-catalog.sh
@@ -103,13 +103,13 @@ report_run() {
     local resolved excluded skipped errors
     local high medium conflicts mismatches ambiguous
     # Note: session report uses variable whitespace for alignment, so [[:space:]]+ not literal space
-    resolved=$(grep -ohE 'Resolved:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
-    excluded=$(grep -ohE 'Excluded:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
-    skipped=$(grep -ohE 'Skipped/Unresolved[^:]*:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+$' || echo "0")
-    errors=$(grep -ohE 'Errors:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
+    resolved=$(grep -ohE '\*?\*?Resolved\*?\*?:[[:space:]]+\*?\*?[0-9]+\*?\*?[[:space:]]+total' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
+    excluded=$(grep -ohE '\*?\*?Excluded\*?\*?:[[:space:]]+\*?\*?[0-9]+\*?\*?[[:space:]]+total' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
+    skipped=$(grep -ohE '\*?\*?Skipped/Unresolved[^:]*\*?\*?:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+$' || echo "0")
+    errors=$(grep -ohE '\*?\*?Errors\*?\*?:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
     high=$(grep -ohE 'High:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
     medium=$(grep -ohE 'Medium:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
-    conflicts=$(grep -ohE 'Conflicts:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
+    conflicts=$(grep -ohE 'Conflicts[^:]*:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
     mismatches=$(grep -ohE 'Name mismatches:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
     ambiguous=$(grep -ohE 'Too ambiguous:[[:space:]]+[0-9]+' "$logfile" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || echo "0")
 


### PR DESCRIPTION
## Summary
- The agent runner uses `grep` to detect the session report marker (`=== ID Mapping Session Report ===`) to determine if a run succeeded
- The LLM occasionally formats the header with markdown (`##`, `**`, emojis) instead of the exact `===` delimiters
- This caused 71 of 731 v2 Deezer runs to be misclassified as failures (9.7% false failure rate) despite completing successfully
- Changed all 6 grep patterns in `run-full-catalog.sh` and `check-status.sh` to match on `ID Mapping Session Report` instead

## Test plan
- [x] Verified 723/732 logs match the relaxed pattern vs 652/732 with the strict pattern
- [x] Remaining 9 unmatched logs are genuine failures (2 API 500s, 7 with no report at all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)