### PR TITLE
chore: reorder admin tabs — move Artist Data after Claims

### DIFF
--- a/src/app/admin/AdminTabs.tsx
+++ b/src/app/admin/AdminTabs.tsx
@@ -33,17 +33,17 @@ export default function AdminTabs({
         <TabsTrigger value="claims">
           Claims ({claimsCount})
         </TabsTrigger>
+        <TabsTrigger value="artist-data">Artist Data</TabsTrigger>
         <TabsTrigger value="users">Users</TabsTrigger>
         <TabsTrigger value="mcp-keys">MCP Keys</TabsTrigger>
         <TabsTrigger value="agent-work">Agent Work</TabsTrigger>
-        <TabsTrigger value="artist-data">Artist Data</TabsTrigger>
       </TabsList>
       <TabsContent value="ugc">{ugcContent}</TabsContent>
       <TabsContent value="claims">{claimsContent}</TabsContent>
+      <TabsContent value="artist-data">{artistDataContent}</TabsContent>
       <TabsContent value="users">{usersContent}</TabsContent>
       <TabsContent value="mcp-keys">{mcpKeysContent}</TabsContent>
       <TabsContent value="agent-work">{agentWorkContent}</TabsContent>
-      <TabsContent value="artist-data">{artistDataContent}</TabsContent>
     </Tabs>
   );
 }


### PR DESCRIPTION
## Summary
- Moves the **Artist Data** tab from last position to after Claims (and before Users) in the admin dashboard tab bar

## Test plan
- [ ] Verify admin dashboard loads with tabs in new order: UGC → Claims → Artist Data → Users → MCP Keys → Agent Work
- [ ] Verify each tab still renders its correct content

🤖 Generated with [Claude Code](https://claude.com/claude-code)