### PR TITLE
feat: DeezerProvider + ArtistMusicPlatformDataProvider (Phase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,3 +348,23 @@ Environment variables are validated via `src/env.ts` — review before adding ne
 1. **Database First**: Most data operations go through Drizzle ORM queries. Import types from `@/server/db/DbTypes`, not from drizzle-orm directly.
 2. **External Dependencies**: Heavy integration with Spotify API and OpenAI — these are mocked in tests.
 3. **ESLint**: Flat config (`eslint.config.mjs`). `@typescript-eslint/no-explicit-any` and `@typescript-eslint/ban-ts-comment` are warnings, not errors. Test files have these rules disabled entirely.
+
+## Skill routing
+
+When the user's request matches an available skill, ALWAYS invoke it using the Skill
+tool as your FIRST action. Do NOT answer directly, do NOT use other tools first.
+The skill has specialized workflows that produce better results than ad-hoc answers.
+
+Key routing rules:
+- Product ideas, "is this worth building", brainstorming → invoke office-hours
+- Bugs, errors, "why is this broken", 500 errors → invoke investigate
+- Ship, deploy, push, create PR → invoke ship
+- QA, test the site, find bugs → invoke qa
+- Code review, check my diff → invoke review
+- Update docs after shipping → invoke document-release
+- Weekly retro → invoke retro
+- Design system, brand → invoke design-consultation
+- Visual audit, design polish → invoke design-review
+- Architecture review → invoke plan-eng-review
+- Save progress, checkpoint, resume → invoke checkpoint
+- Code quality, health check → invoke health

--- a/drizzle/0006_careless_ravenous.sql
+++ b/drizzle/0006_careless_ravenous.sql
@@ -1,0 +1,49 @@
+CREATE TYPE "public"."claim_status" AS ENUM('pending', 'approved', 'rejected');--> statement-breakpoint
+CREATE TYPE "public"."source_status" AS ENUM('pending', 'approved', 'rejected');--> statement-breakpoint
+CREATE TABLE "artist_claims" (
+	"id" uuid PRIMARY KEY DEFAULT uuid_generate_v4() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"artist_id" uuid NOT NULL,
+	"status" "claim_status" DEFAULT 'pending' NOT NULL,
+	"reference_code" text,
+	"created_at" timestamp with time zone DEFAULT (now() AT TIME ZONE 'utc'::text) NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT (now() AT TIME ZONE 'utc'::text) NOT NULL,
+	CONSTRAINT "artist_claims_artist_id_key" UNIQUE("artist_id")
+);
+--> statement-breakpoint
+ALTER TABLE "artist_claims" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE TABLE "artist_vault_sources" (
+	"id" uuid PRIMARY KEY DEFAULT uuid_generate_v4() NOT NULL,
+	"artist_id" uuid NOT NULL,
+	"url" text NOT NULL,
+	"title" text,
+	"snippet" text,
+	"type" text,
+	"status" "source_status" DEFAULT 'pending' NOT NULL,
+	"file_name" text,
+	"file_size" integer,
+	"file_path" text,
+	"content_type" text,
+	"extracted_text" text,
+	"created_at" timestamp with time zone DEFAULT (now() AT TIME ZONE 'utc'::text) NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT (now() AT TIME ZONE 'utc'::text) NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "artist_vault_sources" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "artists" ADD COLUMN "custom_image" text;--> statement-breakpoint
+ALTER TABLE "artists" ADD COLUMN "deezer" text;--> statement-breakpoint
+ALTER TABLE "artist_claims" ADD CONSTRAINT "artist_claims_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "artist_claims" ADD CONSTRAINT "artist_claims_artist_id_fkey" FOREIGN KEY ("artist_id") REFERENCES "public"."artists"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "artist_vault_sources" ADD CONSTRAINT "artist_vault_sources_artist_id_fkey" FOREIGN KEY ("artist_id") REFERENCES "public"."artists"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_artist_claims_user_id" ON "artist_claims" USING btree ("user_id" uuid_ops);--> statement-breakpoint
+CREATE INDEX "idx_artist_claims_artist_id" ON "artist_claims" USING btree ("artist_id" uuid_ops);--> statement-breakpoint
+CREATE INDEX "idx_artist_vault_sources_artist_id" ON "artist_vault_sources" USING btree ("artist_id" uuid_ops);--> statement-breakpoint
+CREATE UNIQUE INDEX "artists_deezer_uniq" ON "artists" USING btree ("deezer" text_ops) WHERE (deezer IS NOT NULL);--> statement-breakpoint
+CREATE POLICY "mnweb_delete_artist_claims" ON "artist_claims" AS PERMISSIVE FOR DELETE TO "mnweb" USING (true);--> statement-breakpoint
+CREATE POLICY "mnweb_insert_artist_claims" ON "artist_claims" AS PERMISSIVE FOR INSERT TO "mnweb";--> statement-breakpoint
+CREATE POLICY "mnweb_select_artist_claims" ON "artist_claims" AS PERMISSIVE FOR SELECT TO "mnweb";--> statement-breakpoint
+CREATE POLICY "mnweb_update_artist_claims" ON "artist_claims" AS PERMISSIVE FOR UPDATE TO "mnweb";--> statement-breakpoint
+CREATE POLICY "mnweb_delete_artist_vault_sources" ON "artist_vault_sources" AS PERMISSIVE FOR DELETE TO "mnweb" USING (true);--> statement-breakpoint
+CREATE POLICY "mnweb_insert_artist_vault_sources" ON "artist_vault_sources" AS PERMISSIVE FOR INSERT TO "mnweb";--> statement-breakpoint
+CREATE POLICY "mnweb_select_artist_vault_sources" ON "artist_vault_sources" AS PERMISSIVE FOR SELECT TO "mnweb";--> statement-breakpoint
+CREATE POLICY "mnweb_update_artist_vault_sources" ON "artist_vault_sources" AS PERMISSIVE FOR UPDATE TO "mnweb";

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,3140 @@
+{
+  "id": "1fe38ca4-00fd-49cf-a0c4-ae578e4fc73a",
+  "prevId": "85f8e446-80a5-40ba-9f06-a3f9c0c391e5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_heartbeats": {
+      "name": "agent_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starting'"
+        },
+        "current_run": {
+          "name": "current_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_platform": {
+          "name": "batch_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_size": {
+          "name": "batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_heartbeats_updated_at": {
+          "name": "idx_agent_heartbeats_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_heartbeats_worker_id_unique": {
+          "name": "agent_heartbeats_worker_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "worker_id"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_select_agent_heartbeats": {
+          "name": "mnweb_select_agent_heartbeats",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_agent_heartbeats": {
+          "name": "mnweb_insert_agent_heartbeats",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        },
+        "mnweb_update_agent_heartbeats": {
+          "name": "mnweb_update_agent_heartbeats",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_number": {
+          "name": "run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deezer'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wall_time_secs": {
+          "name": "wall_time_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claude_time_secs": {
+          "name": "claude_time_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_time_secs": {
+          "name": "api_time_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turns": {
+          "name": "turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_size": {
+          "name": "batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "excluded": {
+          "name": "excluded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "high_confidence": {
+          "name": "high_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "medium_confidence": {
+          "name": "medium_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "conflicts": {
+          "name": "conflicts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "name_mismatches": {
+          "name": "name_mismatches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "too_ambiguous": {
+          "name": "too_ambiguous",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fail_category": {
+          "name": "fail_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fail_reason": {
+          "name": "fail_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_worker_run": {
+          "name": "idx_agent_runs_worker_run",
+          "columns": [
+            {
+              "expression": "worker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_started_at": {
+          "name": "idx_agent_runs_started_at",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_select_agent_runs": {
+          "name": "mnweb_select_agent_runs",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_agent_runs": {
+          "name": "mnweb_insert_agent_runs",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        },
+        "mnweb_update_agent_runs": {
+          "name": "mnweb_update_agent_runs",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.aiprompts": {
+      "name": "aiprompts",
+      "schema": "",
+      "columns": {
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_before_name": {
+          "name": "prompt_before_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "prompt_after_name": {
+          "name": "prompt_after_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_delete_aiprompts": {
+          "name": "mnweb_delete_aiprompts",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_aiprompts": {
+          "name": "mnweb_insert_aiprompts",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_aiprompts": {
+          "name": "mnweb_select_aiprompts",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_aiprompts": {
+          "name": "mnweb_update_aiprompts",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_claims": {
+      "name": "artist_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reference_code": {
+          "name": "reference_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        }
+      },
+      "indexes": {
+        "idx_artist_claims_user_id": {
+          "name": "idx_artist_claims_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artist_claims_artist_id": {
+          "name": "idx_artist_claims_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_claims_user_id_fkey": {
+          "name": "artist_claims_user_id_fkey",
+          "tableFrom": "artist_claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artist_claims_artist_id_fkey": {
+          "name": "artist_claims_artist_id_fkey",
+          "tableFrom": "artist_claims",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artist_claims_artist_id_key": {
+          "name": "artist_claims_artist_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "artist_id"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_delete_artist_claims": {
+          "name": "mnweb_delete_artist_claims",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_artist_claims": {
+          "name": "mnweb_insert_artist_claims",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_artist_claims": {
+          "name": "mnweb_select_artist_claims",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_artist_claims": {
+          "name": "mnweb_update_artist_claims",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_id_mappings": {
+      "name": "artist_id_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "confidence_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_artist_id_mappings_platform_artist": {
+          "name": "idx_artist_id_mappings_platform_artist",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artist_id_mappings_confidence": {
+          "name": "idx_artist_id_mappings_confidence",
+          "columns": [
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_id_mappings_artist_id_fkey": {
+          "name": "artist_id_mappings_artist_id_fkey",
+          "tableFrom": "artist_id_mappings",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artist_id_mappings_artist_platform_uniq": {
+          "name": "artist_id_mappings_artist_platform_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "artist_id",
+            "platform"
+          ]
+        },
+        "artist_id_mappings_platform_id_uniq": {
+          "name": "artist_id_mappings_platform_id_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "platform",
+            "platform_id"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_select_artist_id_mappings": {
+          "name": "mnweb_select_artist_id_mappings",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_artist_id_mappings": {
+          "name": "mnweb_insert_artist_id_mappings",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        },
+        "mnweb_update_artist_id_mappings": {
+          "name": "mnweb_update_artist_id_mappings",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_mapping_exclusions": {
+      "name": "artist_mapping_exclusions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "exclusion_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_artist_mapping_exclusions_platform": {
+          "name": "idx_artist_mapping_exclusions_platform",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_mapping_exclusions_artist_id_fkey": {
+          "name": "artist_mapping_exclusions_artist_id_fkey",
+          "tableFrom": "artist_mapping_exclusions",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artist_mapping_exclusions_artist_platform_uniq": {
+          "name": "artist_mapping_exclusions_artist_platform_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "artist_id",
+            "platform"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_select_artist_mapping_exclusions": {
+          "name": "mnweb_select_artist_mapping_exclusions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_artist_mapping_exclusions": {
+          "name": "mnweb_insert_artist_mapping_exclusions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        },
+        "mnweb_update_artist_mapping_exclusions": {
+          "name": "mnweb_update_artist_mapping_exclusions",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_vault_sources": {
+      "name": "artist_vault_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "source_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        }
+      },
+      "indexes": {
+        "idx_artist_vault_sources_artist_id": {
+          "name": "idx_artist_vault_sources_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_vault_sources_artist_id_fkey": {
+          "name": "artist_vault_sources_artist_id_fkey",
+          "tableFrom": "artist_vault_sources",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_delete_artist_vault_sources": {
+          "name": "mnweb_delete_artist_vault_sources",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_artist_vault_sources": {
+          "name": "mnweb_insert_artist_vault_sources",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_artist_vault_sources": {
+          "name": "mnweb_select_artist_vault_sources",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_artist_vault_sources": {
+          "name": "mnweb_update_artist_vault_sources",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artists": {
+      "name": "artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp": {
+          "name": "bandcamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facebook": {
+          "name": "facebook",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud": {
+          "name": "soundcloud",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patreon": {
+          "name": "patreon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram": {
+          "name": "instagram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube": {
+          "name": "youtube",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtubechannel": {
+          "name": "youtubechannel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lcname": {
+          "name": "lcname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloudID": {
+          "name": "soundcloudID",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify": {
+          "name": "spotify",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitch": {
+          "name": "twitch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imdb": {
+          "name": "imdb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz": {
+          "name": "musicbrainz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata": {
+          "name": "wikidata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mixcloud": {
+          "name": "mixcloud",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facebookID": {
+          "name": "facebookID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs": {
+          "name": "discogs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tiktok": {
+          "name": "tiktok",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tiktokID": {
+          "name": "tiktokID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jaxsta": {
+          "name": "jaxsta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "famousbirthdays": {
+          "name": "famousbirthdays",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "songexploder": {
+          "name": "songexploder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "colorsxstudios": {
+          "name": "colorsxstudios",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandsintown": {
+          "name": "bandsintown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linktree": {
+          "name": "linktree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onlyfans": {
+          "name": "onlyfans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikipedia": {
+          "name": "wikipedia",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audius": {
+          "name": "audius",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zora": {
+          "name": "zora",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catalog": {
+          "name": "catalog",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opensea": {
+          "name": "opensea",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "foundation": {
+          "name": "foundation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastfm": {
+          "name": "lastfm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundxyz": {
+          "name": "soundxyz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror": {
+          "name": "mirror",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "glassnode": {
+          "name": "glassnode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collectsNFTs": {
+          "name": "collectsNFTs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotifyusername": {
+          "name": "spotifyusername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcampfan": {
+          "name": "bandcampfan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tellie": {
+          "name": "tellie",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallets": {
+          "name": "wallets",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ens": {
+          "name": "ens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens": {
+          "name": "lens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cameo": {
+          "name": "cameo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "farcaster": {
+          "name": "farcaster",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "supercollector": {
+          "name": "supercollector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_image": {
+          "name": "custom_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webmapdata": {
+          "name": "webmapdata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_pfp": {
+          "name": "node_pfp",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deezer": {
+          "name": "deezer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artists_added_by_created_at_idx": {
+          "name": "artists_added_by_created_at_idx",
+          "columns": [
+            {
+              "expression": "added_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artists_lcname_btree_idx": {
+          "name": "artists_lcname_btree_idx",
+          "columns": [
+            {
+              "expression": "lcname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artists_lcname_trgm_gin": {
+          "name": "artists_lcname_trgm_gin",
+          "columns": [
+            {
+              "expression": "lcname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "artists_lcname_trgm_idx": {
+          "name": "artists_lcname_trgm_idx",
+          "columns": [
+            {
+              "expression": "lcname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "artists_name_trgm_idx": {
+          "name": "artists_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "artists_spotify_uniq": {
+          "name": "artists_spotify_uniq",
+          "columns": [
+            {
+              "expression": "spotify",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "(spotify IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artists_deezer_uniq": {
+          "name": "artists_deezer_uniq",
+          "columns": [
+            {
+              "expression": "deezer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deezer IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artists_added_by": {
+          "name": "idx_artists_added_by",
+          "columns": [
+            {
+              "expression": "added_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artists_name": {
+          "name": "idx_artists_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artists_name_gin": {
+          "name": "idx_artists_name_gin",
+          "columns": [
+            {
+              "expression": "to_tsvector('english'::regconfig, name)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_artists_created_at": {
+          "name": "idx_artists_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artists_added_by_fkey": {
+          "name": "artists_added_by_fkey",
+          "tableFrom": "artists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Allow webmapdata_editor to see all rows": {
+          "name": "Allow webmapdata_editor to see all rows",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "webmapdata_editor"
+          ],
+          "using": "true"
+        },
+        "Allow webmapdata_editor to update webmapdata column": {
+          "name": "Allow webmapdata_editor to update webmapdata column",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "webmapdata_editor"
+          ]
+        },
+        "mnweb_delete_artists": {
+          "name": "mnweb_delete_artists",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_insert_artists": {
+          "name": "mnweb_insert_artists",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_artists": {
+          "name": "mnweb_select_artists",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_artists": {
+          "name": "mnweb_update_artists",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_prompts": {
+      "name": "bot_prompts",
+      "schema": "",
+      "columns": {
+        "slow": {
+          "name": "slow",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderate": {
+          "name": "moderate",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "busy": {
+          "name": "busy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fun_fact": {
+          "name": "fun_fact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shaming": {
+          "name": "shaming",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_fact": {
+          "name": "track_fact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mn_bot_bot_prompts_sel": {
+          "name": "mn_bot_bot_prompts_sel",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mn_bot"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.featured": {
+      "name": "featured",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "featured_artist": {
+          "name": "featured_artist",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured_collector": {
+          "name": "featured_collector",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "featured_featured_artist_fkey": {
+          "name": "featured_featured_artist_fkey",
+          "tableFrom": "featured",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "featured_artist"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "featured_featured_collector_fkey": {
+          "name": "featured_featured_collector_fkey",
+          "tableFrom": "featured",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "featured_collector"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_delete_featured": {
+          "name": "mnweb_delete_featured",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_featured": {
+          "name": "mnweb_insert_featured",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_featured": {
+          "name": "mnweb_select_featured",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_featured": {
+          "name": "mnweb_update_featured",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funfacts": {
+      "name": "funfacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "funfacts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854776000",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "lore_drop": {
+          "name": "lore_drop",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "behind_the_scenes": {
+          "name": "behind_the_scenes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recent_activity": {
+          "name": "recent_activity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surprise_me": {
+          "name": "surprise_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.history": {
+      "name": "history",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_artist": {
+          "name": "top_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_track": {
+          "name": "top_track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mn_bot_history_ins": {
+          "name": "mn_bot_history_ins",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mn_bot"
+          ],
+          "withCheck": "true"
+        },
+        "mn_bot_history_sel": {
+          "name": "mn_bot_history_sel",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mn_bot"
+          ]
+        },
+        "mn_bot_history_upd": {
+          "name": "mn_bot_history_upd",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mn_bot"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_api_keys": {
+      "name": "mcp_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_api_keys_key_hash_unique": {
+          "name": "mcp_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_select_mcp_api_keys": {
+          "name": "mnweb_select_mcp_api_keys",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_mcp_api_keys": {
+          "name": "mnweb_insert_mcp_api_keys",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        },
+        "mnweb_update_mcp_api_keys": {
+          "name": "mnweb_update_mcp_api_keys",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_url": {
+          "name": "submitted_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_audit_log_artist_id": {
+          "name": "idx_mcp_audit_log_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_audit_log_created_at": {
+          "name": "idx_mcp_audit_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_audit_log_api_key_hash_created_at": {
+          "name": "idx_mcp_audit_log_api_key_hash_created_at",
+          "columns": [
+            {
+              "expression": "api_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_audit_log_artist_id_fkey": {
+          "name": "mcp_audit_log_artist_id_fkey",
+          "tableFrom": "mcp_audit_log",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_select_mcp_audit_log": {
+          "name": "mnweb_select_mcp_audit_log",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_mcp_audit_log": {
+          "name": "mnweb_insert_mcp_audit_log",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ugcresearch": {
+      "name": "ugcresearch",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "artist_uri": {
+          "name": "artist_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted": {
+          "name": "accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ugc_url": {
+          "name": "ugc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_username": {
+          "name": "site_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_processed": {
+          "name": "date_processed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ugcresearch_user_id": {
+          "name": "idx_ugcresearch_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ugcresearch_user_created_at_idx": {
+          "name": "ugcresearch_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamp_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamp_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ugcresearch_date_processed": {
+          "name": "idx_ugcresearch_date_processed",
+          "columns": [
+            {
+              "expression": "date_processed",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ugcresearch_artist_id_fkey": {
+          "name": "ugcresearch_artist_id_fkey",
+          "tableFrom": "ugcresearch",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ugcresearch_user_id_fkey": {
+          "name": "ugcresearch_user_id_fkey",
+          "tableFrom": "ugcresearch",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_delete_ugcresearch": {
+          "name": "mnweb_delete_ugcresearch",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_ugcresearch": {
+          "name": "mnweb_insert_ugcresearch",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_ugcresearch": {
+          "name": "mnweb_select_ugcresearch",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_ugcresearch": {
+          "name": "mnweb_update_ugcresearch",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.urlmap": {
+      "name": "urlmap",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "example": {
+          "name": "example",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_string_format": {
+          "name": "app_string_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_iframe_enabled": {
+          "name": "is_iframe_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_embed_enabled": {
+          "name": "is_embed_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "card_description": {
+          "name": "card_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_platform_name": {
+          "name": "card_platform_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_web3_site": {
+          "name": "is_web3_site",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "site_image": {
+          "name": "site_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regex": {
+          "name": "regex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'\"\"'"
+        },
+        "regex_matcher": {
+          "name": "regex_matcher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_monetized": {
+          "name": "is_monetized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "regex_options": {
+          "name": "regex_options",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#000000'"
+        },
+        "platform_type_list": {
+          "name": "platform_type_list",
+          "type": "platform_type[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"social\"}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "urlmap_siteurl_key": {
+          "name": "urlmap_siteurl_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "site_url"
+          ]
+        },
+        "urlmap_sitename_key": {
+          "name": "urlmap_sitename_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "site_name"
+          ]
+        },
+        "urlmap_example_key": {
+          "name": "urlmap_example_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "example"
+          ]
+        },
+        "urlmap_appstringformat_key": {
+          "name": "urlmap_appstringformat_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_string_format"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_delete_urlmap": {
+          "name": "mnweb_delete_urlmap",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_urlmap": {
+          "name": "mnweb_insert_urlmap",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_urlmap": {
+          "name": "mnweb_select_urlmap",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_urlmap": {
+          "name": "mnweb_update_urlmap",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_tracks": {
+      "name": "user_tracks",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracks": {
+          "name": "tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "top_track": {
+          "name": "top_track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_artist": {
+          "name": "top_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artists": {
+          "name": "artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_user_tracks_guild_id": {
+          "name": "idx_user_tracks_guild_id",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_tracks_user_id": {
+          "name": "idx_user_tracks_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mn_bot_user_tracks_ins": {
+          "name": "mn_bot_user_tracks_ins",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mn_bot"
+          ],
+          "withCheck": "true"
+        },
+        "mn_bot_user_tracks_sel": {
+          "name": "mn_bot_user_tracks_sel",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mn_bot"
+          ]
+        },
+        "mn_bot_user_tracks_upd": {
+          "name": "mn_bot_user_tracks_upd",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mn_bot"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet": {
+          "name": "wallet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privy_user_id": {
+          "name": "privy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_white_listed": {
+          "name": "is_white_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_super_admin": {
+          "name": "is_super_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "legacy_link_dismissed": {
+          "name": "legacy_link_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepted_ugc_count": {
+          "name": "accepted_ugc_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_wallet_key": {
+          "name": "users_wallet_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet"
+          ]
+        },
+        "users_privy_user_id_key": {
+          "name": "users_privy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "privy_user_id"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_delete_users": {
+          "name": "mnweb_delete_users",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_users": {
+          "name": "mnweb_insert_users",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_users": {
+          "name": "mnweb_select_users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_users": {
+          "name": "mnweb_update_users",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wrap_guilds": {
+      "name": "wrap_guilds",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "local_time": {
+          "name": "local_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted": {
+          "name": "posted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wrap_up": {
+          "name": "wrap_up",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shame": {
+          "name": "shame",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wrap_tracks": {
+          "name": "wrap_tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wrap_artists": {
+          "name": "wrap_artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mn_bot_wrap_guilds_del": {
+          "name": "mn_bot_wrap_guilds_del",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mn_bot"
+          ],
+          "using": "true"
+        },
+        "mn_bot_wrap_guilds_ins": {
+          "name": "mn_bot_wrap_guilds_ins",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mn_bot"
+          ]
+        },
+        "mn_bot_wrap_guilds_sel": {
+          "name": "mn_bot_wrap_guilds_sel",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mn_bot"
+          ]
+        },
+        "mn_bot_wrap_guilds_upd": {
+          "name": "mn_bot_wrap_guilds_upd",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mn_bot"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.confidence_level": {
+      "name": "confidence_level",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low",
+        "manual"
+      ]
+    },
+    "public.exclusion_reason": {
+      "name": "exclusion_reason",
+      "schema": "public",
+      "values": [
+        "conflict",
+        "name_mismatch",
+        "too_ambiguous"
+      ]
+    },
+    "public.platform_type": {
+      "name": "platform_type",
+      "schema": "public",
+      "values": [
+        "social",
+        "web3",
+        "listen"
+      ]
+    },
+    "public.source_status": {
+      "name": "source_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1775165400000,
       "tag": "0005_add_claim_rejected_and_reference_code",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1775445241257,
+      "tag": "0006_careless_ravenous",
+      "breakpoints": true
     }
   ]
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -36,7 +36,7 @@ const customJestConfig: Config = {
         '\\.(gif|ttf|eot|svg|png|jpg|jpeg)$': '<rootDir>/__mocks__/fileMock.js',
     },
     transformIgnorePatterns: [
-        'node_modules/(?!(jose|@radix-ui|@panva|@tanstack|@tanstack/react-query|@tanstack/query-core)/)'
+        'node_modules/(?!(jose|@radix-ui|@panva|@tanstack|@tanstack/react-query|@tanstack/query-core|p-limit|yocto-queue)/)'
     ],
     testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/.next/', '<rootDir>/e2e/', '.*\\.smoke\\.test\\.ts$'],
     moduleDirectories: ['node_modules', '<rootDir>/'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "next": "^15.5.6",
         "next-auth": "^4.24.11",
         "openai": "^5.7.0",
+        "p-limit": "^6.2.0",
         "postgres": "^3.4.4",
         "react": "^19.2.0",
         "react-day-picker": "8.10.1",
@@ -18207,6 +18208,35 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-changed-files/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jest-circus": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.2.0.tgz",
@@ -18252,6 +18282,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/jest-circus/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jest-circus/node_modules/pretty-format": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
@@ -18273,6 +18319,19 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jest-circus/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/jest-cli": {
       "version": "30.2.0",
@@ -19009,6 +19068,22 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-runner/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jest-runner/node_modules/source-map-support": {
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
@@ -19018,6 +19093,19 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-runtime": {
@@ -20753,6 +20841,37 @@
       "license": "MIT"
     },
     "node_modules/p-limit": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
@@ -20768,15 +20887,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
       "engines": {
         "node": ">=10"
       },
@@ -25396,13 +25512,12 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "next": "^15.5.6",
     "next-auth": "^4.24.11",
     "openai": "^5.7.0",
+    "p-limit": "^6.2.0",
     "postgres": "^3.4.4",
     "react": "^19.2.0",
     "react-day-picker": "8.10.1",

--- a/src/__tests__/components/ArtistLinks.test.tsx
+++ b/src/__tests__/components/ArtistLinks.test.tsx
@@ -78,6 +78,7 @@ const mockArtist: Artist = {
     webmapdata: null,
     nodePfp: null,
     customImage: null,
+    deezer: null,
 };
 
 // Session removed - authentication disabled

--- a/src/app/api/mcp/__tests__/transformers.test.ts
+++ b/src/app/api/mcp/__tests__/transformers.test.ts
@@ -74,6 +74,7 @@ function createMockArtist(overrides: Partial<Artist> = {}): Artist {
     webmapdata: null,
     nodePfp: null,
     customImage: null,
+    deezer: null,
     ...overrides,
   };
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -177,6 +177,7 @@ export const artists = pgTable("artists", {
 	customImage: text("custom_image"),
 	webmapdata: jsonb(),
 	nodePfp: jsonb("node_pfp"),
+	deezer: text(),
 }, (table) => [
 	index("artists_added_by_created_at_idx").using("btree", table.addedBy.asc().nullsLast().op("timestamptz_ops"), table.createdAt.asc().nullsLast().op("timestamptz_ops")),
 	index("artists_lcname_btree_idx").using("btree", table.lcname.asc().nullsLast().op("text_ops")),
@@ -184,6 +185,7 @@ export const artists = pgTable("artists", {
 	index("artists_lcname_trgm_idx").using("gist", table.lcname.asc().nullsLast().op("gist_trgm_ops")),
 	index("artists_name_trgm_idx").using("gist", table.name.asc().nullsLast().op("gist_trgm_ops")),
 	uniqueIndex("artists_spotify_uniq").using("btree", table.spotify.asc().nullsLast().op("text_ops")).where(sql`(spotify IS NOT NULL)`),
+	uniqueIndex("artists_deezer_uniq").using("btree", table.deezer.asc().nullsLast().op("text_ops")).where(sql`(deezer IS NOT NULL)`),
 	index("idx_artists_added_by").using("btree", table.addedBy.asc().nullsLast().op("uuid_ops")),
 	index("idx_artists_name").using("btree", table.name.asc().nullsLast().op("text_ops")),
 	index("idx_artists_name_gin").using("gin", sql`to_tsvector('english'::regconfig, name)`),

--- a/src/server/utils/__tests__/__mocks__/mockDatabase.ts
+++ b/src/server/utils/__tests__/__mocks__/mockDatabase.ts
@@ -120,6 +120,7 @@ export const createMockArtist = (id: string, name: string, spotify: string): Art
     webmapdata: null,
     nodePfp: null,
     customImage: null,
+    deezer: null,
 });
 
 // Basic tests to verify mock functionality

--- a/src/server/utils/artistLinkService.ts
+++ b/src/server/utils/artistLinkService.ts
@@ -7,13 +7,13 @@ import { eq, sql } from "drizzle-orm";
 import { artists } from "@/server/db/schema";
 import { regenerateArtistBio } from "./queries/artistBioQuery";
 
-export const BIO_RELEVANT_COLUMNS = ["spotify", "instagram", "x", "soundcloud", "youtube", "youtubechannel"];
+export const BIO_RELEVANT_COLUMNS = ["spotify", "deezer", "instagram", "x", "soundcloud", "youtube", "youtubechannel"];
 
 // Whitelist of platform columns that can be written via link helpers.
 // Derived from the artists table schema — only platform/social columns.
 // System columns (id, name, bio, etc.) are excluded by omission.
 const WRITABLE_LINK_COLUMNS = new Set([
-  "bandcamp", "facebook", "x", "soundcloud", "patreon", "instagram",
+  "bandcamp", "deezer", "facebook", "x", "soundcloud", "patreon", "instagram",
   "youtube", "youtubechannel", "spotify", "twitch", "imdb", "musicbrainz",
   "wikidata", "mixcloud", "facebookID", "discogs", "tiktok", "tiktokID",
   "jaxsta", "famousbirthdays", "songexploder", "colorsxstudios", "bandsintown",

--- a/src/server/utils/musicPlatform/__tests__/artistMusicPlatformDataProvider.test.ts
+++ b/src/server/utils/musicPlatform/__tests__/artistMusicPlatformDataProvider.test.ts
@@ -1,8 +1,18 @@
 // @ts-nocheck
 import { jest } from '@jest/globals';
+
+jest.mock('p-limit', () => ({
+    __esModule: true,
+    default: jest.fn(() => {
+        return (fn: () => Promise<unknown>) => fn();
+    }),
+}));
+
 import type { Artist } from '@/server/db/DbTypes';
 import type { MusicPlatformArtist, MusicPlatformProvider } from '../types';
-import { ArtistMusicPlatformDataProvider } from '../artistMusicPlatformDataProvider';
+
+// Dynamic import so p-limit mock takes effect before module loads
+let ArtistMusicPlatformDataProvider: typeof import('../artistMusicPlatformDataProvider').ArtistMusicPlatformDataProvider;
 
 function makeArtist(overrides: Partial<Artist> = {}): Artist {
     return {
@@ -61,9 +71,12 @@ function createMockProvider(platform: 'deezer' | 'spotify', defaultResult: Music
 describe('ArtistMusicPlatformDataProvider', () => {
     let primary: ReturnType<typeof createMockProvider>;
     let fallback: ReturnType<typeof createMockProvider>;
-    let ampdp: ArtistMusicPlatformDataProvider;
+    let ampdp: InstanceType<typeof ArtistMusicPlatformDataProvider>;
 
-    beforeEach(() => {
+    beforeEach(async () => {
+        jest.resetModules();
+        const mod = await import('../artistMusicPlatformDataProvider');
+        ArtistMusicPlatformDataProvider = mod.ArtistMusicPlatformDataProvider;
         primary = createMockProvider('deezer', mockDeezerResult);
         fallback = createMockProvider('spotify', mockSpotifyResult);
         ampdp = new ArtistMusicPlatformDataProvider(primary, fallback);

--- a/src/server/utils/musicPlatform/__tests__/artistMusicPlatformDataProvider.test.ts
+++ b/src/server/utils/musicPlatform/__tests__/artistMusicPlatformDataProvider.test.ts
@@ -124,9 +124,11 @@ describe('ArtistMusicPlatformDataProvider', () => {
             primary.getArtist.mockRejectedValueOnce(new Error('Deezer down'));
             const artist = makeArtist({ deezer: '4738512', spotify: 'spotify-123' });
 
-            // The current implementation doesn't catch provider errors in getArtist
-            // It will propagate. Test documents this behavior.
-            await expect(ampdp.getArtist(artist)).rejects.toThrow('Deezer down');
+            const result = await ampdp.getArtist(artist);
+
+            expect(result).toEqual(mockSpotifyResult);
+            expect(primary.getArtist).toHaveBeenCalledWith('4738512');
+            expect(fallback.getArtist).toHaveBeenCalledWith('spotify-123');
         });
 
         it('should treat empty string deezer ID as null', async () => {

--- a/src/server/utils/musicPlatform/__tests__/artistMusicPlatformDataProvider.test.ts
+++ b/src/server/utils/musicPlatform/__tests__/artistMusicPlatformDataProvider.test.ts
@@ -1,0 +1,230 @@
+// @ts-nocheck
+import { jest } from '@jest/globals';
+import type { Artist } from '@/server/db/DbTypes';
+import type { MusicPlatformArtist, MusicPlatformProvider } from '../types';
+import { ArtistMusicPlatformDataProvider } from '../artistMusicPlatformDataProvider';
+
+function makeArtist(overrides: Partial<Artist> = {}): Artist {
+    return {
+        id: 'uuid-123',
+        name: 'Test Artist',
+        spotify: null,
+        deezer: null,
+        lcname: 'test artist',
+        createdAt: '2024-01-01',
+        updatedAt: '2024-01-01',
+        ...overrides,
+    } as Artist;
+}
+
+const mockDeezerResult: MusicPlatformArtist = {
+    platform: 'deezer',
+    platformId: '4738512',
+    name: 'FKJ',
+    imageUrl: 'https://deezer.com/image.jpg',
+    followerCount: 1200000,
+    albumCount: 8,
+    genres: [],
+    profileUrl: 'https://www.deezer.com/artist/4738512',
+    topTrackName: 'Ylang Ylang',
+};
+
+const mockSpotifyResult: MusicPlatformArtist = {
+    platform: 'spotify',
+    platformId: 'spotify-123',
+    name: 'FKJ',
+    imageUrl: 'https://spotify.com/image.jpg',
+    followerCount: 500000,
+    albumCount: 5,
+    genres: ['electronic'],
+    profileUrl: 'https://open.spotify.com/artist/spotify-123',
+    topTrackName: 'Tadow',
+};
+
+function createMockProvider(platform: 'deezer' | 'spotify', defaultResult: MusicPlatformArtist | null): MusicPlatformProvider & {
+    getArtist: jest.Mock;
+    getArtistImage: jest.Mock;
+    getTopTrackName: jest.Mock;
+    searchArtists: jest.Mock;
+    getArtists: jest.Mock;
+} {
+    return {
+        platform,
+        getArtist: jest.fn<() => Promise<MusicPlatformArtist | null>>().mockResolvedValue(defaultResult),
+        getArtistImage: jest.fn<() => Promise<string | null>>().mockResolvedValue(defaultResult?.imageUrl ?? null),
+        getTopTrackName: jest.fn<() => Promise<string | null>>().mockResolvedValue(defaultResult?.topTrackName ?? null),
+        searchArtists: jest.fn<() => Promise<MusicPlatformArtist[]>>().mockResolvedValue(defaultResult ? [defaultResult] : []),
+        getArtists: jest.fn<() => Promise<MusicPlatformArtist[]>>().mockResolvedValue(defaultResult ? [defaultResult] : []),
+    };
+}
+
+describe('ArtistMusicPlatformDataProvider', () => {
+    let primary: ReturnType<typeof createMockProvider>;
+    let fallback: ReturnType<typeof createMockProvider>;
+    let ampdp: ArtistMusicPlatformDataProvider;
+
+    beforeEach(() => {
+        primary = createMockProvider('deezer', mockDeezerResult);
+        fallback = createMockProvider('spotify', mockSpotifyResult);
+        ampdp = new ArtistMusicPlatformDataProvider(primary, fallback);
+    });
+
+    describe('getArtist', () => {
+        it('should use primary (Deezer) when artist has both IDs', async () => {
+            const artist = makeArtist({ deezer: '4738512', spotify: 'spotify-123' });
+
+            const result = await ampdp.getArtist(artist);
+
+            expect(result).toEqual(mockDeezerResult);
+            expect(primary.getArtist).toHaveBeenCalledWith('4738512');
+            expect(fallback.getArtist).not.toHaveBeenCalled();
+        });
+
+        it('should use primary when artist has deezer only', async () => {
+            const artist = makeArtist({ deezer: '4738512' });
+
+            const result = await ampdp.getArtist(artist);
+
+            expect(result).toEqual(mockDeezerResult);
+            expect(primary.getArtist).toHaveBeenCalledWith('4738512');
+        });
+
+        it('should use fallback when artist has spotify only', async () => {
+            const artist = makeArtist({ spotify: 'spotify-123' });
+
+            const result = await ampdp.getArtist(artist);
+
+            expect(result).toEqual(mockSpotifyResult);
+            expect(primary.getArtist).not.toHaveBeenCalled();
+            expect(fallback.getArtist).toHaveBeenCalledWith('spotify-123');
+        });
+
+        it('should return null when artist has neither ID', async () => {
+            const artist = makeArtist();
+
+            const result = await ampdp.getArtist(artist);
+
+            expect(result).toBeNull();
+            expect(primary.getArtist).not.toHaveBeenCalled();
+            expect(fallback.getArtist).not.toHaveBeenCalled();
+        });
+
+        it('should fall back to Spotify when Deezer returns null', async () => {
+            primary.getArtist.mockResolvedValueOnce(null);
+            const artist = makeArtist({ deezer: '4738512', spotify: 'spotify-123' });
+
+            const result = await ampdp.getArtist(artist);
+
+            expect(result).toEqual(mockSpotifyResult);
+            expect(primary.getArtist).toHaveBeenCalledWith('4738512');
+            expect(fallback.getArtist).toHaveBeenCalledWith('spotify-123');
+        });
+
+        it('should fall back to Spotify when Deezer throws', async () => {
+            primary.getArtist.mockRejectedValueOnce(new Error('Deezer down'));
+            const artist = makeArtist({ deezer: '4738512', spotify: 'spotify-123' });
+
+            // The current implementation doesn't catch provider errors in getArtist
+            // It will propagate. Test documents this behavior.
+            await expect(ampdp.getArtist(artist)).rejects.toThrow('Deezer down');
+        });
+
+        it('should treat empty string deezer ID as null', async () => {
+            const artist = makeArtist({ deezer: '', spotify: 'spotify-123' });
+
+            const result = await ampdp.getArtist(artist);
+
+            expect(result).toEqual(mockSpotifyResult);
+            expect(primary.getArtist).not.toHaveBeenCalled();
+        });
+
+        it('should treat whitespace-only deezer ID as null', async () => {
+            const artist = makeArtist({ deezer: '  ', spotify: 'spotify-123' });
+
+            const result = await ampdp.getArtist(artist);
+
+            expect(result).toEqual(mockSpotifyResult);
+            expect(primary.getArtist).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getArtistImage', () => {
+        it('should return primary image when deezer ID exists', async () => {
+            const artist = makeArtist({ deezer: '4738512' });
+
+            const result = await ampdp.getArtistImage(artist);
+
+            expect(result).toBe('https://deezer.com/image.jpg');
+        });
+
+        it('should fall back to Spotify image when Deezer returns null', async () => {
+            primary.getArtistImage.mockResolvedValueOnce(null);
+            const artist = makeArtist({ deezer: '4738512', spotify: 'spotify-123' });
+
+            const result = await ampdp.getArtistImage(artist);
+
+            expect(result).toBe('https://spotify.com/image.jpg');
+        });
+    });
+
+    describe('searchArtists', () => {
+        it('should always delegate to primary provider', async () => {
+            const result = await ampdp.searchArtists('FKJ', 10);
+
+            expect(result).toEqual([mockDeezerResult]);
+            expect(primary.searchArtists).toHaveBeenCalledWith('FKJ', 10);
+            expect(fallback.searchArtists).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getArtistImages', () => {
+        it('should return Map keyed by artist UUID', async () => {
+            const artists = [
+                makeArtist({ id: 'uuid-1', deezer: '111' }),
+                makeArtist({ id: 'uuid-2', spotify: 'sp-222' }),
+            ];
+            primary.getArtistImage.mockResolvedValue('https://deezer.com/img1.jpg');
+            fallback.getArtistImage.mockResolvedValue('https://spotify.com/img2.jpg');
+
+            const result = await ampdp.getArtistImages(artists);
+
+            expect(result.size).toBe(2);
+            expect(result.get('uuid-1')).toBe('https://deezer.com/img1.jpg');
+            expect(result.get('uuid-2')).toBe('https://spotify.com/img2.jpg');
+        });
+
+        it('should skip artists with no platform IDs', async () => {
+            const artists = [
+                makeArtist({ id: 'uuid-1', deezer: '111' }),
+                makeArtist({ id: 'uuid-no-ids' }),
+            ];
+
+            const result = await ampdp.getArtistImages(artists);
+
+            expect(result.size).toBe(1);
+            expect(result.has('uuid-no-ids')).toBe(false);
+        });
+    });
+
+    describe('getActivePlatform', () => {
+        it('should return deezer when artist has deezer ID', () => {
+            const artist = makeArtist({ deezer: '4738512' });
+            expect(ampdp.getActivePlatform(artist)).toBe('deezer');
+        });
+
+        it('should return spotify when artist has only spotify ID', () => {
+            const artist = makeArtist({ spotify: 'spotify-123' });
+            expect(ampdp.getActivePlatform(artist)).toBe('spotify');
+        });
+
+        it('should return deezer when artist has both IDs', () => {
+            const artist = makeArtist({ deezer: '4738512', spotify: 'spotify-123' });
+            expect(ampdp.getActivePlatform(artist)).toBe('deezer');
+        });
+
+        it('should return null when artist has neither ID', () => {
+            const artist = makeArtist();
+            expect(ampdp.getActivePlatform(artist)).toBeNull();
+        });
+    });
+});

--- a/src/server/utils/musicPlatform/__tests__/deezerProvider.test.ts
+++ b/src/server/utils/musicPlatform/__tests__/deezerProvider.test.ts
@@ -194,14 +194,22 @@ describe('DeezerProvider', () => {
             expect(result[1].name).toBe('FKJ Clone');
         });
 
-        it('should return empty array on error response', async () => {
+        it('should return empty array on Deezer error response', async () => {
             const { provider, axiosGet } = await setup();
             axiosGet.mockResolvedValueOnce({
                 data: { error: { type: 'Exception', message: 'bad query' } },
             });
 
+            const result = await provider.searchArtists('test query', 10);
+            expect(result).toEqual([]);
+        });
+
+        it('should return empty array for empty query', async () => {
+            const { provider, axiosGet } = await setup();
+
             const result = await provider.searchArtists('', 10);
             expect(result).toEqual([]);
+            expect(axiosGet).not.toHaveBeenCalled();
         });
 
         it('should return empty array on network error', async () => {

--- a/src/server/utils/musicPlatform/__tests__/deezerProvider.test.ts
+++ b/src/server/utils/musicPlatform/__tests__/deezerProvider.test.ts
@@ -1,0 +1,253 @@
+// @ts-nocheck
+import { jest } from '@jest/globals';
+
+jest.mock('next/cache', () => ({
+    unstable_cache: jest.fn((fn) => fn),
+}));
+
+jest.mock('axios', () => ({
+    __esModule: true,
+    default: { get: jest.fn() },
+}));
+
+jest.mock('p-limit', () => ({
+    __esModule: true,
+    default: jest.fn((concurrency: number) => {
+        // Return a limiter that just calls the function directly
+        return (fn: () => Promise<unknown>) => fn();
+    }),
+}));
+
+const mockDeezerArtist = {
+    id: 4738512,
+    name: 'FKJ',
+    link: 'https://www.deezer.com/artist/4738512',
+    picture_medium: 'https://api.deezer.com/artist/4738512/image?size=medium',
+    picture_xl: 'https://api.deezer.com/artist/4738512/image?size=xl',
+    nb_fan: 1200000,
+    nb_album: 8,
+};
+
+const mockTopTrackResponse = {
+    data: [{ id: 123456, title: 'Ylang Ylang' }],
+};
+
+describe('DeezerProvider', () => {
+    beforeEach(() => {
+        jest.resetModules();
+    });
+
+    async function setup() {
+        const axios = (await import('axios')).default;
+        const { DeezerProvider } = await import('../deezerProvider');
+
+        const axiosGet = axios.get as jest.Mock;
+
+        return { provider: new DeezerProvider(), axiosGet };
+    }
+
+    it('should have platform set to deezer', async () => {
+        const { provider } = await setup();
+        expect(provider.platform).toBe('deezer');
+    });
+
+    describe('getArtist', () => {
+        it('should normalize Deezer response to MusicPlatformArtist', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet
+                .mockResolvedValueOnce({ data: mockDeezerArtist })
+                .mockResolvedValueOnce({ data: mockTopTrackResponse });
+
+            const result = await provider.getArtist('4738512');
+
+            expect(result).toEqual({
+                platform: 'deezer',
+                platformId: '4738512',
+                name: 'FKJ',
+                imageUrl: 'https://api.deezer.com/artist/4738512/image?size=xl',
+                followerCount: 1200000,
+                albumCount: 8,
+                genres: [],
+                profileUrl: 'https://www.deezer.com/artist/4738512',
+                topTrackName: 'Ylang Ylang',
+            });
+        });
+
+        it('should return null when Deezer returns error object', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet.mockResolvedValueOnce({
+                data: { error: { type: 'DataException', message: 'no data', code: 800 } },
+            });
+
+            const result = await provider.getArtist('99999999999');
+            expect(result).toBeNull();
+        });
+
+        it('should return null when axios throws', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet.mockRejectedValueOnce(new Error('Network error'));
+
+            const result = await provider.getArtist('4738512');
+            expect(result).toBeNull();
+        });
+
+        it('should handle artist with no picture_xl', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet
+                .mockResolvedValueOnce({ data: { ...mockDeezerArtist, picture_xl: '' } })
+                .mockResolvedValueOnce({ data: mockTopTrackResponse });
+
+            const result = await provider.getArtist('4738512');
+            expect(result?.imageUrl).toBeNull();
+        });
+
+        it('should handle top track call failure gracefully', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet
+                .mockResolvedValueOnce({ data: mockDeezerArtist })
+                .mockRejectedValueOnce(new Error('timeout'));
+
+            const result = await provider.getArtist('4738512');
+            expect(result).not.toBeNull();
+            expect(result?.topTrackName).toBeNull();
+            expect(result?.name).toBe('FKJ');
+        });
+
+        it('should handle empty top tracks data', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet
+                .mockResolvedValueOnce({ data: mockDeezerArtist })
+                .mockResolvedValueOnce({ data: { data: [] } });
+
+            const result = await provider.getArtist('4738512');
+            expect(result?.topTrackName).toBeNull();
+        });
+    });
+
+    describe('getArtistImage', () => {
+        it('should return picture_medium URL', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet.mockResolvedValueOnce({ data: mockDeezerArtist });
+
+            const result = await provider.getArtistImage('4738512');
+            expect(result).toBe('https://api.deezer.com/artist/4738512/image?size=medium');
+        });
+
+        it('should return null when Deezer returns error', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet.mockResolvedValueOnce({
+                data: { error: { type: 'DataException', message: 'no data' } },
+            });
+
+            const result = await provider.getArtistImage('99999999999');
+            expect(result).toBeNull();
+        });
+
+        it('should return null when picture_medium is empty', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet.mockResolvedValueOnce({ data: { ...mockDeezerArtist, picture_medium: '' } });
+
+            const result = await provider.getArtistImage('4738512');
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('getTopTrackName', () => {
+        it('should return track name', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet.mockResolvedValueOnce({ data: mockTopTrackResponse });
+
+            const result = await provider.getTopTrackName('4738512');
+            expect(result).toBe('Ylang Ylang');
+        });
+
+        it('should return null when no top tracks', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet.mockResolvedValueOnce({ data: { data: [] } });
+
+            const result = await provider.getTopTrackName('4738512');
+            expect(result).toBeNull();
+        });
+
+        it('should return null on network error', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet.mockRejectedValueOnce(new Error('timeout'));
+
+            const result = await provider.getTopTrackName('4738512');
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('searchArtists', () => {
+        it('should map search results to MusicPlatformArtist array', async () => {
+            const { provider, axiosGet } = await setup();
+            const secondArtist = { ...mockDeezerArtist, id: 999, name: 'FKJ Clone' };
+            axiosGet.mockResolvedValueOnce({
+                data: { data: [mockDeezerArtist, secondArtist] },
+            });
+
+            const result = await provider.searchArtists('FKJ', 10);
+
+            expect(result).toHaveLength(2);
+            expect(result[0].platformId).toBe('4738512');
+            expect(result[0].topTrackName).toBeNull();
+            expect(result[1].name).toBe('FKJ Clone');
+        });
+
+        it('should return empty array on error response', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet.mockResolvedValueOnce({
+                data: { error: { type: 'Exception', message: 'bad query' } },
+            });
+
+            const result = await provider.searchArtists('', 10);
+            expect(result).toEqual([]);
+        });
+
+        it('should return empty array on network error', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet.mockRejectedValueOnce(new Error('Network error'));
+
+            const result = await provider.searchArtists('FKJ', 10);
+            expect(result).toEqual([]);
+        });
+
+        it('should encode query parameter', async () => {
+            const { provider, axiosGet } = await setup();
+            axiosGet.mockResolvedValueOnce({ data: { data: [] } });
+
+            await provider.searchArtists('FKJ & Friends', 5);
+
+            expect(axiosGet).toHaveBeenCalledWith(
+                expect.stringContaining('q=FKJ%20%26%20Friends&limit=5'),
+            );
+        });
+    });
+
+    describe('getArtists', () => {
+        it('should return empty array for empty input', async () => {
+            const { provider, axiosGet } = await setup();
+
+            const result = await provider.getArtists([]);
+
+            expect(result).toEqual([]);
+            expect(axiosGet).not.toHaveBeenCalled();
+        });
+
+        it('should fetch multiple artists and filter nulls', async () => {
+            const { provider, axiosGet } = await setup();
+            // First artist: success (2 calls: artist + top track)
+            axiosGet
+                .mockResolvedValueOnce({ data: mockDeezerArtist })
+                .mockResolvedValueOnce({ data: mockTopTrackResponse });
+            // Second artist: error (1 call: artist returns error)
+            axiosGet
+                .mockResolvedValueOnce({ data: { error: { type: 'DataException', message: 'no data' } } });
+
+            const result = await provider.getArtists(['4738512', '99999999999']);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].platformId).toBe('4738512');
+        });
+    });
+});

--- a/src/server/utils/musicPlatform/__tests__/deezerProvider.test.ts
+++ b/src/server/utils/musicPlatform/__tests__/deezerProvider.test.ts
@@ -220,6 +220,7 @@ describe('DeezerProvider', () => {
 
             expect(axiosGet).toHaveBeenCalledWith(
                 expect.stringContaining('q=FKJ%20%26%20Friends&limit=5'),
+                expect.objectContaining({ timeout: 5000 }),
             );
         });
     });

--- a/src/server/utils/musicPlatform/artistMusicPlatformDataProvider.ts
+++ b/src/server/utils/musicPlatform/artistMusicPlatformDataProvider.ts
@@ -7,64 +7,52 @@ export class ArtistMusicPlatformDataProvider {
         private fallbackProvider: MusicPlatformProvider,
     ) {}
 
-    private getPlatformId(artist: Artist): { provider: MusicPlatformProvider; id: string } | null {
-        const deezer = artist.deezer?.trim() || null;
-        const spotify = artist.spotify?.trim() || null;
+    private resolveIds(artist: Artist): { primaryId: string | null; fallbackId: string | null } {
+        return {
+            primaryId: artist.deezer?.trim() || null,
+            fallbackId: artist.spotify?.trim() || null,
+        };
+    }
 
-        if (deezer) return { provider: this.primaryProvider, id: deezer };
-        if (spotify) return { provider: this.fallbackProvider, id: spotify };
+    // Try primary, fall back to fallback on null/error. Providers should return null
+    // on failure, but we catch throws defensively so fallback always triggers.
+    private async withFallback<T>(
+        primaryId: string | null,
+        fallbackId: string | null,
+        fn: (provider: MusicPlatformProvider, id: string) => Promise<T | null>,
+    ): Promise<T | null> {
+        if (primaryId) {
+            try {
+                const result = await fn(this.primaryProvider, primaryId);
+                if (result != null) return result;
+            } catch (error) {
+                console.error('[AMPDP] Primary provider error, trying fallback:', error);
+            }
+            if (fallbackId) return fn(this.fallbackProvider, fallbackId);
+            return null;
+        }
+
+        if (fallbackId) return fn(this.fallbackProvider, fallbackId);
         return null;
     }
 
     async getArtist(artist: Artist): Promise<MusicPlatformArtist | null> {
-        const deezer = artist.deezer?.trim() || null;
-        const spotify = artist.spotify?.trim() || null;
-
-        // Try primary (Deezer) first
-        if (deezer) {
-            const result = await this.primaryProvider.getArtist(deezer);
-            if (result) return result;
-            // Deezer failed, fall back to Spotify if available
-            if (spotify) return this.fallbackProvider.getArtist(spotify);
-            return null;
-        }
-
-        // No Deezer ID, try Spotify
-        if (spotify) return this.fallbackProvider.getArtist(spotify);
-
-        return null;
+        const { primaryId, fallbackId } = this.resolveIds(artist);
+        return this.withFallback(primaryId, fallbackId, (p, id) => p.getArtist(id));
     }
 
     async getArtistImage(artist: Artist): Promise<string | null> {
-        const deezer = artist.deezer?.trim() || null;
-        const spotify = artist.spotify?.trim() || null;
-
-        if (deezer) {
-            const result = await this.primaryProvider.getArtistImage(deezer);
-            if (result) return result;
-            if (spotify) return this.fallbackProvider.getArtistImage(spotify);
-            return null;
-        }
-
-        if (spotify) return this.fallbackProvider.getArtistImage(spotify);
-        return null;
+        const { primaryId, fallbackId } = this.resolveIds(artist);
+        return this.withFallback(primaryId, fallbackId, (p, id) => p.getArtistImage(id));
     }
 
     async getTopTrackName(artist: Artist): Promise<string | null> {
-        const deezer = artist.deezer?.trim() || null;
-        const spotify = artist.spotify?.trim() || null;
-
-        if (deezer) {
-            const result = await this.primaryProvider.getTopTrackName(deezer);
-            if (result) return result;
-            if (spotify) return this.fallbackProvider.getTopTrackName(spotify);
-            return null;
-        }
-
-        if (spotify) return this.fallbackProvider.getTopTrackName(spotify);
-        return null;
+        const { primaryId, fallbackId } = this.resolveIds(artist);
+        return this.withFallback(primaryId, fallbackId, (p, id) => p.getTopTrackName(id));
     }
 
+    // Search always uses primary provider (Deezer). No fallback: we want consistent
+    // search source, and Spotify search will be removed in Phase 5.
     async searchArtists(query: string, limit: number): Promise<MusicPlatformArtist[]> {
         return this.primaryProvider.searchArtists(query, limit);
     }
@@ -82,7 +70,9 @@ export class ArtistMusicPlatformDataProvider {
     }
 
     getActivePlatform(artist: Artist): 'deezer' | 'spotify' | null {
-        const resolved = this.getPlatformId(artist);
-        return resolved?.provider.platform ?? null;
+        const { primaryId, fallbackId } = this.resolveIds(artist);
+        if (primaryId) return this.primaryProvider.platform;
+        if (fallbackId) return this.fallbackProvider.platform;
+        return null;
     }
 }

--- a/src/server/utils/musicPlatform/artistMusicPlatformDataProvider.ts
+++ b/src/server/utils/musicPlatform/artistMusicPlatformDataProvider.ts
@@ -1,0 +1,88 @@
+import type { Artist } from '@/server/db/DbTypes';
+import type { MusicPlatformArtist, MusicPlatformProvider } from './types';
+
+export class ArtistMusicPlatformDataProvider {
+    constructor(
+        private primaryProvider: MusicPlatformProvider,
+        private fallbackProvider: MusicPlatformProvider,
+    ) {}
+
+    private getPlatformId(artist: Artist): { provider: MusicPlatformProvider; id: string } | null {
+        const deezer = artist.deezer?.trim() || null;
+        const spotify = artist.spotify?.trim() || null;
+
+        if (deezer) return { provider: this.primaryProvider, id: deezer };
+        if (spotify) return { provider: this.fallbackProvider, id: spotify };
+        return null;
+    }
+
+    async getArtist(artist: Artist): Promise<MusicPlatformArtist | null> {
+        const deezer = artist.deezer?.trim() || null;
+        const spotify = artist.spotify?.trim() || null;
+
+        // Try primary (Deezer) first
+        if (deezer) {
+            const result = await this.primaryProvider.getArtist(deezer);
+            if (result) return result;
+            // Deezer failed, fall back to Spotify if available
+            if (spotify) return this.fallbackProvider.getArtist(spotify);
+            return null;
+        }
+
+        // No Deezer ID, try Spotify
+        if (spotify) return this.fallbackProvider.getArtist(spotify);
+
+        return null;
+    }
+
+    async getArtistImage(artist: Artist): Promise<string | null> {
+        const deezer = artist.deezer?.trim() || null;
+        const spotify = artist.spotify?.trim() || null;
+
+        if (deezer) {
+            const result = await this.primaryProvider.getArtistImage(deezer);
+            if (result) return result;
+            if (spotify) return this.fallbackProvider.getArtistImage(spotify);
+            return null;
+        }
+
+        if (spotify) return this.fallbackProvider.getArtistImage(spotify);
+        return null;
+    }
+
+    async getTopTrackName(artist: Artist): Promise<string | null> {
+        const deezer = artist.deezer?.trim() || null;
+        const spotify = artist.spotify?.trim() || null;
+
+        if (deezer) {
+            const result = await this.primaryProvider.getTopTrackName(deezer);
+            if (result) return result;
+            if (spotify) return this.fallbackProvider.getTopTrackName(spotify);
+            return null;
+        }
+
+        if (spotify) return this.fallbackProvider.getTopTrackName(spotify);
+        return null;
+    }
+
+    async searchArtists(query: string, limit: number): Promise<MusicPlatformArtist[]> {
+        return this.primaryProvider.searchArtists(query, limit);
+    }
+
+    async getArtistImages(artists: Artist[]): Promise<Map<string, string>> {
+        const imageMap = new Map<string, string>();
+
+        const tasks = artists.map(async (artist) => {
+            const image = await this.getArtistImage(artist);
+            if (image) imageMap.set(artist.id, image);
+        });
+
+        await Promise.all(tasks);
+        return imageMap;
+    }
+
+    getActivePlatform(artist: Artist): 'deezer' | 'spotify' | null {
+        const resolved = this.getPlatformId(artist);
+        return resolved?.provider.platform ?? null;
+    }
+}

--- a/src/server/utils/musicPlatform/artistMusicPlatformDataProvider.ts
+++ b/src/server/utils/musicPlatform/artistMusicPlatformDataProvider.ts
@@ -1,5 +1,6 @@
 import type { Artist } from '@/server/db/DbTypes';
 import type { MusicPlatformArtist, MusicPlatformProvider } from './types';
+import pLimit from 'p-limit';
 
 export class ArtistMusicPlatformDataProvider {
     constructor(
@@ -14,8 +15,8 @@ export class ArtistMusicPlatformDataProvider {
         };
     }
 
-    // Try primary, fall back to fallback on null/error. Providers should return null
-    // on failure, but we catch throws defensively so fallback always triggers.
+    // Try primary, fall back to fallback on null/error. Both calls are wrapped
+    // so callers never need their own try/catch.
     private async withFallback<T>(
         primaryId: string | null,
         fallbackId: string | null,
@@ -28,11 +29,25 @@ export class ArtistMusicPlatformDataProvider {
             } catch (error) {
                 console.error('[AMPDP] Primary provider error, trying fallback:', error);
             }
-            if (fallbackId) return fn(this.fallbackProvider, fallbackId);
+            if (fallbackId) {
+                try {
+                    return await fn(this.fallbackProvider, fallbackId);
+                } catch (error) {
+                    console.error('[AMPDP] Fallback provider error:', error);
+                    return null;
+                }
+            }
             return null;
         }
 
-        if (fallbackId) return fn(this.fallbackProvider, fallbackId);
+        if (fallbackId) {
+            try {
+                return await fn(this.fallbackProvider, fallbackId);
+            } catch (error) {
+                console.error('[AMPDP] Fallback provider error:', error);
+                return null;
+            }
+        }
         return null;
     }
 
@@ -59,11 +74,12 @@ export class ArtistMusicPlatformDataProvider {
 
     async getArtistImages(artists: Artist[]): Promise<Map<string, string>> {
         const imageMap = new Map<string, string>();
+        const limit = pLimit(10);
 
-        const tasks = artists.map(async (artist) => {
+        const tasks = artists.map((artist) => limit(async () => {
             const image = await this.getArtistImage(artist);
             if (image) imageMap.set(artist.id, image);
-        });
+        }));
 
         await Promise.all(tasks);
         return imageMap;

--- a/src/server/utils/musicPlatform/deezerProvider.ts
+++ b/src/server/utils/musicPlatform/deezerProvider.ts
@@ -6,6 +6,7 @@ import pLimit from 'p-limit';
 const DEEZER_API = 'https://api.deezer.com';
 const CACHE_TTL = 86400; // 24 hours
 const BATCH_CONCURRENCY = 10;
+const REQUEST_TIMEOUT = 5000; // 5s per request
 
 interface DeezerArtistResponse {
     id: number;
@@ -40,7 +41,7 @@ function mapDeezerArtist(
         platform: 'deezer',
         platformId: String(artist.id),
         name: artist.name,
-        imageUrl: artist.picture_xl || null,
+        imageUrl: artist.picture_xl || null, // XL (1000x1000) for hero/OG contexts
         followerCount: artist.nb_fan,
         albumCount: artist.nb_album,
         genres: [], // Deezer only has genres on albums, not artists
@@ -52,7 +53,7 @@ function mapDeezerArtist(
 const fetchDeezerArtist = unstable_cache(
     async (id: string): Promise<DeezerArtistResponse | null> => {
         try {
-            const { data } = await axios.get<DeezerArtistResponse>(`${DEEZER_API}/artist/${id}`);
+            const { data } = await axios.get<DeezerArtistResponse>(`${DEEZER_API}/artist/${id}`, { timeout: REQUEST_TIMEOUT });
             if (isDeezerError(data)) {
                 console.error(`[DeezerProvider] Artist ${id} error:`, data.error);
                 return null;
@@ -70,7 +71,7 @@ const fetchDeezerArtist = unstable_cache(
 const fetchDeezerTopTrack = unstable_cache(
     async (id: string): Promise<string | null> => {
         try {
-            const { data } = await axios.get<DeezerTopTrackResponse>(`${DEEZER_API}/artist/${id}/top?limit=1`);
+            const { data } = await axios.get<DeezerTopTrackResponse>(`${DEEZER_API}/artist/${id}/top?limit=1`, { timeout: REQUEST_TIMEOUT });
             if (isDeezerError(data)) return null;
             return data.data?.[0]?.title ?? null;
         } catch {
@@ -96,7 +97,7 @@ export class DeezerProvider implements MusicPlatformProvider {
     async getArtistImage(id: string): Promise<string | null> {
         const artist = await fetchDeezerArtist(id);
         if (!artist) return null;
-        return artist.picture_medium || null;
+        return artist.picture_medium || null; // Medium (250x250) for thumbnails
     }
 
     async getTopTrackName(id: string): Promise<string | null> {
@@ -107,6 +108,7 @@ export class DeezerProvider implements MusicPlatformProvider {
         try {
             const { data } = await axios.get<DeezerSearchResponse>(
                 `${DEEZER_API}/search/artist?q=${encodeURIComponent(query)}&limit=${limit}`,
+                { timeout: REQUEST_TIMEOUT },
             );
             if (isDeezerError(data)) {
                 console.error('[DeezerProvider] Search error:', data.error);

--- a/src/server/utils/musicPlatform/deezerProvider.ts
+++ b/src/server/utils/musicPlatform/deezerProvider.ts
@@ -1,0 +1,133 @@
+import type { MusicPlatformArtist, MusicPlatformProvider } from './types';
+import axios from 'axios';
+import { unstable_cache } from 'next/cache';
+import pLimit from 'p-limit';
+
+const DEEZER_API = 'https://api.deezer.com';
+const CACHE_TTL = 86400; // 24 hours
+const BATCH_CONCURRENCY = 10;
+
+interface DeezerArtistResponse {
+    id: number;
+    name: string;
+    link: string;
+    picture_medium: string;
+    picture_xl: string;
+    nb_fan: number;
+    nb_album: number;
+    error?: { type: string; message: string; code: number };
+}
+
+interface DeezerTopTrackResponse {
+    data: { id: number; title: string }[];
+    error?: { type: string; message: string; code: number };
+}
+
+interface DeezerSearchResponse {
+    data: DeezerArtistResponse[];
+    error?: { type: string; message: string; code: number };
+}
+
+function isDeezerError(data: unknown): data is { error: { type: string; message: string } } {
+    return typeof data === 'object' && data !== null && 'error' in data && typeof (data as Record<string, unknown>).error === 'object';
+}
+
+function mapDeezerArtist(
+    artist: DeezerArtistResponse,
+    topTrackName: string | null,
+): MusicPlatformArtist {
+    return {
+        platform: 'deezer',
+        platformId: String(artist.id),
+        name: artist.name,
+        imageUrl: artist.picture_xl || null,
+        followerCount: artist.nb_fan,
+        albumCount: artist.nb_album,
+        genres: [], // Deezer only has genres on albums, not artists
+        profileUrl: artist.link,
+        topTrackName,
+    };
+}
+
+const fetchDeezerArtist = unstable_cache(
+    async (id: string): Promise<DeezerArtistResponse | null> => {
+        try {
+            const { data } = await axios.get<DeezerArtistResponse>(`${DEEZER_API}/artist/${id}`);
+            if (isDeezerError(data)) {
+                console.error(`[DeezerProvider] Artist ${id} error:`, data.error);
+                return null;
+            }
+            return data;
+        } catch (error) {
+            console.error(`[DeezerProvider] Artist ${id} network error:`, error);
+            return null;
+        }
+    },
+    ['deezer-artist'],
+    { revalidate: CACHE_TTL },
+);
+
+const fetchDeezerTopTrack = unstable_cache(
+    async (id: string): Promise<string | null> => {
+        try {
+            const { data } = await axios.get<DeezerTopTrackResponse>(`${DEEZER_API}/artist/${id}/top?limit=1`);
+            if (isDeezerError(data)) return null;
+            return data.data?.[0]?.title ?? null;
+        } catch {
+            return null;
+        }
+    },
+    ['deezer-top-track'],
+    { revalidate: CACHE_TTL },
+);
+
+export class DeezerProvider implements MusicPlatformProvider {
+    readonly platform = 'deezer' as const;
+
+    async getArtist(id: string): Promise<MusicPlatformArtist | null> {
+        const [artist, topTrackName] = await Promise.all([
+            fetchDeezerArtist(id),
+            fetchDeezerTopTrack(id),
+        ]);
+        if (!artist) return null;
+        return mapDeezerArtist(artist, topTrackName);
+    }
+
+    async getArtistImage(id: string): Promise<string | null> {
+        const artist = await fetchDeezerArtist(id);
+        if (!artist) return null;
+        return artist.picture_medium || null;
+    }
+
+    async getTopTrackName(id: string): Promise<string | null> {
+        return fetchDeezerTopTrack(id);
+    }
+
+    async searchArtists(query: string, limit: number): Promise<MusicPlatformArtist[]> {
+        try {
+            const { data } = await axios.get<DeezerSearchResponse>(
+                `${DEEZER_API}/search/artist?q=${encodeURIComponent(query)}&limit=${limit}`,
+            );
+            if (isDeezerError(data)) {
+                console.error('[DeezerProvider] Search error:', data.error);
+                return [];
+            }
+            return (data.data ?? []).map((artist) => mapDeezerArtist(artist, null));
+        } catch (error) {
+            console.error('[DeezerProvider] Search network error:', error);
+            return [];
+        }
+    }
+
+    async getArtists(ids: string[]): Promise<MusicPlatformArtist[]> {
+        if (ids.length === 0) return [];
+
+        const limit = pLimit(BATCH_CONCURRENCY);
+        const results = await Promise.all(
+            ids.map((id) => limit(() => this.getArtist(id))),
+        );
+        return results.filter((a): a is MusicPlatformArtist => a != null);
+    }
+}
+
+export const deezerProvider = new DeezerProvider();

--- a/src/server/utils/musicPlatform/deezerProvider.ts
+++ b/src/server/utils/musicPlatform/deezerProvider.ts
@@ -50,8 +50,13 @@ function mapDeezerArtist(
     };
 }
 
+function isValidDeezerId(id: string): boolean {
+    return /^\d+$/.test(id);
+}
+
 const fetchDeezerArtist = unstable_cache(
     async (id: string): Promise<DeezerArtistResponse | null> => {
+        if (!isValidDeezerId(id)) return null;
         try {
             const { data } = await axios.get<DeezerArtistResponse>(`${DEEZER_API}/artist/${id}`, { timeout: REQUEST_TIMEOUT });
             if (isDeezerError(data)) {
@@ -70,6 +75,7 @@ const fetchDeezerArtist = unstable_cache(
 
 const fetchDeezerTopTrack = unstable_cache(
     async (id: string): Promise<string | null> => {
+        if (!isValidDeezerId(id)) return null;
         try {
             const { data } = await axios.get<DeezerTopTrackResponse>(`${DEEZER_API}/artist/${id}/top?limit=1`, { timeout: REQUEST_TIMEOUT });
             if (isDeezerError(data)) return null;
@@ -105,6 +111,7 @@ export class DeezerProvider implements MusicPlatformProvider {
     }
 
     async searchArtists(query: string, limit: number): Promise<MusicPlatformArtist[]> {
+        if (!query?.trim()) return [];
         try {
             const { data } = await axios.get<DeezerSearchResponse>(
                 `${DEEZER_API}/search/artist?q=${encodeURIComponent(query)}&limit=${limit}`,

--- a/src/server/utils/musicPlatform/index.ts
+++ b/src/server/utils/musicPlatform/index.ts
@@ -1,13 +1,13 @@
-import { DeezerProvider } from './deezerProvider';
-import { SpotifyProvider } from './spotifyProvider';
-import { ArtistMusicPlatformDataProvider } from './artistMusicPlatformDataProvider';
-
 export type { MusicPlatform, MusicPlatformArtist, MusicPlatformProvider } from './types';
 export { SpotifyProvider, spotifyProvider } from './spotifyProvider';
 export { DeezerProvider, deezerProvider } from './deezerProvider';
 export { ArtistMusicPlatformDataProvider } from './artistMusicPlatformDataProvider';
 
+import { deezerProvider } from './deezerProvider';
+import { spotifyProvider } from './spotifyProvider';
+import { ArtistMusicPlatformDataProvider } from './artistMusicPlatformDataProvider';
+
 export const musicPlatformData = new ArtistMusicPlatformDataProvider(
-    new DeezerProvider(),
-    new SpotifyProvider(),
+    deezerProvider,
+    spotifyProvider,
 );

--- a/src/server/utils/musicPlatform/index.ts
+++ b/src/server/utils/musicPlatform/index.ts
@@ -1,2 +1,13 @@
 export type { MusicPlatform, MusicPlatformArtist, MusicPlatformProvider } from './types';
 export { SpotifyProvider, spotifyProvider } from './spotifyProvider';
+export { DeezerProvider, deezerProvider } from './deezerProvider';
+export { ArtistMusicPlatformDataProvider } from './artistMusicPlatformDataProvider';
+
+import { DeezerProvider } from './deezerProvider';
+import { SpotifyProvider } from './spotifyProvider';
+import { ArtistMusicPlatformDataProvider } from './artistMusicPlatformDataProvider';
+
+export const musicPlatformData = new ArtistMusicPlatformDataProvider(
+    new DeezerProvider(),
+    new SpotifyProvider(),
+);

--- a/src/server/utils/musicPlatform/index.ts
+++ b/src/server/utils/musicPlatform/index.ts
@@ -1,11 +1,11 @@
+import { DeezerProvider } from './deezerProvider';
+import { SpotifyProvider } from './spotifyProvider';
+import { ArtistMusicPlatformDataProvider } from './artistMusicPlatformDataProvider';
+
 export type { MusicPlatform, MusicPlatformArtist, MusicPlatformProvider } from './types';
 export { SpotifyProvider, spotifyProvider } from './spotifyProvider';
 export { DeezerProvider, deezerProvider } from './deezerProvider';
 export { ArtistMusicPlatformDataProvider } from './artistMusicPlatformDataProvider';
-
-import { DeezerProvider } from './deezerProvider';
-import { SpotifyProvider } from './spotifyProvider';
-import { ArtistMusicPlatformDataProvider } from './artistMusicPlatformDataProvider';
 
 export const musicPlatformData = new ArtistMusicPlatformDataProvider(
     new DeezerProvider(),


### PR DESCRIPTION
## Summary
- Phase 2 of the [Deezer cutover plan](docs/deezer-cutover-plan.md): adds provider abstraction layer with Deezer primary + Spotify fallback, without changing any consumer code
- `DeezerProvider`: no auth, axios + `unstable_cache` (24h), `p-limit(10)` for batch, error guard on every response
- `ArtistMusicPlatformDataProvider`: routes to correct provider based on artist's `deezer`/`spotify` IDs, with empty-string normalization and fallback on failure
- Adds `deezer` text column + partial unique index to artists schema
- Adds `"deezer"` to `WRITABLE_LINK_COLUMNS` and `BIO_RELEVANT_COLUMNS` in artistLinkService
- 36 new unit tests covering happy path, Deezer error responses (HTTP 200 + error object), fallback routing, and edge cases

## Pre-merge checklist
- [x] DB migration applied (column + index + data population + urlmap row)
- [x] Spot-check of 50 random medium-confidence Deezer IDs: 4% error rate, acceptable per plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (996 tests, 0 failures)
- [x] `npm run build` passes

## Test plan
- [ ] Verify `musicPlatformData.getArtist(artist)` returns Deezer data for artists with deezer IDs
- [ ] Verify fallback to Spotify for artists without deezer IDs
- [ ] Verify `set_artist_link` MCP tool accepts Deezer URLs via new urlmap regex
- [ ] Phase 3 (consumer migration) can proceed on top of this

🤖 Generated with [Claude Code](https://claude.com/claude-code)