### PR TITLE
test: Deezer API smoke test

### DIFF
--- a/docs/deezer-cutover-plan.md
+++ b/docs/deezer-cutover-plan.md
@@ -294,21 +294,23 @@ Existing tests must stay green throughout. Tests that mock Spotify internals are
 
 ---
 
-### Deezer API Smoke Test (run once after Phase 1, before building DeezerProvider)
+### Deezer API Smoke Test ✅ (completed 2026-04-02)
 
 **Purpose**: Validate our assumptions about Deezer API response shapes before writing the provider. Hits real Deezer API (requires network). Not part of CI — run on-demand.
 
 **File**: `src/server/utils/musicPlatform/__tests__/deezerApiSmoke.test.ts`
 
-**Test cases** (use known artist, e.g. Deezer ID `4495513` = FKJ):
-- `GET /artist/4495513` → response has `id` (number), `name` (string), `picture_xl` (non-empty URL), `nb_fan` (number > 0), `nb_album` (number > 0), `link` (string)
-- `GET /artist/4495513` → response does NOT have `genres` field (confirming our "no artist genres" assumption)
-- `GET /artist/4495513/top?limit=1` → response has `data[0].title` (string), `data[0].id` (number)
+**Test cases** (use known artist, Deezer ID `4738512` = FKJ):
+- `GET /artist/4738512` → response has `id` (number), `name` (string), `picture_xl` (non-empty URL), `nb_fan` (number > 0), `nb_album` (number > 0), `link` (string)
+- `GET /artist/4738512` → response does NOT have `genres` field (confirming our "no artist genres" assumption)
+- `GET /artist/4738512/top?limit=1` → response has `data[0].title` (string), `data[0].id` (number)
 - `GET /search/artist?q=FKJ&limit=5` → response has `data` (array), each item has `id`, `name`, `picture_xl`, `nb_fan`
-- `GET /artist/99999999999` → response has `error` object (confirming error shape)
+- `GET /artist/99999999999` → response has `error` object with `type` and `message` fields (HTTP 200, not 4xx)
 - Verify no auth headers needed (request succeeds with no Authorization header)
 
 **Run with**: `npx jest deezerApiSmoke --testTimeout=30000` (longer timeout for network calls)
+
+**Results**: All 6 tests pass. All assumptions confirmed. Notable: Deezer returns errors as `{ error: { type, message } }` with HTTP 200 (not 4xx status codes). The DeezerProvider must check for `data.error` on every response, not rely on HTTP status.
 
 ---
 

--- a/docs/deezer-cutover-plan.md
+++ b/docs/deezer-cutover-plan.md
@@ -298,7 +298,7 @@ Existing tests must stay green throughout. Tests that mock Spotify internals are
 
 **Purpose**: Validate our assumptions about Deezer API response shapes before writing the provider. Hits real Deezer API (requires network). Not part of CI — run on-demand.
 
-**File**: `src/server/utils/musicPlatform/__tests__/deezerApiSmoke.test.ts`
+**File**: `src/server/utils/musicPlatform/__tests__/deezerApiSmoke.smoke.test.ts`
 
 **Test cases** (use known artist, Deezer ID `4738512` = FKJ):
 - `GET /artist/4738512` → response has `id` (number), `name` (string), `picture_xl` (non-empty URL), `nb_fan` (number > 0), `nb_album` (number > 0), `link` (string)
@@ -308,7 +308,7 @@ Existing tests must stay green throughout. Tests that mock Spotify internals are
 - `GET /artist/99999999999` → response has `error` object with `type` and `message` fields (HTTP 200, not 4xx)
 - Verify no auth headers needed (request succeeds with no Authorization header)
 
-**Run with**: `npx jest deezerApiSmoke --testTimeout=30000` (longer timeout for network calls)
+**Run with**: `npx jest --testPathIgnorePatterns='[]' --testPathPatterns=deezerApiSmoke` (excluded from CI via `.smoke.test.ts` pattern in `jest.config.ts`)
 
 **Results**: All 6 tests pass. All assumptions confirmed. Notable: Deezer returns errors as `{ error: { type, message } }` with HTTP 200 (not 4xx status codes). The DeezerProvider must check for `data.error` on every response, not rely on HTTP status.
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -38,7 +38,7 @@ const customJestConfig: Config = {
     transformIgnorePatterns: [
         'node_modules/(?!(jose|@radix-ui|@panva|@tanstack|@tanstack/react-query|@tanstack/query-core)/)'
     ],
-    testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/.next/', '<rootDir>/e2e/'],
+    testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/.next/', '<rootDir>/e2e/', '.*\\.smoke\\.test\\.ts$'],
     moduleDirectories: ['node_modules', '<rootDir>/'],
     testMatch: [
         '**/__tests__/**/*.[jt]s?(x)',

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -36,36 +36,38 @@ configure({
     testIdAttribute: 'data-testid',
 });
 
-// Mock window.matchMedia
-Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    value: jest.fn().mockImplementation(query => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-    })),
-});
+// Mock window.matchMedia (skip in node environment, e.g. API smoke tests)
+if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation(query => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(),
+        })),
+    });
 
-// Mock IntersectionObserver
-const mockIntersectionObserver = jest.fn();
-mockIntersectionObserver.mockReturnValue({
-    observe: () => null,
-    unobserve: () => null,
-    disconnect: () => null
-});
-window.IntersectionObserver = mockIntersectionObserver;
+    // Mock IntersectionObserver
+    const mockIntersectionObserver = jest.fn();
+    mockIntersectionObserver.mockReturnValue({
+        observe: () => null,
+        unobserve: () => null,
+        disconnect: () => null
+    });
+    window.IntersectionObserver = mockIntersectionObserver;
 
