### PR TITLE
feat: add MusicPlatformProvider interface and SpotifyProvider

### DIFF
--- a/src/server/utils/musicPlatform/__tests__/spotifyProvider.test.ts
+++ b/src/server/utils/musicPlatform/__tests__/spotifyProvider.test.ts
@@ -1,0 +1,244 @@
+// @ts-nocheck
+import { jest } from '@jest/globals';
+
+jest.mock('@/server/utils/queries/externalApiQueries', () => ({
+    getSpotifyHeaders: jest.fn(),
+    getSpotifyArtist: jest.fn(),
+    getSpotifyImage: jest.fn(),
+    getNumberOfSpotifyReleases: jest.fn(),
+    getArtistTopTrackName: jest.fn(),
+    getSpotifyArtists: jest.fn(),
+}));
+
+jest.mock('axios', () => ({
+    __esModule: true,
+    default: { get: jest.fn() },
+}));
+
+const mockHeaders = { headers: { Authorization: 'Bearer test-token' } };
+
+const mockSpotifyArtist = {
+    id: 'spotify-123',
+    name: 'Test Artist',
+    images: [{ url: 'https://img.spotify.com/artist.jpg', height: 640, width: 640 }],
+    followers: { total: 50000 },
+    genres: ['electronic', 'ambient'],
+    type: 'artist',
+    uri: 'spotify:artist:spotify-123',
+    external_urls: { spotify: 'https://open.spotify.com/artist/spotify-123' },
+};
+
+describe('SpotifyProvider', () => {
+    beforeEach(() => {
+        jest.resetModules();
+    });
+
+    async function setup() {
+        const externalApi = await import('@/server/utils/queries/externalApiQueries');
+        const axios = (await import('axios')).default;
+        const { SpotifyProvider } = await import('../spotifyProvider');
+
+        const mocks = {
+            getSpotifyHeaders: externalApi.getSpotifyHeaders as jest.Mock,
+            getSpotifyArtist: externalApi.getSpotifyArtist as jest.Mock,
+            getSpotifyImage: externalApi.getSpotifyImage as jest.Mock,
+            getNumberOfSpotifyReleases: externalApi.getNumberOfSpotifyReleases as jest.Mock,
+            getArtistTopTrackName: externalApi.getArtistTopTrackName as jest.Mock,
+            getSpotifyArtists: externalApi.getSpotifyArtists as jest.Mock,
+            axiosGet: axios.get as jest.Mock,
+        };
+
+        mocks.getSpotifyHeaders.mockResolvedValue(mockHeaders);
+
+        return { provider: new SpotifyProvider(), ...mocks };
+    }
+
+    it('should have platform set to spotify', async () => {
+        const { provider } = await setup();
+        expect(provider.platform).toBe('spotify');
+    });
+
+    describe('getArtist', () => {
+        it('should normalize SpotifyArtist to MusicPlatformArtist', async () => {
+            const { provider, getSpotifyArtist, getNumberOfSpotifyReleases, getArtistTopTrackName } = await setup();
+            getSpotifyArtist.mockResolvedValue({ data: mockSpotifyArtist, error: null });
+            getNumberOfSpotifyReleases.mockResolvedValue(5);
+            getArtistTopTrackName.mockResolvedValue('Hit Song');
+
+            const result = await provider.getArtist('spotify-123');
+
+            expect(result).toEqual({
+                platform: 'spotify',
+                platformId: 'spotify-123',
+                name: 'Test Artist',
+                imageUrl: 'https://img.spotify.com/artist.jpg',
+                followerCount: 50000,
+                albumCount: 5,
+                genres: ['electronic', 'ambient'],
+                profileUrl: 'https://open.spotify.com/artist/spotify-123',
+                topTrackName: 'Hit Song',
+            });
+        });
+
+        it('should return null when getSpotifyArtist returns error', async () => {
+            const { provider, getSpotifyArtist, getNumberOfSpotifyReleases, getArtistTopTrackName } = await setup();
+            getSpotifyArtist.mockResolvedValue({ data: null, error: 'Invalid Spotify ID' });
+            getNumberOfSpotifyReleases.mockResolvedValue(0);
+            getArtistTopTrackName.mockResolvedValue(null);
+
+            const result = await provider.getArtist('bad-id');
+            expect(result).toBeNull();
+        });
+
+        it('should handle artist with no images', async () => {
+            const { provider, getSpotifyArtist, getNumberOfSpotifyReleases, getArtistTopTrackName } = await setup();
+            getSpotifyArtist.mockResolvedValue({
+                data: { ...mockSpotifyArtist, images: [] },
+                error: null,
+            });
+            getNumberOfSpotifyReleases.mockResolvedValue(3);
+            getArtistTopTrackName.mockResolvedValue(null);
+
+            const result = await provider.getArtist('spotify-123');
+            expect(result?.imageUrl).toBeNull();
+        });
+
+        it('should default albumCount to 0 on failure', async () => {
+            const { provider, getSpotifyArtist, getNumberOfSpotifyReleases, getArtistTopTrackName } = await setup();
+            getSpotifyArtist.mockResolvedValue({ data: mockSpotifyArtist, error: null });
+            getNumberOfSpotifyReleases.mockResolvedValue(0);
+            getArtistTopTrackName.mockResolvedValue('Track');
+
+            const result = await provider.getArtist('spotify-123');
+            expect(result?.albumCount).toBe(0);
+        });
+
+        it('should default topTrackName to null on failure', async () => {
+            const { provider, getSpotifyArtist, getNumberOfSpotifyReleases, getArtistTopTrackName } = await setup();
+            getSpotifyArtist.mockResolvedValue({ data: mockSpotifyArtist, error: null });
+            getNumberOfSpotifyReleases.mockResolvedValue(5);
+            getArtistTopTrackName.mockResolvedValue(null);
+
+            const result = await provider.getArtist('spotify-123');
+            expect(result?.topTrackName).toBeNull();
+        });
+    });
+
+    describe('getArtistImage', () => {
+        it('should return image URL', async () => {
+            const { provider, getSpotifyImage } = await setup();
+            getSpotifyImage.mockResolvedValue({ artistImage: 'https://img.spotify.com/artist.jpg', artistId: '' });
+
+            const result = await provider.getArtistImage('spotify-123');
+            expect(result).toBe('https://img.spotify.com/artist.jpg');
+        });
+
+        it('should return null when image is empty string', async () => {
+            const { provider, getSpotifyImage } = await setup();
+            getSpotifyImage.mockResolvedValue({ artistImage: '', artistId: '' });
+
+            const result = await provider.getArtistImage('spotify-123');
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('getTopTrackName', () => {
+        it('should return track name', async () => {
+            const { provider, getArtistTopTrackName } = await setup();
+            getArtistTopTrackName.mockResolvedValue('Hit Song');
+
+            const result = await provider.getTopTrackName('spotify-123');
+            expect(result).toBe('Hit Song');
+        });
+
+        it('should return null when no top track', async () => {
+            const { provider, getArtistTopTrackName } = await setup();
+            getArtistTopTrackName.mockResolvedValue(null);
+
+            const result = await provider.getTopTrackName('spotify-123');
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('searchArtists', () => {
+        it('should call Spotify search API and normalize results', async () => {
+            const { provider, axiosGet } = await setup();
+            const secondArtist = {
+                ...mockSpotifyArtist,
+                id: 'spotify-456',
+                name: 'Another Artist',
+            };
+            axiosGet.mockResolvedValue({
+                data: { artists: { items: [mockSpotifyArtist, secondArtist] } },
+            });
+
+            const result = await provider.searchArtists('test', 10);
+
+            expect(result).toHaveLength(2);
+            expect(result[0]).toEqual({
+                platform: 'spotify',
+                platformId: 'spotify-123',
+                name: 'Test Artist',
+                imageUrl: 'https://img.spotify.com/artist.jpg',
+                followerCount: 50000,
+                albumCount: 0,
+                genres: ['electronic', 'ambient'],
+                profileUrl: 'https://open.spotify.com/artist/spotify-123',
+                topTrackName: null,
+            });
+            expect(result[1].platformId).toBe('spotify-456');
+        });
+
+        it('should return empty array on API error', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet.mockRejectedValue(new Error('Network error'));
+
+            const result = await provider.searchArtists('test', 10);
+            expect(result).toEqual([]);
+        });
+
+        it('should pass limit to Spotify API', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet.mockResolvedValue({ data: { artists: { items: [] } } });
+
+            await provider.searchArtists('query', 5);
+
+            expect(axiosGet).toHaveBeenCalledWith(
+                expect.stringContaining('&limit=5'),
+                mockHeaders,
+            );
+        });
+    });
+
+    describe('getArtists', () => {
+        it('should normalize batch results', async () => {
+            const { provider, getSpotifyArtists } = await setup();
+            const secondArtist = { ...mockSpotifyArtist, id: 'spotify-456', name: 'Artist 2' };
+            getSpotifyArtists.mockResolvedValue([mockSpotifyArtist, secondArtist]);
+
+            const result = await provider.getArtists(['spotify-123', 'spotify-456']);
+
+            expect(result).toHaveLength(2);
+            expect(result[0].albumCount).toBe(0);
+            expect(result[0].topTrackName).toBeNull();
+            expect(result[1].platformId).toBe('spotify-456');
+        });
+
+        it('should filter out null entries', async () => {
+            const { provider, getSpotifyArtists } = await setup();
+            getSpotifyArtists.mockResolvedValue([mockSpotifyArtist, null, mockSpotifyArtist]);
+
+            const result = await provider.getArtists(['id1', 'id2', 'id3']);
+            expect(result).toHaveLength(2);
+        });
+
+        it('should return empty array for empty input', async () => {
+            const { provider, getSpotifyArtists } = await setup();
+
+            const result = await provider.getArtists([]);
+
+            expect(result).toEqual([]);
+            expect(getSpotifyArtists).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/server/utils/musicPlatform/__tests__/spotifyProvider.test.ts
+++ b/src/server/utils/musicPlatform/__tests__/spotifyProvider.test.ts
@@ -83,11 +83,12 @@ describe('SpotifyProvider', () => {
         it('should return null when getSpotifyArtist returns error', async () => {
             const { provider, getSpotifyArtist, getNumberOfSpotifyReleases, getArtistTopTrackName } = await setup();
             getSpotifyArtist.mockResolvedValue({ data: null, error: 'Invalid Spotify ID' });
-            getNumberOfSpotifyReleases.mockResolvedValue(0);
-            getArtistTopTrackName.mockResolvedValue(null);
 
             const result = await provider.getArtist('bad-id');
             expect(result).toBeNull();
+            // Enrichment calls should not fire for invalid artists
+            expect(getNumberOfSpotifyReleases).not.toHaveBeenCalled();
+            expect(getArtistTopTrackName).not.toHaveBeenCalled();
         });
 
         it('should handle artist with no images', async () => {
@@ -103,23 +104,25 @@ describe('SpotifyProvider', () => {
             expect(result?.imageUrl).toBeNull();
         });
 
-        it('should default albumCount to 0 on failure', async () => {
+        it('should default albumCount to 0 when enrichment rejects', async () => {
             const { provider, getSpotifyArtist, getNumberOfSpotifyReleases, getArtistTopTrackName } = await setup();
             getSpotifyArtist.mockResolvedValue({ data: mockSpotifyArtist, error: null });
-            getNumberOfSpotifyReleases.mockResolvedValue(0);
+            getNumberOfSpotifyReleases.mockRejectedValue(new Error('Spotify rate limit'));
             getArtistTopTrackName.mockResolvedValue('Track');
 
             const result = await provider.getArtist('spotify-123');
             expect(result?.albumCount).toBe(0);
+            expect(result?.topTrackName).toBeNull();
         });
 
-        it('should default topTrackName to null on failure', async () => {
+        it('should default topTrackName to null when enrichment rejects', async () => {
             const { provider, getSpotifyArtist, getNumberOfSpotifyReleases, getArtistTopTrackName } = await setup();
             getSpotifyArtist.mockResolvedValue({ data: mockSpotifyArtist, error: null });
             getNumberOfSpotifyReleases.mockResolvedValue(5);
-            getArtistTopTrackName.mockResolvedValue(null);
+            getArtistTopTrackName.mockRejectedValue(new Error('Spotify error'));
 
             const result = await provider.getArtist('spotify-123');
+            expect(result?.albumCount).toBe(0);
             expect(result?.topTrackName).toBeNull();
         });
     });

--- a/src/server/utils/musicPlatform/__tests__/spotifyProvider.test.ts
+++ b/src/server/utils/musicPlatform/__tests__/spotifyProvider.test.ts
@@ -104,7 +104,7 @@ describe('SpotifyProvider', () => {
             expect(result?.imageUrl).toBeNull();
         });
 
-        it('should default albumCount to 0 when enrichment rejects', async () => {
+        it('should default albumCount to 0 when releases call rejects', async () => {
             const { provider, getSpotifyArtist, getNumberOfSpotifyReleases, getArtistTopTrackName } = await setup();
             getSpotifyArtist.mockResolvedValue({ data: mockSpotifyArtist, error: null });
             getNumberOfSpotifyReleases.mockRejectedValue(new Error('Spotify rate limit'));
@@ -112,17 +112,17 @@ describe('SpotifyProvider', () => {
 
             const result = await provider.getArtist('spotify-123');
             expect(result?.albumCount).toBe(0);
-            expect(result?.topTrackName).toBeNull();
+            expect(result?.topTrackName).toBe('Track');
         });
 
-        it('should default topTrackName to null when enrichment rejects', async () => {
+        it('should default topTrackName to null when top track call rejects', async () => {
             const { provider, getSpotifyArtist, getNumberOfSpotifyReleases, getArtistTopTrackName } = await setup();
             getSpotifyArtist.mockResolvedValue({ data: mockSpotifyArtist, error: null });
             getNumberOfSpotifyReleases.mockResolvedValue(5);
             getArtistTopTrackName.mockRejectedValue(new Error('Spotify error'));
 
             const result = await provider.getArtist('spotify-123');
-            expect(result?.albumCount).toBe(0);
+            expect(result?.albumCount).toBe(5);
             expect(result?.topTrackName).toBeNull();
         });
     });

--- a/src/server/utils/musicPlatform/index.ts
+++ b/src/server/utils/musicPlatform/index.ts
@@ -1,0 +1,2 @@
+export type { MusicPlatformArtist, MusicPlatformProvider } from './types';
+export { SpotifyProvider, spotifyProvider } from './spotifyProvider';

--- a/src/server/utils/musicPlatform/index.ts
+++ b/src/server/utils/musicPlatform/index.ts
@@ -1,2 +1,2 @@
-export type { MusicPlatformArtist, MusicPlatformProvider } from './types';
+export type { MusicPlatform, MusicPlatformArtist, MusicPlatformProvider } from './types';
 export { SpotifyProvider, spotifyProvider } from './spotifyProvider';

--- a/src/server/utils/musicPlatform/spotifyProvider.ts
+++ b/src/server/utils/musicPlatform/spotifyProvider.ts
@@ -39,20 +39,26 @@ export class SpotifyProvider implements MusicPlatformProvider {
 
     async getArtist(id: string): Promise<MusicPlatformArtist | null> {
         const headers = await getSpotifyHeaders();
-        const [artistResponse, albumCount, topTrackName] = await Promise.all([
-            getSpotifyArtist(id, headers),
-            getNumberOfSpotifyReleases(id, headers),
-            getArtistTopTrackName(id, headers),
-        ]);
-
+        const artistResponse = await getSpotifyArtist(id, headers);
         if (artistResponse.error || !artistResponse.data) return null;
+
+        let albumCount = 0;
+        let topTrackName: string | null = null;
+        try {
+            [albumCount, topTrackName] = await Promise.all([
+                getNumberOfSpotifyReleases(id, headers),
+                getArtistTopTrackName(id, headers),
+            ]);
+        } catch (error) {
+            console.error('SpotifyProvider.getArtist enrichment failed:', error);
+        }
 
         return mapSpotifyArtist(artistResponse.data, albumCount, topTrackName);
     }
 
     async getArtistImage(id: string): Promise<string | null> {
         const headers = await getSpotifyHeaders();
-        const result = await getSpotifyImage(id, '', headers);
+        const result = await getSpotifyImage(id, undefined, headers);
         return result.artistImage || null;
     }
 
@@ -61,6 +67,8 @@ export class SpotifyProvider implements MusicPlatformProvider {
         return getArtistTopTrackName(id, headers);
     }
 
+    // Inline axios call: no search function exists in externalApiQueries.ts, and we
+    // don't modify that file in Phase 1. It gets deleted entirely in Phase 5.
     async searchArtists(query: string, limit: number): Promise<MusicPlatformArtist[]> {
         try {
             const headers = await getSpotifyHeaders();
@@ -83,8 +91,8 @@ export class SpotifyProvider implements MusicPlatformProvider {
         const headers = await getSpotifyHeaders();
         const artists = await getSpotifyArtists(ids, headers);
         return artists
-            .filter(Boolean)
-            .map((artist: SpotifyArtist) => mapSpotifyArtist(artist, 0, null));
+            .filter((a): a is SpotifyArtist => a != null)
+            .map((artist) => mapSpotifyArtist(artist, 0, null));
     }
 }
 

--- a/src/server/utils/musicPlatform/spotifyProvider.ts
+++ b/src/server/utils/musicPlatform/spotifyProvider.ts
@@ -42,16 +42,12 @@ export class SpotifyProvider implements MusicPlatformProvider {
         const artistResponse = await getSpotifyArtist(id, headers);
         if (artistResponse.error || !artistResponse.data) return null;
 
-        let albumCount = 0;
-        let topTrackName: string | null = null;
-        try {
-            [albumCount, topTrackName] = await Promise.all([
-                getNumberOfSpotifyReleases(id, headers),
-                getArtistTopTrackName(id, headers),
-            ]);
-        } catch (error) {
-            console.error('SpotifyProvider.getArtist enrichment failed:', error);
-        }
+        const [releasesResult, trackResult] = await Promise.allSettled([
+            getNumberOfSpotifyReleases(id, headers),
+            getArtistTopTrackName(id, headers),
+        ]);
+        const albumCount = releasesResult.status === 'fulfilled' ? releasesResult.value : 0;
+        const topTrackName = trackResult.status === 'fulfilled' ? trackResult.value : null;
 
         return mapSpotifyArtist(artistResponse.data, albumCount, topTrackName);
     }

--- a/src/server/utils/musicPlatform/spotifyProvider.ts
+++ b/src/server/utils/musicPlatform/spotifyProvider.ts
@@ -1,0 +1,91 @@
+import type { MusicPlatformArtist, MusicPlatformProvider } from './types';
+import {
+    getSpotifyHeaders,
+    getSpotifyArtist,
+    getSpotifyImage,
+    getNumberOfSpotifyReleases,
+    getArtistTopTrackName,
+    getSpotifyArtists,
+    type SpotifyArtist,
+} from '@/server/utils/queries/externalApiQueries';
+import axios from 'axios';
+
+interface SpotifySearchResponse {
+    artists: {
+        items: SpotifyArtist[];
+    };
+}
+
+function mapSpotifyArtist(
+    artist: SpotifyArtist,
+    albumCount: number,
+    topTrackName: string | null,
+): MusicPlatformArtist {
+    return {
+        platform: 'spotify',
+        platformId: artist.id,
+        name: artist.name,
+        imageUrl: artist.images[0]?.url ?? null,
+        followerCount: artist.followers.total,
+        albumCount,
+        genres: artist.genres,
+        profileUrl: artist.external_urls.spotify,
+        topTrackName,
+    };
+}
+
+export class SpotifyProvider implements MusicPlatformProvider {
+    readonly platform = 'spotify' as const;
+
+    async getArtist(id: string): Promise<MusicPlatformArtist | null> {
+        const headers = await getSpotifyHeaders();
+        const [artistResponse, albumCount, topTrackName] = await Promise.all([
+            getSpotifyArtist(id, headers),
+            getNumberOfSpotifyReleases(id, headers),
+            getArtistTopTrackName(id, headers),
+        ]);
+
+        if (artistResponse.error || !artistResponse.data) return null;
+
+        return mapSpotifyArtist(artistResponse.data, albumCount, topTrackName);
+    }
+
+    async getArtistImage(id: string): Promise<string | null> {
+        const headers = await getSpotifyHeaders();
+        const result = await getSpotifyImage(id, '', headers);
+        return result.artistImage || null;
+    }
+
+    async getTopTrackName(id: string): Promise<string | null> {
+        const headers = await getSpotifyHeaders();
+        return getArtistTopTrackName(id, headers);
+    }
+
+    async searchArtists(query: string, limit: number): Promise<MusicPlatformArtist[]> {
+        try {
+            const headers = await getSpotifyHeaders();
+            const response = await axios.get<SpotifySearchResponse>(
+                `https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=artist&limit=${limit}`,
+                headers,
+            );
+            return response.data.artists.items.map((artist) =>
+                mapSpotifyArtist(artist, 0, null),
+            );
+        } catch (error) {
+            console.error('SpotifyProvider.searchArtists failed:', error);
+            return [];
+        }
+    }
+
+    async getArtists(ids: string[]): Promise<MusicPlatformArtist[]> {
+        if (ids.length === 0) return [];
+
+        const headers = await getSpotifyHeaders();
+        const artists = await getSpotifyArtists(ids, headers);
+        return artists
+            .filter(Boolean)
+            .map((artist: SpotifyArtist) => mapSpotifyArtist(artist, 0, null));
+    }
+}
+
+export const spotifyProvider = new SpotifyProvider();

--- a/src/server/utils/musicPlatform/types.ts
+++ b/src/server/utils/musicPlatform/types.ts
@@ -1,5 +1,7 @@
+export type MusicPlatform = 'spotify' | 'deezer';
+
 export interface MusicPlatformArtist {
-  platform: 'spotify' | 'deezer';
+  platform: MusicPlatform;
   platformId: string;
   name: string;
   imageUrl: string | null;
@@ -11,7 +13,7 @@ export interface MusicPlatformArtist {
 }
 
 export interface MusicPlatformProvider {
-  readonly platform: 'spotify' | 'deezer';
+  readonly platform: MusicPlatform;
 
   /** Full artist data including top track. */
   getArtist(id: string): Promise<MusicPlatformArtist | null>;

--- a/src/server/utils/musicPlatform/types.ts
+++ b/src/server/utils/musicPlatform/types.ts
@@ -5,7 +5,7 @@ export interface MusicPlatformArtist {
   platformId: string;
   name: string;
   imageUrl: string | null;
-  followerCount: number;
+  followerCount: number | null;
   albumCount: number;
   genres: string[];
   profileUrl: string;

--- a/src/server/utils/musicPlatform/types.ts
+++ b/src/server/utils/musicPlatform/types.ts
@@ -1,0 +1,30 @@
+export interface MusicPlatformArtist {
+  platform: 'spotify' | 'deezer';
+  platformId: string;
+  name: string;
+  imageUrl: string | null;
+  followerCount: number;
+  albumCount: number;
+  genres: string[];
+  profileUrl: string;
+  topTrackName: string | null;
+}
+
+export interface MusicPlatformProvider {
+  readonly platform: 'spotify' | 'deezer';
+
+  /** Full artist data including top track. */
+  getArtist(id: string): Promise<MusicPlatformArtist | null>;
+
+  /** Image only — lighter than getArtist when only image is needed. */
+  getArtistImage(id: string): Promise<string | null>;
+
+  /** Top track name. */
+  getTopTrackName(id: string): Promise<string | null>;
+
+  /** Search external catalog. Returns array of platform artists (without topTrackName). */
+  searchArtists(query: string, limit: number): Promise<MusicPlatformArtist[]>;
+
+  /** Batch fetch. */
+  getArtists(ids: string[]): Promise<MusicPlatformArtist[]>;
+}


### PR DESCRIPTION
## Summary

Phase 1 of the Deezer cutover plan. Introduces a platform-agnostic abstraction layer under `src/server/utils/musicPlatform/`:

- `MusicPlatformArtist` and `MusicPlatformProvider` interfaces in `types.ts`
- `SpotifyProvider` class wrapping existing `externalApiQueries.ts` functions (`getArtist`, `getArtistImage`, `getTopTrackName`, `searchArtists`, `getArtists`)
- 16 unit tests covering all methods and edge cases
- Barrel `index.ts` re-exporting types and provider

No consumer changes — `externalApiQueries.ts` and all existing callers remain untouched. This sets the foundation for Phase 2 (DeezerProvider + ArtistMusicPlatformDataProvider).