-// Mock ResizeObserver
-window.ResizeObserver = jest.fn().mockImplementation(() => ({
-    observe: jest.fn(),
-    unobserve: jest.fn(),
-    disconnect: jest.fn(),
-}));
+    // Mock ResizeObserver
+    window.ResizeObserver = jest.fn().mockImplementation(() => ({
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+        disconnect: jest.fn(),
+    }));
+}
 
 // Mock window.fetch
 global.fetch = jest.fn(() =>

--- a/src/server/utils/musicPlatform/__tests__/deezerApiSmoke.smoke.test.ts
+++ b/src/server/utils/musicPlatform/__tests__/deezerApiSmoke.smoke.test.ts
@@ -8,9 +8,11 @@
  * Validates assumptions about Deezer API response shapes before building DeezerProvider.
  * Hits real Deezer API (requires network). Not part of CI — run on-demand:
  *
- *   npx jest deezerApiSmoke --testTimeout=30000
+ *   npx jest --testPathIgnorePatterns='[]' --testPathPatterns=deezerApiSmoke
  */
 import axios from 'axios';
+
+jest.setTimeout(30000);
 
 const DEEZER_BASE = 'https://api.deezer.com';
 const KNOWN_ARTIST_ID = 4738512; // FKJ

--- a/src/server/utils/musicPlatform/__tests__/deezerApiSmoke.test.ts
+++ b/src/server/utils/musicPlatform/__tests__/deezerApiSmoke.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Deezer API Smoke Test
+ *
+ * Validates assumptions about Deezer API response shapes before building DeezerProvider.
+ * Hits real Deezer API (requires network). Not part of CI — run on-demand:
+ *
+ *   npx jest deezerApiSmoke --testTimeout=30000
+ */
+import axios from 'axios';
+
+const DEEZER_BASE = 'https://api.deezer.com';
+const KNOWN_ARTIST_ID = 4738512; // FKJ
+
+describe('Deezer API Smoke Test', () => {
+  it('GET /artist/:id returns expected fields with correct types', async () => {
+    const { data } = await axios.get(`${DEEZER_BASE}/artist/${KNOWN_ARTIST_ID}`);
+
+    expect(typeof data.id).toBe('number');
+    expect(typeof data.name).toBe('string');
+    expect(typeof data.picture_xl).toBe('string');
+    expect(data.picture_xl.length).toBeGreaterThan(0);
+    expect(typeof data.nb_fan).toBe('number');
+    expect(data.nb_fan).toBeGreaterThan(0);
+    expect(typeof data.nb_album).toBe('number');
+    expect(data.nb_album).toBeGreaterThan(0);
+    expect(typeof data.link).toBe('string');
+  });
+
+  it('GET /artist/:id does NOT have a genres field', async () => {
+    const { data } = await axios.get(`${DEEZER_BASE}/artist/${KNOWN_ARTIST_ID}`);
+
+    expect(data).not.toHaveProperty('genres');
+  });
+
+  it('GET /artist/:id/top?limit=1 returns top track with title and id', async () => {
+    const { data } = await axios.get(
+      `${DEEZER_BASE}/artist/${KNOWN_ARTIST_ID}/top?limit=1`,
+    );
+
+    expect(Array.isArray(data.data)).toBe(true);
+    expect(data.data.length).toBeGreaterThan(0);
+    expect(typeof data.data[0].title).toBe('string');
+    expect(typeof data.data[0].id).toBe('number');
+  });
+
+  it('GET /search/artist returns array of artists with expected fields', async () => {
+    const { data } = await axios.get(
+      `${DEEZER_BASE}/search/artist?q=FKJ&limit=5`,
+    );
+
+    expect(Array.isArray(data.data)).toBe(true);
+    expect(data.data.length).toBeGreaterThan(0);
+
+    for (const artist of data.data) {
+      expect(typeof artist.id).toBe('number');
+      expect(typeof artist.name).toBe('string');
+      expect(typeof artist.picture_xl).toBe('string');
+      expect(typeof artist.nb_fan).toBe('number');
+    }
+  });
+
+  it('GET /artist/:invalidId returns an error object', async () => {
+    const { data } = await axios.get(`${DEEZER_BASE}/artist/99999999999`);
+
+    expect(data).toHaveProperty('error');
+    expect(typeof data.error).toBe('object');
+    expect(data.error).toHaveProperty('type');
+    expect(data.error).toHaveProperty('message');
+  });
+
+  it('requests succeed without any Authorization header', async () => {
+    // Explicitly ensure no auth headers are sent
+    const { data, status } = await axios.get(
+      `${DEEZER_BASE}/artist/${KNOWN_ARTIST_ID}`,
+      { headers: {} },
+    );
+
+    expect(status).toBe(200);
+    expect(typeof data.id).toBe('number');
+    expect(typeof data.name).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary
- Add Deezer API smoke test (`deezerApiSmoke.test.ts`) validating all 6 API shape assumptions from the cutover plan before building DeezerProvider
- Fix FKJ's Deezer ID from `4495513` (Travis Scott) to `4738512` in the cutover plan
- Guard `window`-dependent mocks in `jest.setup.ts` so `@jest-environment node` tests work alongside jsdom tests

## Test plan
- [x] All 6 smoke tests pass: `npx jest deezerApiSmoke --testTimeout=30000`
- [x] Full test suite passes (92 suites, 936 tests): `npx jest --ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)