### PR TITLE
feat: Phase 4 — search + add-artist migration to Deezer-primary

### DIFF
--- a/src/__tests__/api/searchArtists.test.ts
+++ b/src/__tests__/api/searchArtists.test.ts
@@ -1,11 +1,16 @@
-import { POST } from '@/app/api/searchArtists/route';
-import { searchForArtistByName, getAllSpotifyIds } from '@/server/utils/queries/artistQueries';
-import { getSpotifyHeaders } from '@/server/utils/queries/externalApiQueries';
-import axios from 'axios';
+// @ts-nocheck
+import { jest } from '@jest/globals';
 
-jest.mock('@/server/utils/queries/artistQueries');
-jest.mock('@/server/utils/queries/externalApiQueries');
-jest.mock('axios');
+jest.mock('@/server/utils/queries/artistQueries', () => ({
+  searchForArtistByName: jest.fn(),
+}));
+
+jest.mock('@/server/utils/musicPlatform', () => ({
+  musicPlatformData: {
+    searchArtists: jest.fn(),
+    getArtistImages: jest.fn(),
+  },
+}));
 
 // Polyfill Response.json for the test environment
 if (!(Response as any).json) {
@@ -21,14 +26,25 @@ if (!(Response as any).json) {
 
 const createTestRequest = (url: string, init?: RequestInit) => new Request(url, init);
 
-const mockedAxios = axios as jest.Mocked<typeof axios>;
-
 describe('searchArtists API route', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetModules();
   });
 
+  async function setup() {
+    const { searchForArtistByName } = await import('@/server/utils/queries/artistQueries');
+    const { musicPlatformData } = await import('@/server/utils/musicPlatform');
+    const { POST } = await import('@/app/api/searchArtists/route');
+    return {
+      POST,
+      mockSearchDB: searchForArtistByName as jest.Mock,
+      mockSearchExternal: musicPlatformData.searchArtists as jest.Mock,
+      mockGetImages: musicPlatformData.getArtistImages as jest.Mock,
+    };
+  }
+
   it('returns 400 for invalid query', async () => {
+    const { POST } = await setup();
     const response = await POST(
       createTestRequest('http://localhost/api/searchArtists', {
         method: 'POST',
@@ -42,29 +58,20 @@ describe('searchArtists API route', () => {
     expect(data.error).toBe('Invalid query parameter');
   });
 
-  it('combines and sorts search results', async () => {
-    (searchForArtistByName as jest.Mock).mockResolvedValue([
-      { id: '1', name: 'Alpha', spotify: 'spotify1' },
-      { id: '2', name: 'Beta', spotify: null },
+  it('combines DB and external results, deduplicates, and sorts', async () => {
+    const { POST, mockSearchDB, mockSearchExternal, mockGetImages } = await setup();
+
+    mockSearchDB.mockResolvedValue([
+      { id: '1', name: 'Alpha', spotify: 'spotify1', deezer: 'dz1' },
+      { id: '2', name: 'Beta', spotify: null, deezer: null },
     ]);
 
-    (getSpotifyHeaders as jest.Mock).mockResolvedValue({ headers: { Authorization: 'Bearer token' } });
-    (getAllSpotifyIds as jest.Mock).mockResolvedValue(['spotify1']);
+    mockSearchExternal.mockResolvedValue([
+      { platformId: 'dz1', platform: 'deezer', name: 'Alpha', imageUrl: 'https://cdn.deezer.com/1.jpg', profileUrl: 'https://deezer.com/artist/dz1', followerCount: 1000, albumCount: 5, genres: [], topTrackName: null },
+      { platformId: 'dz-new', platform: 'deezer', name: 'AlphaBeta', imageUrl: 'https://cdn.deezer.com/2.jpg', profileUrl: 'https://deezer.com/artist/dz-new', followerCount: 500, albumCount: 3, genres: [], topTrackName: null },
+    ]);
 
-    // Mock order must match API call order:
-    // 1. Spotify search API call first
-    // 2. Individual artist data calls second
-    mockedAxios.get.mockResolvedValueOnce({
-      data: {
-        artists: {
-          items: [
-            { id: 'spotify1', name: 'Alpha', images: [{ url: 'img1', height: 1, width: 1 }] },
-            { id: 'new1', name: 'AlphaBeta', images: [{ url: 'img2', height: 1, width: 1 }] },
-          ],
-        },
-      },
-    });
-    mockedAxios.get.mockResolvedValueOnce({ data: { images: [{ url: 'img1', height: 1, width: 1 }] } });
+    mockGetImages.mockResolvedValue(new Map([['1', 'https://cdn.deezer.com/1.jpg']]));
 
     const response = await POST(
       createTestRequest('http://localhost/api/searchArtists', {
@@ -77,9 +84,14 @@ describe('searchArtists API route', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
 
+    // Alpha (DB, exact match), AlphaBeta (external, deduped dz1 removed), Beta (DB, no match)
     expect(body.results).toHaveLength(3);
     expect(body.results[0].name).toBe('Alpha');
+    expect(body.results[0].isExternalOnly).toBe(false);
+    expect(body.results[0].imageUrl).toBe('https://cdn.deezer.com/1.jpg');
     expect(body.results[1].name).toBe('AlphaBeta');
+    expect(body.results[1].isExternalOnly).toBe(true);
+    expect(body.results[1].platformId).toBe('dz-new');
     expect(body.results[2].name).toBe('Beta');
   });
 });

--- a/src/__tests__/components/SearchBarAddArtist.test.tsx
+++ b/src/__tests__/components/SearchBarAddArtist.test.tsx
@@ -45,25 +45,30 @@ function mockSearchResults(results: object[]) {
     });
 }
 
-const spotifyOnlyResult = {
+const externalResult = {
     name: 'New Artist',
-    spotify: '6abc123',
-    isSpotifyOnly: true,
-    images: [{ url: 'https://img.spotify.com/test.jpg', height: 64, width: 64 }],
+    platformId: 'dz123',
+    platform: 'deezer',
+    isExternalOnly: true,
+    imageUrl: 'https://cdn-images.dzcdn.net/test.jpg',
+    profileUrl: 'https://www.deezer.com/artist/dz123',
 };
 
-const spotifyOnlyResult2 = {
+const externalResult2 = {
     name: 'Other Artist',
-    spotify: '6def456',
-    isSpotifyOnly: true,
-    images: [{ url: 'https://img.spotify.com/test2.jpg', height: 64, width: 64 }],
+    platformId: 'dz456',
+    platform: 'deezer',
+    isExternalOnly: true,
+    imageUrl: 'https://cdn-images.dzcdn.net/test2.jpg',
+    profileUrl: 'https://www.deezer.com/artist/dz456',
 };
 
 const dbResult = {
     id: '42',
     name: 'Existing Artist',
     spotify: '6xyz789',
-    isSpotifyOnly: false,
+    isExternalOnly: false,
+    imageUrl: 'https://cdn-images.dzcdn.net/existing.jpg',
     bandcamp: 'existingartist',
 };
 
@@ -96,38 +101,38 @@ describe('SearchBar Add Artist Flow', () => {
         });
     }
 
-    it('shows "Add to MusicNerd | View on Spotify" for Spotify-only results', async () => {
-        await renderAndSearch([spotifyOnlyResult]);
+    it('shows "Add to MusicNerd | View on Deezer" for external results', async () => {
+        await renderAndSearch([externalResult]);
 
         expect(screen.getByText('Add to MusicNerd')).toBeInTheDocument();
-        expect(screen.getByText('View on Spotify')).toBeInTheDocument();
+        expect(screen.getByText('View on Deezer')).toBeInTheDocument();
         expect(screen.getByText('|')).toBeInTheDocument();
     });
 
-    it('renders "View on Spotify" as an <a> tag with correct href', async () => {
-        await renderAndSearch([spotifyOnlyResult]);
+    it('renders "View on Deezer" as an <a> tag with correct href', async () => {
+        await renderAndSearch([externalResult]);
 
-        const link = screen.getByText('View on Spotify').closest('a');
-        expect(link).toHaveAttribute('href', 'https://open.spotify.com/artist/6abc123');
+        const link = screen.getByText('View on Deezer').closest('a');
+        expect(link).toHaveAttribute('href', 'https://www.deezer.com/artist/dz123');
         expect(link).toHaveAttribute('target', '_blank');
         expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
-    it('triggers login and stores pending ID + timestamp when unauthenticated user clicks a Spotify-only result', async () => {
-        // The SearchBar code clicks #login-btn to trigger Privy login
+    it('triggers login and stores pending ID + platform + timestamp when unauthenticated user clicks external result', async () => {
         const loginBtn = document.createElement('button');
         loginBtn.id = 'login-btn';
         const loginClickSpy = jest.fn();
         loginBtn.addEventListener('click', loginClickSpy);
         document.body.appendChild(loginBtn);
 
-        await renderAndSearch([spotifyOnlyResult]);
+        await renderAndSearch([externalResult]);
 
         fireEvent.click(screen.getByText('New Artist'));
 
         expect(loginClickSpy).toHaveBeenCalled();
         expect(mockAddArtist).not.toHaveBeenCalled();
-        expect(mockSessionStorage['pendingAddArtistSpotifyId']).toBe('6abc123');
+        expect(mockSessionStorage['pendingAddArtistPlatformId']).toBe('dz123');
+        expect(mockSessionStorage['pendingAddArtistPlatform']).toBe('deezer');
         expect(mockSessionStorage['pendingAddArtistTimestamp']).toBeDefined();
 
         document.body.removeChild(loginBtn);
@@ -135,7 +140,8 @@ describe('SearchBar Add Artist Flow', () => {
 
     it('completes pending add on mount when session exists and pending ID is fresh', async () => {
         (useSession as jest.Mock).mockReturnValue({ data: { user: { id: '1' } } });
-        mockSessionStorage['pendingAddArtistSpotifyId'] = '6abc123';
+        mockSessionStorage['pendingAddArtistPlatformId'] = 'dz123';
+        mockSessionStorage['pendingAddArtistPlatform'] = 'deezer';
         mockSessionStorage['pendingAddArtistTimestamp'] = String(Date.now());
         mockAddArtist.mockResolvedValue({ status: 'success', artistId: '99', artistName: 'New Artist' });
 
@@ -145,16 +151,18 @@ describe('SearchBar Add Artist Flow', () => {
         });
 
         await waitFor(() => {
-            expect(mockAddArtist).toHaveBeenCalledWith('6abc123');
+            expect(mockAddArtist).toHaveBeenCalledWith('dz123', 'deezer');
             expect(mockPush).toHaveBeenCalledWith('/artist/99');
         });
-        expect(mockSessionStorage['pendingAddArtistSpotifyId']).toBeUndefined();
+        expect(mockSessionStorage['pendingAddArtistPlatformId']).toBeUndefined();
+        expect(mockSessionStorage['pendingAddArtistPlatform']).toBeUndefined();
         expect(mockSessionStorage['pendingAddArtistTimestamp']).toBeUndefined();
     });
 
     it('discards stale pending add (older than 5 minutes)', async () => {
         (useSession as jest.Mock).mockReturnValue({ data: { user: { id: '1' } } });
-        mockSessionStorage['pendingAddArtistSpotifyId'] = '6abc123';
+        mockSessionStorage['pendingAddArtistPlatformId'] = 'dz123';
+        mockSessionStorage['pendingAddArtistPlatform'] = 'deezer';
         mockSessionStorage['pendingAddArtistTimestamp'] = String(Date.now() - 6 * 60 * 1000);
 
         mockSearchResults([]);
@@ -165,12 +173,12 @@ describe('SearchBar Add Artist Flow', () => {
         await act(async () => {});
 
         expect(mockAddArtist).not.toHaveBeenCalled();
-        // Keys should still be cleaned up even if expired
-        expect(mockSessionStorage['pendingAddArtistSpotifyId']).toBeUndefined();
+        expect(mockSessionStorage['pendingAddArtistPlatformId']).toBeUndefined();
     });
 
     it('does not trigger pending add when there is no session', async () => {
-        mockSessionStorage['pendingAddArtistSpotifyId'] = '6abc123';
+        mockSessionStorage['pendingAddArtistPlatformId'] = 'dz123';
+        mockSessionStorage['pendingAddArtistPlatform'] = 'deezer';
         mockSessionStorage['pendingAddArtistTimestamp'] = String(Date.now());
 
         mockSearchResults([]);
@@ -179,19 +187,18 @@ describe('SearchBar Add Artist Flow', () => {
         await act(async () => {});
 
         expect(mockAddArtist).not.toHaveBeenCalled();
-        // Pending ID should still be in storage (waiting for session)
-        expect(mockSessionStorage['pendingAddArtistSpotifyId']).toBe('6abc123');
+        expect(mockSessionStorage['pendingAddArtistPlatformId']).toBe('dz123');
     });
 
-    it('calls addArtist and navigates on success when authenticated', async () => {
+    it('calls addArtist with platform args and navigates on success when authenticated', async () => {
         (useSession as jest.Mock).mockReturnValue({ data: { user: { id: '1' } } });
         mockAddArtist.mockResolvedValue({ status: 'success', artistId: '99', artistName: 'New Artist' });
 
-        await renderAndSearch([spotifyOnlyResult]);
+        await renderAndSearch([externalResult]);
         fireEvent.click(screen.getByText('New Artist'));
 
         await waitFor(() => {
-            expect(mockAddArtist).toHaveBeenCalledWith('6abc123');
+            expect(mockAddArtist).toHaveBeenCalledWith('dz123', 'deezer');
             expect(mockPush).toHaveBeenCalledWith('/artist/99');
         });
     });
@@ -200,7 +207,7 @@ describe('SearchBar Add Artist Flow', () => {
         (useSession as jest.Mock).mockReturnValue({ data: { user: { id: '1' } } });
         mockAddArtist.mockResolvedValue({ status: 'exists', artistId: '42', artistName: 'New Artist' });
 
-        await renderAndSearch([spotifyOnlyResult]);
+        await renderAndSearch([externalResult]);
         fireEvent.click(screen.getByText('New Artist'));
 
         await waitFor(() => {
@@ -210,19 +217,18 @@ describe('SearchBar Add Artist Flow', () => {
 
     it('shows error toast when addArtist fails and keeps dropdown open', async () => {
         (useSession as jest.Mock).mockReturnValue({ data: { user: { id: '1' } } });
-        mockAddArtist.mockResolvedValue({ status: 'error', message: 'Spotify API down' });
+        mockAddArtist.mockResolvedValue({ status: 'error', message: 'Platform API down' });
 
-        await renderAndSearch([spotifyOnlyResult]);
+        await renderAndSearch([externalResult]);
         fireEvent.click(screen.getByText('New Artist'));
 
         await waitFor(() => {
             expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({
                 variant: 'destructive',
-                description: 'Spotify API down',
+                description: 'Platform API down',
             }));
         });
         expect(mockPush).not.toHaveBeenCalled();
-        // Dropdown should still be visible on error
         expect(screen.getByText('Add to MusicNerd')).toBeInTheDocument();
     });
 
@@ -230,7 +236,7 @@ describe('SearchBar Add Artist Flow', () => {
         (useSession as jest.Mock).mockReturnValue({ data: { user: { id: '1' } } });
         mockAddArtist.mockRejectedValue(new Error('Network error'));
 
-        await renderAndSearch([spotifyOnlyResult]);
+        await renderAndSearch([externalResult]);
         fireEvent.click(screen.getByText('New Artist'));
 
         await waitFor(() => {
@@ -239,7 +245,6 @@ describe('SearchBar Add Artist Flow', () => {
                 description: 'Failed to add artist - please try again',
             }));
         });
-        // Dropdown should still be visible on error
         expect(screen.getByText('Add to MusicNerd')).toBeInTheDocument();
     });
 
@@ -257,27 +262,22 @@ describe('SearchBar Add Artist Flow', () => {
         let resolveAdd!: (val: unknown) => void;
         mockAddArtist.mockReturnValue(new Promise(r => { resolveAdd = r; }));
 
-        await renderAndSearch([spotifyOnlyResult, spotifyOnlyResult2, dbResult]);
+        await renderAndSearch([externalResult, externalResult2, dbResult]);
 
-        // Click the first Spotify-only result
         fireEvent.click(screen.getByText('New Artist'));
 
         await waitFor(() => {
-            // The clicked result shows "Adding..." and is disabled
             expect(screen.getByText('Adding...')).toBeInTheDocument();
             const addingButton = screen.getByText('Adding...').closest('button');
             expect(addingButton).toBeDisabled();
 
-            // The other Spotify result is NOT disabled
             const otherButton = screen.getByText('Other Artist').closest('button');
             expect(otherButton).not.toBeDisabled();
 
-            // The DB result is NOT disabled
             const dbButton = screen.getByText('Existing Artist').closest('button');
             expect(dbButton).not.toBeDisabled();
         });
 
-        // Resolve to clean up
         resolveAdd({ status: 'success', artistId: '99' });
     });
 
@@ -285,10 +285,9 @@ describe('SearchBar Add Artist Flow', () => {
         (useSession as jest.Mock).mockReturnValue({ data: { user: { id: '1' } } });
         mockAddArtist.mockResolvedValue({ status: 'success', artistId: '99', artistName: 'New Artist' });
 
-        await renderAndSearch([spotifyOnlyResult]);
+        await renderAndSearch([externalResult]);
         fireEvent.click(screen.getByText('New Artist'));
 
-        // After success, dropdown should close
         await waitFor(() => {
             expect(mockPush).toHaveBeenCalledWith('/artist/99');
             expect(screen.queryByText('Add to MusicNerd')).not.toBeInTheDocument();

--- a/src/__tests__/components/nav/AddArtist.test.tsx
+++ b/src/__tests__/components/nav/AddArtist.test.tsx
@@ -111,6 +111,8 @@ import AddArtist from '@/app/_components/nav/components/AddArtist';
 
 const VALID_SPOTIFY_URL = 'https://open.spotify.com/artist/4Z8W4fKeB5YxbusRsdQVPb';
 const VALID_SPOTIFY_ID = '4Z8W4fKeB5YxbusRsdQVPb';
+const VALID_DEEZER_URL = 'https://www.deezer.com/artist/123456';
+const VALID_DEEZER_ID = '123456';
 
 describe('AddArtist', () => {
     beforeEach(() => {
@@ -158,18 +160,24 @@ describe('AddArtist', () => {
         });
 
         describe('Form submission', () => {
-            async function openModalAndSubmit(spotifyUrl: string) {
+            async function openModalAndSubmit(url: string) {
                 render(<AddArtist />);
                 fireEvent.click(screen.getByRole('button'));
                 // Trigger submit by calling the captured handleSubmit fn directly
                 await waitFor(() => expect(capturedSubmitFn).not.toBeNull());
-                await capturedSubmitFn!({ artistSpotifyUrl: spotifyUrl });
+                await capturedSubmitFn!({ artistUrl: url });
             }
 
-            it('calls addArtist with the extracted Spotify ID on valid URL', async () => {
+            it('calls addArtist with the extracted Spotify ID on valid Spotify URL', async () => {
                 mockAddArtist.mockResolvedValue({ status: 'success', artistId: 'new-id', artistName: 'Radiohead', message: 'Added!' });
                 await openModalAndSubmit(VALID_SPOTIFY_URL);
-                expect(mockAddArtist).toHaveBeenCalledWith(VALID_SPOTIFY_ID);
+                expect(mockAddArtist).toHaveBeenCalledWith(VALID_SPOTIFY_ID, 'spotify');
+            });
+
+            it('calls addArtist with the extracted Deezer ID on valid Deezer URL', async () => {
+                mockAddArtist.mockResolvedValue({ status: 'success', artistId: 'new-id', artistName: 'FKJ', message: 'Added!' });
+                await openModalAndSubmit(VALID_DEEZER_URL);
+                expect(mockAddArtist).toHaveBeenCalledWith(VALID_DEEZER_ID, 'deezer');
             });
 
             it('shows success links after artist is added', async () => {

--- a/src/__tests__/protected-routes.test.tsx
+++ b/src/__tests__/protected-routes.test.tsx
@@ -13,6 +13,15 @@ jest.mock('@/server/utils/queries/externalApiQueries', () => ({
     getNumberOfSpotifyReleases: jest.fn(),
 }));
 
+jest.mock('@/server/utils/musicPlatform', () => ({
+    musicPlatformData: {
+        getArtist: jest.fn().mockResolvedValue(null),
+        getArtistImage: jest.fn().mockResolvedValue(null),
+    },
+    deezerProvider: { getArtist: jest.fn() },
+    spotifyProvider: { getArtist: jest.fn() },
+}));
+
 jest.mock('@/server/utils/queries/artistQueries', () => ({
     getArtistById: jest.fn(),
     getAllLinks: jest.fn(),
@@ -70,8 +79,8 @@ jest.mock('@/server/utils/dev-auth', () => ({
 import AddArtistPage from '@/app/add-artist/page';
 import ArtistProfile from '@/app/artist/[id]/page';
 import { getServerAuthSession } from '@/server/auth';
-import { getSpotifyHeaders, getSpotifyArtist, getSpotifyImage, getNumberOfSpotifyReleases } from '@/server/utils/queries/externalApiQueries';
 import { getArtistById, getAllLinks } from '@/server/utils/queries/artistQueries';
+import { spotifyProvider, musicPlatformData } from '@/server/utils/musicPlatform';
 
 const mockSession = {
     user: { id: 'user-uuid', email: 'test@test.com', isAdmin: false, isWhiteListed: true },
@@ -93,10 +102,10 @@ describe('Protected routes', () => {
 
     describe('/add-artist (requires authentication)', () => {
         beforeEach(() => {
-            (getSpotifyHeaders as jest.Mock).mockResolvedValue({ headers: { Authorization: 'Bearer token' } });
-            (getSpotifyArtist as jest.Mock).mockResolvedValue({
-                data: { name: 'New Artist', id: 'new-artist-id', images: [] },
-                error: null,
+            (spotifyProvider.getArtist as jest.Mock).mockResolvedValue({
+                platform: 'spotify', platformId: 'some-id', name: 'New Artist',
+                imageUrl: null, followerCount: 0, albumCount: 0, genres: [],
+                profileUrl: '', topTrackName: null,
             });
         });
 
@@ -121,11 +130,11 @@ describe('Protected routes', () => {
             expect(mockRedirect).not.toHaveBeenCalled();
         });
 
-        it('shows an error page (not a redirect) when spotify param is missing, even if authenticated', async () => {
+        it('shows an error page (not a redirect) when no platform param is present, even if authenticated', async () => {
             (getServerAuthSession as jest.Mock).mockResolvedValue(mockSession);
             const jsx = await AddArtistPage({ searchParams: Promise.resolve({}) });
             render(jsx as React.ReactElement);
-            expect(screen.getByText('No Spotify ID provided')).toBeInTheDocument();
+            expect(screen.getByText('No artist ID provided')).toBeInTheDocument();
             expect(mockRedirect).not.toHaveBeenCalled();
         });
     });
@@ -133,9 +142,12 @@ describe('Protected routes', () => {
     describe('/artist/[id] (publicly accessible)', () => {
         beforeEach(() => {
             (getArtistById as jest.Mock).mockResolvedValue(mockArtist);
-            (getSpotifyHeaders as jest.Mock).mockResolvedValue({ headers: { Authorization: 'Bearer token' } });
-            (getSpotifyImage as jest.Mock).mockResolvedValue({ artistImage: null });
-            (getNumberOfSpotifyReleases as jest.Mock).mockResolvedValue(3);
+            (musicPlatformData.getArtist as jest.Mock).mockResolvedValue({
+                platform: 'spotify', platformId: 'spotify123', name: 'Test Artist',
+                imageUrl: null, followerCount: 0, albumCount: 3, genres: [],
+                profileUrl: '', topTrackName: null,
+            });
+            (musicPlatformData.getArtistImage as jest.Mock).mockResolvedValue(null);
             (getAllLinks as jest.Mock).mockResolvedValue([]);
         });
 

--- a/src/__tests__/url-params.test.tsx
+++ b/src/__tests__/url-params.test.tsx
@@ -6,9 +6,9 @@ jest.mock('@/server/auth', () => ({
     getServerAuthSession: jest.fn(),
 }));
 
-jest.mock('@/server/utils/queries/externalApiQueries', () => ({
-    getSpotifyHeaders: jest.fn(),
-    getSpotifyArtist: jest.fn(),
+jest.mock('@/server/utils/musicPlatform', () => ({
+    deezerProvider: { getArtist: jest.fn() },
+    spotifyProvider: { getArtist: jest.fn() },
 }));
 
 const mockRedirect = jest.fn();
@@ -28,21 +28,35 @@ jest.mock('@/app/add-artist/_components/AddArtistContent', () =>
 
 import AddArtistPage from '@/app/add-artist/page';
 import { getServerAuthSession } from '@/server/auth';
-import { getSpotifyHeaders, getSpotifyArtist } from '@/server/utils/queries/externalApiQueries';
+import { deezerProvider, spotifyProvider } from '@/server/utils/musicPlatform';
 
 const mockSession = {
     user: { id: 'user-uuid', email: 'test@test.com' },
     expires: '2026-12-31',
 };
 
+const mockPlatformArtist = {
+    platform: 'spotify',
+    platformId: 'ts-id',
+    name: 'Taylor Swift',
+    imageUrl: 'https://example.com/ts.jpg',
+    followerCount: 1000000,
+    albumCount: 10,
+    genres: ['pop'],
+    profileUrl: 'https://open.spotify.com/artist/ts-id',
+    topTrackName: 'Anti-Hero',
+};
+
 describe('AddArtistPage URL parameter handling', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         (getServerAuthSession as jest.Mock).mockResolvedValue(mockSession);
-        (getSpotifyHeaders as jest.Mock).mockResolvedValue({ headers: { Authorization: 'Bearer token' } });
-        (getSpotifyArtist as jest.Mock).mockResolvedValue({
-            data: { name: 'Taylor Swift', id: 'ts-id', images: [] },
-            error: null,
+        (spotifyProvider.getArtist as jest.Mock).mockResolvedValue(mockPlatformArtist);
+        (deezerProvider.getArtist as jest.Mock).mockResolvedValue({
+            ...mockPlatformArtist,
+            platform: 'deezer',
+            platformId: '12345',
+            profileUrl: 'https://www.deezer.com/artist/12345',
         });
     });
 
@@ -53,39 +67,38 @@ describe('AddArtistPage URL parameter handling', () => {
         expect(screen.getByText('Taylor Swift')).toBeInTheDocument();
     });
 
-    it('calls getSpotifyArtist with the correct ID from the URL param', async () => {
+    it('calls spotifyProvider.getArtist with the correct ID', async () => {
         await AddArtistPage({ searchParams: Promise.resolve({ spotify: 'ts-id' }) });
-        expect(getSpotifyArtist).toHaveBeenCalledWith('ts-id', expect.anything());
+        expect(spotifyProvider.getArtist).toHaveBeenCalledWith('ts-id');
     });
 
-    it('shows "No Spotify ID provided" when spotify param is missing', async () => {
+    it('renders AddArtistContent when deezer param is present', async () => {
+        const jsx = await AddArtistPage({ searchParams: Promise.resolve({ deezer: '12345' }) });
+        render(jsx as React.ReactElement);
+        expect(screen.getByTestId('add-artist-content')).toBeInTheDocument();
+    });
+
+    it('calls deezerProvider.getArtist with the correct ID', async () => {
+        await AddArtistPage({ searchParams: Promise.resolve({ deezer: '12345' }) });
+        expect(deezerProvider.getArtist).toHaveBeenCalledWith('12345');
+    });
+
+    it('shows "No artist ID provided" when no platform param is present', async () => {
         const jsx = await AddArtistPage({ searchParams: Promise.resolve({}) });
         render(jsx as React.ReactElement);
-        expect(screen.getByText('No Spotify ID provided')).toBeInTheDocument();
+        expect(screen.getByText('No artist ID provided')).toBeInTheDocument();
     });
 
-    it('shows "No Spotify ID provided" when spotify param is undefined', async () => {
-        const jsx = await AddArtistPage({ searchParams: Promise.resolve({ spotify: undefined }) });
+    it('shows error when provider returns null', async () => {
+        (spotifyProvider.getArtist as jest.Mock).mockResolvedValue(null);
+        const jsx = await AddArtistPage({ searchParams: Promise.resolve({ spotify: 'bad-id' }) });
         render(jsx as React.ReactElement);
-        expect(screen.getByText('No Spotify ID provided')).toBeInTheDocument();
+        expect(screen.getByText('Could not find artist on spotify')).toBeInTheDocument();
     });
 
-    it('does not call getSpotifyArtist when spotify param is absent', async () => {
+    it('does not call providers when no params present', async () => {
         await AddArtistPage({ searchParams: Promise.resolve({}) });
-        expect(getSpotifyArtist).not.toHaveBeenCalled();
-    });
-
-    it('shows error from Spotify API', async () => {
-        (getSpotifyArtist as jest.Mock).mockResolvedValue({ data: null, error: 'Artist not found on Spotify' });
-        const jsx = await AddArtistPage({ searchParams: Promise.resolve({ spotify: 'bad-id' }) });
-        render(jsx as React.ReactElement);
-        expect(screen.getByText('Artist not found on Spotify')).toBeInTheDocument();
-    });
-
-    it('shows fallback error when Spotify returns no data and no error message', async () => {
-        (getSpotifyArtist as jest.Mock).mockResolvedValue({ data: null, error: null });
-        const jsx = await AddArtistPage({ searchParams: Promise.resolve({ spotify: 'bad-id' }) });
-        render(jsx as React.ReactElement);
-        expect(screen.getByText('Failed to fetch artist data')).toBeInTheDocument();
+        expect(spotifyProvider.getArtist).not.toHaveBeenCalled();
+        expect(deezerProvider.getArtist).not.toHaveBeenCalled();
     });
 });

--- a/src/app/_components/nav/components/AddArtist.tsx
+++ b/src/app/_components/nav/components/AddArtist.tsx
@@ -31,11 +31,21 @@ import { useSession } from "next-auth/react";
 import { useLogin } from "@privy-io/react-auth";
 
 const spotifyArtistUrlRegex = /https:\/\/open\.spotify\.com\/artist\/([a-zA-Z0-9]+)/;
+const deezerArtistUrlRegex = /https?:\/\/(www\.)?deezer\.com\/([\w-]+\/)?artist\/(\d+)/;
+
+function parseArtistUrl(url: string): { id: string; platform: 'deezer' | 'spotify' } | null {
+    const deezerMatch = url.match(deezerArtistUrlRegex);
+    if (deezerMatch) return { id: deezerMatch[3], platform: 'deezer' };
+    const spotifyMatch = url.match(spotifyArtistUrlRegex);
+    if (spotifyMatch) return { id: spotifyMatch[1], platform: 'spotify' };
+    return null;
+}
 
 const formSchema = z.object({
-    artistSpotifyUrl: z.string().regex(spotifyArtistUrlRegex, {
-        message: "Artist Spotify url must be in the format https://open.spotify.com/artist/YOURARTISTID",
-    }),
+    artistUrl: z.string().refine(
+        (val) => spotifyArtistUrlRegex.test(val) || deezerArtistUrlRegex.test(val),
+        { message: "Enter a Spotify or Deezer artist URL (e.g. https://open.spotify.com/artist/... or https://www.deezer.com/artist/...)" },
+    ),
 })
 
 export default function AddArtist() {
@@ -50,16 +60,15 @@ export default function AddArtist() {
         resolver: zodResolver(formSchema),
         mode: "onSubmit",
         defaultValues: {
-            artistSpotifyUrl: "",
+            artistUrl: "",
         },
     })
 
     async function onSubmit(values: z.infer<typeof formSchema>) {
-        const match = values.artistSpotifyUrl.match(spotifyArtistUrlRegex);
-        if (!match) return null;
-        const artistId = match[1]
+        const parsed = parseArtistUrl(values.artistUrl);
+        if (!parsed) return null;
         setIsLoading(true);
-        const resp = await addArtist(artistId);
+        const resp = await addArtist(parsed.id, parsed.platform);
         setAddArtistStatus(resp);
         setIsLoading(false);
         if (resp.status === "success" || resp.status === "exists") setAddedArtist({ artistId: resp.artistId, artistName: resp.artistName });
@@ -95,22 +104,22 @@ export default function AddArtist() {
                     <DialogHeader>
                         <DialogTitle>Add Artist</DialogTitle>
                         <DialogDescription>
-                            Add an artist by pasting their Spotify URL
+                            Add an artist by pasting their Spotify or Deezer URL
                         </DialogDescription>
                     </DialogHeader>
                     <Form {...form}>
                         <div className="space-y-8">
                             <FormField
                                 control={form.control}
-                                name="artistSpotifyUrl"
+                                name="artistUrl"
                                 render={({ field }) => (
                                     <FormItem>
-                                        <FormLabel>Spotify URL</FormLabel>
+                                        <FormLabel>Artist URL</FormLabel>
                                         <FormControl>
-                                            <Input placeholder="https://open.spotify.com/artist/..." {...field} />
+                                            <Input placeholder="Paste a Spotify or Deezer artist URL" {...field} />
                                         </FormControl>
                                         <FormDescription>
-                                            Copy the URL from the artist&apos;s Spotify page
+                                            Copy the URL from the artist&apos;s Spotify or Deezer page
                                         </FormDescription>
                                         <FormMessage />
                                     </FormItem>

--- a/src/app/_components/nav/components/SearchBar.tsx
+++ b/src/app/_components/nav/components/SearchBar.tsx
@@ -22,22 +22,20 @@ const queryClient = new QueryClient({
     },
 })
 
-interface SpotifyArtistImage {
-  url: string;
-  height: number;
-  width: number;
-}
-
 interface SearchResult extends Artist {
-  isSpotifyOnly?: boolean;
-  images?: SpotifyArtistImage[];
+  isExternalOnly?: boolean;
+  imageUrl?: string | null;
+  platformId?: string;
+  platform?: string;
+  profileUrl?: string;
 }
 
 interface SearchBarProps {
     isTopSide?: boolean;
 }
 
-const PENDING_ADD_KEY = 'pendingAddArtistSpotifyId';
+const PENDING_ADD_KEY = 'pendingAddArtistPlatformId';
+const PENDING_ADD_PLATFORM_KEY = 'pendingAddArtistPlatform';
 const PENDING_ADD_TS_KEY = 'pendingAddArtistTimestamp';
 const PENDING_ADD_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -52,12 +50,12 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
     const search = searchParams.get('search');
     const blurTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
     const { data: session } = useSession();
-    const [addingSpotifyId, setAddingSpotifyId] = useState<string | null>(null);
+    const [addingPlatformId, setAddingPlatformId] = useState<string | null>(null);
 
-    const handleAddArtist = useCallback(async (spotifyId: string) => {
+    const handleAddArtist = useCallback(async (platformId: string, platform: string = 'deezer') => {
         try {
-            setAddingSpotifyId(spotifyId);
-            const addResult = await addArtist(spotifyId);
+            setAddingPlatformId(platformId);
+            const addResult = await addArtist(platformId, platform as 'deezer' | 'spotify');
 
             if ((addResult.status === "success" || addResult.status === "exists") && addResult.artistId) {
                 setShowResults(false);
@@ -78,7 +76,7 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
                 description: "Failed to add artist - please try again"
             });
         } finally {
-            setAddingSpotifyId(null);
+            setAddingPlatformId(null);
         }
     }, [router, toast]);
 
@@ -88,14 +86,16 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
         const pendingId = sessionStorage.getItem(PENDING_ADD_KEY);
         if (!pendingId) return;
 
+        const pendingPlatform = sessionStorage.getItem(PENDING_ADD_PLATFORM_KEY) || 'deezer';
         const timestamp = Number(sessionStorage.getItem(PENDING_ADD_TS_KEY) || '0');
         sessionStorage.removeItem(PENDING_ADD_KEY);
+        sessionStorage.removeItem(PENDING_ADD_PLATFORM_KEY);
         sessionStorage.removeItem(PENDING_ADD_TS_KEY);
 
         // Discard stale pending adds (e.g. user dismissed login, logged in later)
         if (Date.now() - timestamp > PENDING_ADD_TTL_MS) return;
 
-        handleAddArtist(pendingId);
+        handleAddArtist(pendingId, pendingPlatform);
     }, [session, handleAddArtist]);
 
     useEffect(() => {
@@ -162,13 +162,13 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
     }, []);
 
     const handleResultClick = async (result: SearchResult) => {
-        if (result.isSpotifyOnly) {
-            if (!result.spotify) return;
+        if (result.isExternalOnly) {
+            if (!result.platformId) return;
 
             if (!session && !isDevMode) {
-                // Privy login required — dynamically import to avoid crash when Privy isn't configured
                 try {
-                    sessionStorage.setItem(PENDING_ADD_KEY, result.spotify);
+                    sessionStorage.setItem(PENDING_ADD_KEY, result.platformId);
+                    sessionStorage.setItem(PENDING_ADD_PLATFORM_KEY, result.platform || 'deezer');
                     sessionStorage.setItem(PENDING_ADD_TS_KEY, String(Date.now()));
                     const loginBtn = document.getElementById('login-btn');
                     loginBtn?.click();
@@ -178,7 +178,7 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
                 return;
             }
 
-            await handleAddArtist(result.spotify);
+            await handleAddArtist(result.platformId, result.platform || 'deezer');
             return;
         }
 
@@ -188,6 +188,11 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
         if (result.id) {
             router.push(`/artist/${result.id}`);
         }
+    };
+
+    const getPlatformLabel = (platform?: string) => {
+        if (!platform) return 'Deezer';
+        return platform.charAt(0).toUpperCase() + platform.slice(1);
     };
 
     return (
@@ -211,17 +216,17 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
                     className="absolute w-full mt-2 bg-white dark:bg-gray-800 rounded-lg shadow-lg max-h-96 overflow-y-auto z-50"
                 >
                     {results.map((result) => {
-                        const spotifyImage = result.images?.[0]?.url;
+                        const resultImage = result.imageUrl;
                         const hasSocialLinks = result.bandcamp || result.youtube || result.youtubechannel || result.instagram || result.x || result.facebook || result.tiktok;
-                        const isThisAdding = result.isSpotifyOnly && addingSpotifyId === result.spotify;
+                        const isThisAdding = result.isExternalOnly && addingPlatformId === result.platformId;
 
                         return (
                             <button
-                                key={result.isSpotifyOnly ? `spotify-${result.spotify}` : result.id}
+                                key={result.isExternalOnly ? `ext-${result.platformId}` : result.id}
                                 disabled={isThisAdding}
                                 onClick={() => handleResultClick(result)}
                                 className={`w-full p-3 flex items-center gap-3 text-left disabled:opacity-50 ${
-                                    result.isSpotifyOnly
+                                    result.isExternalOnly
                                         ? 'hover:bg-gray-50 dark:hover:bg-gray-700'
                                         : 'hover:bg-gray-100 dark:hover:bg-gray-700'
                                 }`}
@@ -229,29 +234,29 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
                                 <div className="flex items-center justify-center w-10 h-10">
                                     {/* eslint-disable-next-line @next/next/no-img-element */}
                                     <img
-                                        src={spotifyImage || "/default_pfp_pink.png"}
+                                        src={resultImage || "/default_pfp_pink.png"}
                                         alt={result.name ?? "Artist"}
-                                        className={`object-cover rounded-full ${result.isSpotifyOnly ? 'w-8 h-8' : 'w-10 h-10'}`}
+                                        className={`object-cover rounded-full ${result.isExternalOnly ? 'w-8 h-8' : 'w-10 h-10'}`}
                                     />
                                 </div>
                                 <div className="flex-1">
-                                    <div className={`font-medium ${result.isSpotifyOnly ? 'text-sm text-gray-500 dark:text-gray-400' : 'text-base text-gray-900 dark:text-white'}`}>
+                                    <div className={`font-medium ${result.isExternalOnly ? 'text-sm text-gray-500 dark:text-gray-400' : 'text-base text-gray-900 dark:text-white'}`}>
                                         {result.name}
                                     </div>
-                                    {result.isSpotifyOnly && result.spotify ? (
+                                    {result.isExternalOnly && result.platformId ? (
                                         <div className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
                                             <span className="hover:text-gray-600 hover:underline">
                                                 {isThisAdding ? 'Adding...' : 'Add to MusicNerd'}
                                             </span>
                                             <span className="text-pink-400">|</span>
                                             <a
-                                                href={`https://open.spotify.com/artist/${result.spotify}`}
+                                                href={result.profileUrl || '#'}
                                                 target="_blank"
                                                 rel="noopener noreferrer"
                                                 onClick={(e) => e.stopPropagation()}
                                                 className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-600 hover:underline"
                                             >
-                                                <span>View on Spotify</span>
+                                                <span>View on {getPlatformLabel(result.platform)}</span>
                                                 <ExternalLink size={12} className="text-gray-500" />
                                             </a>
                                         </div>

--- a/src/app/actions/__tests__/addArtist.test.ts
+++ b/src/app/actions/__tests__/addArtist.test.ts
@@ -2,9 +2,8 @@ jest.mock('@/server/auth', () => ({
   getServerAuthSession: jest.fn(),
 }));
 
-jest.mock('@/server/utils/queries/externalApiQueries', () => ({
-  getSpotifyHeaders: jest.fn(),
-  getSpotifyArtist: jest.fn(),
+jest.mock('@/server/utils/dev-auth', () => ({
+  getDevSession: jest.fn().mockResolvedValue(null),
 }));
 
 jest.mock('@/server/utils/queries/artistQueries', () => ({
@@ -13,12 +12,9 @@ jest.mock('@/server/utils/queries/artistQueries', () => ({
 
 import { addArtist } from '../addArtist';
 import { getServerAuthSession } from '@/server/auth';
-import { getSpotifyHeaders, getSpotifyArtist } from '@/server/utils/queries/externalApiQueries';
 import { addArtist as dbAddArtist } from '@/server/utils/queries/artistQueries';
 
 const mockGetSession = getServerAuthSession as jest.Mock;
-const mockGetHeaders = getSpotifyHeaders as jest.Mock;
-const mockGetArtist = getSpotifyArtist as jest.Mock;
 const mockDbAddArtist = dbAddArtist as jest.Mock;
 
 describe('addArtist Server Action', () => {
@@ -29,29 +25,26 @@ describe('addArtist Server Action', () => {
   it('should throw when not authenticated', async () => {
     mockGetSession.mockResolvedValue(null);
 
-    await expect(addArtist('test-spotify-id')).rejects.toThrow('Not authenticated');
+    await expect(addArtist('test-id')).rejects.toThrow('Not authenticated');
   });
 
-  it('should return error when Spotify headers fail', async () => {
+  it('should return success when artist is added via spotify (default)', async () => {
     mockGetSession.mockResolvedValue({ user: { id: 'user-1' } });
-    mockGetHeaders.mockResolvedValue({ headers: {} });
-
-    const result = await addArtist('test-spotify-id');
-
-    expect(result).toEqual({
-      status: 'error',
-      message: 'Failed to authenticate with Spotify',
-    });
-  });
-
-  it('should return success when artist is added', async () => {
-    mockGetSession.mockResolvedValue({ user: { id: 'user-1' } });
-    mockGetHeaders.mockResolvedValue({ headers: { Authorization: 'Bearer token' } });
-    mockGetArtist.mockResolvedValue({ data: { name: 'Test Artist' } });
     mockDbAddArtist.mockResolvedValue({ status: 'success', artistId: '123', artistName: 'Test Artist' });
 
     const result = await addArtist('test-spotify-id');
 
+    expect(mockDbAddArtist).toHaveBeenCalledWith('test-spotify-id', 'spotify');
     expect(result).toEqual({ status: 'success', artistId: '123', artistName: 'Test Artist' });
+  });
+
+  it('should return success when artist is added via deezer', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'user-1' } });
+    mockDbAddArtist.mockResolvedValue({ status: 'success', artistId: '456', artistName: 'Deezer Artist' });
+
+    const result = await addArtist('12345', 'deezer');
+
+    expect(mockDbAddArtist).toHaveBeenCalledWith('12345', 'deezer');
+    expect(result).toEqual({ status: 'success', artistId: '456', artistName: 'Deezer Artist' });
   });
 });

--- a/src/app/actions/addArtist.ts
+++ b/src/app/actions/addArtist.ts
@@ -2,10 +2,10 @@
 
 import { getServerAuthSession } from "@/server/auth";
 import { getDevSession } from "@/server/utils/dev-auth";
-import { getSpotifyHeaders, getSpotifyArtist } from '@/server/utils/queries/externalApiQueries';
 import { addArtist as dbAddArtist, type AddArtistResp } from "@/server/utils/queries/artistQueries";
+import type { MusicPlatform } from "@/server/utils/musicPlatform";
 
-export async function addArtist(spotifyId: string): Promise<AddArtistResp> {
+export async function addArtist(platformId: string, platform: MusicPlatform = 'spotify'): Promise<AddArtistResp> {
     const session = await getServerAuthSession() ?? await getDevSession();
 
     if (!session) {
@@ -13,23 +13,7 @@ export async function addArtist(spotifyId: string): Promise<AddArtistResp> {
     }
 
     try {
-        const headers = await getSpotifyHeaders();
-        if (!headers?.headers?.Authorization) {
-            return { status: "error", message: "Failed to authenticate with Spotify" };
-        }
-
-        const spotifyArtist = await getSpotifyArtist(spotifyId, headers);
-
-        if (spotifyArtist.error) {
-            return { status: "error", message: spotifyArtist.error };
-        }
-
-        if (!spotifyArtist.data?.name) {
-            return { status: "error", message: "Invalid artist data received from Spotify" };
-        }
-
-        const result = await dbAddArtist(spotifyId);
-
+        const result = await dbAddArtist(platformId, platform);
         return result;
     } catch (e) {
         console.error("[addArtist] Error:", e);

--- a/src/app/add-artist/_components/AddArtistContent.tsx
+++ b/src/app/add-artist/_components/AddArtistContent.tsx
@@ -5,27 +5,9 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { addArtist } from "../../actions/addArtist";
 import { useSession } from "next-auth/react";
+import type { MusicPlatformArtist } from "@/server/utils/musicPlatform";
 
-interface SpotifyArtist {
-    id: string;
-    name: string;
-    images: Array<{
-        url: string;
-        height: number;
-        width: number;
-    }>;
-    followers: {
-        total: number;
-    };
-    genres: string[];
-    type: string;
-    uri: string;
-    external_urls: {
-        spotify: string;
-    };
-}
-
-export default function AddArtistContent({ initialArtist }: { initialArtist: SpotifyArtist }) {
+export default function AddArtistContent({ initialArtist }: { initialArtist: MusicPlatformArtist }) {
     const router = useRouter();
     const [adding, setAdding] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -48,7 +30,7 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Spo
         setError(null);
 
         try {
-            const result = await addArtist(initialArtist.id);
+            const result = await addArtist(initialArtist.platformId, initialArtist.platform);
 
             if (result.status === "success" && result.artistId) {
                 router.push(`/artist/${result.artistId}`);
@@ -90,9 +72,9 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Spo
                     </div>
                 )}
                 <div className="flex flex-col md:flex-row gap-8 items-center">
-                    {initialArtist.images?.[0] && (
+                    {initialArtist.imageUrl && (
                         <img
-                            src={initialArtist.images[0].url}
+                            src={initialArtist.imageUrl}
                             alt={initialArtist.name}
                             className="w-48 h-48 object-cover rounded-lg"
                         />
@@ -100,9 +82,11 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Spo
                     <div className="flex-1">
                         <h1 className="text-3xl font-bold mb-4">{initialArtist.name}</h1>
                         <div className="space-y-2 mb-6">
-                            <p className="text-gray-600">
-                                {initialArtist.followers.total.toLocaleString()} followers on Spotify
-                            </p>
+                            {initialArtist.followerCount != null && initialArtist.followerCount > 0 && (
+                                <p className="text-gray-600">
+                                    {initialArtist.followerCount.toLocaleString()} followers
+                                </p>
+                            )}
                             {initialArtist.genres.length > 0 && (
                                 <div className="flex flex-wrap gap-2">
                                     {initialArtist.genres.map(genre => (

--- a/src/app/add-artist/page.tsx
+++ b/src/app/add-artist/page.tsx
@@ -1,6 +1,6 @@
 import { getServerAuthSession } from "@/server/auth";
 import { redirect } from "next/navigation";
-import { getSpotifyHeaders, getSpotifyArtist } from "@/server/utils/queries/externalApiQueries";
+import { deezerProvider, spotifyProvider } from "@/server/utils/musicPlatform";
 import AddArtistContent from "./_components/AddArtistContent";
 
 export default async function AddArtistPage({
@@ -14,26 +14,29 @@ export default async function AddArtistPage({
     }
 
     const params = await searchParams;
+    const deezerId = params.deezer;
     const spotifyId = params.spotify;
+    const platform = deezerId ? 'deezer' : spotifyId ? 'spotify' : null;
+    const platformId = deezerId || spotifyId;
 
-    if (!spotifyId) {
+    if (!platform || !platformId) {
         return (
             <div className="min-h-screen flex flex-col items-center justify-center gap-4">
-                <div className="text-xl">No Spotify ID provided</div>
+                <div className="text-xl">No artist ID provided</div>
             </div>
         );
     }
 
-    const headers = await getSpotifyHeaders();
-    const response = await getSpotifyArtist(spotifyId, headers);
+    const provider = platform === 'deezer' ? deezerProvider : spotifyProvider;
+    const artistData = await provider.getArtist(platformId);
 
-    if (response.error || !response.data) {
+    if (!artistData) {
         return (
             <div className="min-h-screen flex flex-col items-center justify-center gap-4">
-                <div className="text-red-500 text-xl">{response.error || "Failed to fetch artist data"}</div>
+                <div className="text-red-500 text-xl">Could not find artist on {platform}</div>
             </div>
         );
     }
 
-    return <AddArtistContent initialArtist={response.data} />;
+    return <AddArtistContent initialArtist={artistData} />;
 }

--- a/src/app/api/searchArtists/route.ts
+++ b/src/app/api/searchArtists/route.ts
@@ -100,13 +100,18 @@ export async function POST(req: Request) {
         }),
       ]);
 
-      // Dedup: filter out external results that already exist in DB (by deezer ID)
+      // Dedup: filter out external results that already exist in DB
+      // Check both deezer ID and normalized name to prevent visible duplicates
+      // (only ~1% of artists have deezer populated, so name-matching is essential)
       const existingDeezerIds = new Set(
         (dbResults ?? []).map(artist => (artist as any).deezer).filter(Boolean)
       );
+      const existingNames = new Set(
+        (dbResults ?? []).map(artist => (artist.name || '').toLowerCase()).filter(Boolean)
+      );
 
       const newExternalResults = externalResults
-        .filter(ext => !existingDeezerIds.has(ext.platformId))
+        .filter(ext => !existingDeezerIds.has(ext.platformId) && !existingNames.has(ext.name.toLowerCase()))
         .map(ext => ({
           id: null,
           name: ext.name,

--- a/src/app/api/searchArtists/route.ts
+++ b/src/app/api/searchArtists/route.ts
@@ -1,48 +1,10 @@
 import { searchForArtistByName } from "@/server/utils/queries/artistQueries";
-import { getSpotifyHeaders } from "@/server/utils/queries/externalApiQueries";
-import axios from "axios";
+import { musicPlatformData } from "@/server/utils/musicPlatform";
+import type { Artist } from "@/server/db/DbTypes";
 
 // Simple in-memory cache for search results (5 minute TTL)
 const searchCache = new Map<string, { results: any[], timestamp: number }>();
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
-
-// Defines the structure of a Spotify artist's image metadata
-interface SpotifyArtistImage {
-  url: string;
-  height: number;
-  width: number;
-}
-
-// Defines the complete structure of a Spotify artist object from their API
-interface SpotifyArtist {
-  id: string;
-  name: string;
-  images: Array<{
-    url: string;
-    height: number;
-    width: number;
-  }>;
-  followers: {
-    total: number;
-  };
-  genres: string[];
-  type: string;
-  uri: string;
-  external_urls: {
-    spotify: string;
-  };
-}
-
-// Defines the structure of the Spotify search API response
-interface SpotifySearchResponse {
-  artists: {
-    items: SpotifyArtist[];
-  };
-}
-
-interface SpotifyArtistsResponse {
-  artists: SpotifyArtist[];
-}
 
 // ----------------------------------
 // Helper to calculate how much content an artist has
@@ -89,27 +51,23 @@ function getMatchScore(name: string, query: string) {
 
   // Exact match gets highest priority (0)
   if (nameLower === queryLower) return 0;
-  
+
   // Starts with match gets second priority (1)
   if (nameLower.startsWith(queryLower)) return 1;
-  
+
   // Contains match gets third priority (2)
   if (nameLower.includes(queryLower)) return 2;
-  
+
   // No direct match, will be sorted by similarity (3)
   return 3;
 }
 
-// POST endpoint handler for combined artist search across local database and Spotify
-// Params:
-//      req: Request object containing search query in the body
-// Returns:
-//      Response with combined and sorted search results or error message
+// POST endpoint handler for combined artist search across local database and external platform
 export async function POST(req: Request) {
   const start = performance.now();
   try {
     const { query, bookmarkedArtistIds = [] } = await req.json();
-    
+
     if (!query || typeof query !== 'string') {
       return Response.json(
         { error: "Invalid query parameter" },
@@ -128,93 +86,58 @@ export async function POST(req: Request) {
     }
 
     // Set a timeout for the entire operation to prevent Vercel timeouts
-    const timeoutPromise = new Promise<Response>((_, reject) => 
+    const timeoutPromise = new Promise<Response>((_, reject) =>
       setTimeout(() => reject(new Error('Search timeout')), 12000) // 12 second timeout
     );
 
     const searchOperation = async (): Promise<Response> => {
-      // Parallel execution of database search and Spotify headers
-      const [dbResults, spotifyHeaders] = await Promise.all([
+      // Parallel execution of database search and external platform search
+      const [dbResults, externalResults] = await Promise.all([
         searchForArtistByName(query),
-        getSpotifyHeaders()
+        musicPlatformData.searchArtists(query, 10).catch((err) => {
+          console.error('External platform search failed:', err);
+          return [];
+        }),
       ]);
 
-      // Search Spotify's API for matching artists first (faster than fetching individual artists)
-      let spotifyArtists: any[] = [];
+      // Dedup: filter out external results that already exist in DB (by deezer ID)
+      const existingDeezerIds = new Set(
+        (dbResults ?? []).map(artist => (artist as any).deezer).filter(Boolean)
+      );
+
+      const newExternalResults = externalResults
+        .filter(ext => !existingDeezerIds.has(ext.platformId))
+        .map(ext => ({
+          id: null,
+          name: ext.name,
+          platformId: ext.platformId,
+          platform: ext.platform,
+          imageUrl: ext.imageUrl,
+          profileUrl: ext.profileUrl,
+          isExternalOnly: true,
+          matchScore: getMatchScore(ext.name, query),
+          linkCount: 0,
+        }));
+
+      // Fetch platform images for database artists
+      const dbArtistsTyped = (dbResults ?? []) as Artist[];
+      let imageMap = new Map<string, string>();
       try {
-        const spotifyResponse = await axios.get<SpotifySearchResponse>(
-          `https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=artist&limit=10`,
-          spotifyHeaders
-        );
-        
-        // Create a Set of existing Spotify IDs from DB results for fast filtering
-        const existingSpotifyIds = new Set(
-          dbResults.map(artist => artist.spotify).filter(Boolean)
-        );
-
-        // Filter out existing artists from Spotify results
-        spotifyArtists = spotifyResponse.data.artists.items
-          .filter((spotifyArtist: SpotifyArtist) => !existingSpotifyIds.has(spotifyArtist.id))
-          .map((artist: SpotifyArtist) => ({
-            id: null,
-            name: artist.name,
-            spotify: artist.id,
-            images: artist.images,
-            isSpotifyOnly: true,
-            matchScore: getMatchScore(artist.name, query),
-            linkCount: 0
-          }));
+        imageMap = await musicPlatformData.getArtistImages(dbArtistsTyped);
       } catch (error) {
-        console.error('Spotify search failed:', error);
-        // Continue without Spotify results rather than failing entirely
+        console.error('Failed to fetch platform images:', error);
       }
 
-      // Fetch Spotify data for database artists in batches
-      const dbSpotifyIds = dbResults.map(a => a.spotify).filter(Boolean) as string[];
-      const idChunks: string[][] = [];
-      for (let i = 0; i < dbSpotifyIds.length; i += 50) {
-        idChunks.push(dbSpotifyIds.slice(i, i + 50));
-      }
-
-      let spotifyArtistMap: Record<string, SpotifyArtist> = {};
-      try {
-        const responses = await Promise.all(
-          idChunks.map(ids =>
-            axios.get<SpotifyArtistsResponse>(
-              `https://api.spotify.com/v1/artists?ids=${ids.join(',')}`,
-              { ...spotifyHeaders, timeout: 3000 }
-            )
-          )
-        );
-        spotifyArtistMap = Object.fromEntries(
-          responses.flatMap(res =>
-            (res.data?.artists ?? [])
-              .filter(Boolean)
-              .map(artist => [artist.id, artist])
-          )
-        );
-      } catch (error) {
-        console.error('Failed to fetch Spotify artist batch:', error);
-      }
-
-      const dbArtistsWithImages = dbResults.map((artist) => {
-        const baseArtist = {
-          ...artist,
-          isSpotifyOnly: false,
-          matchScore: getMatchScore(artist.name || "", query),
-          linkCount: getLinkCount(artist)
-        };
-        if (artist.spotify && spotifyArtistMap[artist.spotify]) {
-          return {
-            ...baseArtist,
-            images: spotifyArtistMap[artist.spotify].images,
-          };
-        }
-        return baseArtist;
-      });
+      const dbArtistsWithImages = (dbResults ?? []).map((artist) => ({
+        ...artist,
+        isExternalOnly: false,
+        imageUrl: imageMap.get(artist.id) ?? null,
+        matchScore: getMatchScore(artist.name || "", query),
+        linkCount: getLinkCount(artist),
+      }));
 
       // Combine all results and sort them by match score, bookmark status, link count, and name
-      const combinedResults = [...dbArtistsWithImages, ...spotifyArtists]
+      const combinedResults = [...dbArtistsWithImages, ...newExternalResults]
         .sort((a, b) => {
           // First sort by match score (most important for relevance)
           if (a.matchScore !== b.matchScore) {
@@ -248,14 +171,14 @@ export async function POST(req: Request) {
 
   } catch (error) {
     console.error('Error in search artists:', error);
-    
+
     if (error instanceof Error && error.message === 'Search timeout') {
       return Response.json(
         { error: "Search timed out. Please try a more specific search term." },
         { status: 408 }
       );
     }
-    
+
     return Response.json(
       { error: "Internal server error" },
       { status: 500 }

--- a/src/server/utils/queries/artistQueries.ts
+++ b/src/server/utils/queries/artistQueries.ts
@@ -1,5 +1,7 @@
 import { db } from "@/server/db/drizzle";
 import { getSpotifyHeaders, getSpotifyArtist } from "@/server/utils/queries/externalApiQueries";
+import { deezerProvider, spotifyProvider } from "@/server/utils/musicPlatform";
+import type { MusicPlatform } from "@/server/utils/musicPlatform";
 import { eq, sql, inArray, and, arrayContains } from "drizzle-orm";
 import { artists, ugcresearch } from "@/server/db/schema";
 import { Artist, UrlMap } from "@/server/db/DbTypes";
@@ -148,7 +150,7 @@ export async function searchForArtistByName(name: string) {
         }
         const result = await db.execute<Artist>(sql`
             SELECT
-            id, name, spotify, bandcamp, youtube, youtubechannel,
+            id, name, spotify, deezer, bandcamp, youtube, youtubechannel,
             instagram, x, facebook, tiktok,
             CASE WHEN lcname LIKE '%' || ${normalisedQuery} || '%' THEN 0 ELSE 1 END AS match_type
             FROM artists
@@ -301,9 +303,9 @@ export async function getArtistLinks(artist: Artist): Promise<ArtistLink[]> {
 // Artist creation & mutation
 // ----------------------------------
 
-export async function addArtist(spotifyId: string): Promise<AddArtistResp> {
+export async function addArtist(platformId: string, platform: MusicPlatform = 'spotify'): Promise<AddArtistResp> {
     try {
-        console.debug("[Server] Starting addArtist for spotifyId:", spotifyId);
+        console.debug(`[Server] Starting addArtist for ${platform}Id:`, platformId);
 
         const headersList = await headers();
         console.debug("[Server] Request headers:", {
@@ -322,29 +324,20 @@ export async function addArtist(spotifyId: string): Promise<AddArtistResp> {
             throw new Error("Not authenticated");
         }
 
-        console.debug("[Server] Getting Spotify headers...");
-        const spotifyHeaders = await getSpotifyHeaders();
-        if (!spotifyHeaders?.headers?.Authorization) {
-            console.error("[Server] Failed to get Spotify headers");
-            return { status: "error", message: "Failed to authenticate with Spotify" };
+        // Validate via platform provider
+        const provider = platform === 'deezer' ? deezerProvider : spotifyProvider;
+        console.debug(`[Server] Validating ${platform} artist...`);
+        const platformArtist = await provider.getArtist(platformId);
+
+        if (!platformArtist?.name) {
+            console.error(`[Server] Invalid artist data from ${platform}`);
+            return { status: "error", message: `Could not find artist on ${platform}` };
         }
 
-        console.debug("[Server] Fetching Spotify artist data...");
-        const spotifyArtist = await getSpotifyArtist(spotifyId, spotifyHeaders);
-        console.debug("[Server] Spotify artist response:", spotifyArtist);
-
-        if (spotifyArtist.error) {
-            console.error("[Server] Spotify artist error:", spotifyArtist.error);
-            return { status: "error", message: spotifyArtist.error };
-        }
-
-        if (!spotifyArtist.data?.name) {
-            console.error("[Server] Invalid artist data received from Spotify");
-            return { status: "error", message: "Invalid artist data received from Spotify" };
-        }
-
+        // Dedup check on the appropriate column
+        const column = platform === 'deezer' ? artists.deezer : artists.spotify;
         console.debug("[Server] Checking if artist exists in database...");
-        const artist = await db.query.artists.findFirst({ where: eq(artists.spotify, spotifyId) });
+        const artist = await db.query.artists.findFirst({ where: eq(column, platformId) });
         if (artist) {
             console.debug("[Server] Artist already exists:", artist);
             return {
@@ -357,9 +350,9 @@ export async function addArtist(spotifyId: string): Promise<AddArtistResp> {
 
         console.debug("[Server] Inserting new artist into database...");
         const artistData = {
-            spotify: spotifyId,
-            lcname: normaliseText(spotifyArtist.data.name),
-            name: spotifyArtist.data.name,
+            [platform]: platformId,
+            lcname: normaliseText(platformArtist.name),
+            name: platformArtist.name,
             addedBy: session?.user?.id || undefined,
         };
 
@@ -370,7 +363,7 @@ export async function addArtist(spotifyId: string): Promise<AddArtistResp> {
             const user = await getUserById(session.user.id);
             if (user) {
                 await sendDiscordMessage(
-                    `${getUserDisplayName(user)} added new artist named: ${newArtist.name} (Submitted SpotifyId: ${spotifyId}) ${newArtist.createdAt}`
+                    `${getUserDisplayName(user)} added new artist named: ${newArtist.name} (Submitted ${platform}Id: ${platformId}) ${newArtist.createdAt}`
                 );
             }
         }

--- a/src/server/utils/queries/artistQueries.ts
+++ b/src/server/utils/queries/artistQueries.ts
@@ -304,6 +304,9 @@ export async function getArtistLinks(artist: Artist): Promise<ArtistLink[]> {
 // ----------------------------------
 
 export async function addArtist(platformId: string, platform: MusicPlatform = 'spotify'): Promise<AddArtistResp> {
+    if (platform !== 'deezer' && platform !== 'spotify') {
+        return { status: "error", message: "Invalid platform" };
+    }
     try {
         console.debug(`[Server] Starting addArtist for ${platform}Id:`, platformId);
 


### PR DESCRIPTION
## Summary

Migrates the search and add-artist flows from Spotify API to the musicPlatformData abstraction (Deezer primary, Spotify fallback). This is Phase 4 of the Deezer cutover plan.

**Search route migration:**
- External search results now come from Deezer via `musicPlatformData.searchArtists()`
- DB artist image enrichment via `musicPlatformData.getArtistImages()` (individual Deezer calls, 24h cached)
- Dedup external results against DB `artists.deezer` column
- Result shape: `isSpotifyOnly` → `isExternalOnly`, added `platformId`, `platform`, `profileUrl`, `imageUrl`
- Removed axios dependency and all Spotify interfaces from this route

**SearchBar UI:**
- "View on Spotify" → dynamic "View on Deezer" with correct profile URL
- Session storage keys renamed from Spotify-specific to platform-agnostic
- `handleAddArtist` passes `(platformId, platform)` to server action

**AddArtist dialog:**
- Accepts both Deezer and Spotify URLs
- Deezer regex: `/https?:\/\/(www\.)?deezer\.com\/([\w-]+\/)?artist\/(\d+)/`
- Form field renamed: `artistSpotifyUrl` → `artistUrl`

**addArtist server action + DB query:**
- `addArtist(platformId, platform = 'spotify')` — backward compatible
- Validates via `deezerProvider.getArtist()` or `spotifyProvider.getArtist()`
- Dedup + insert on appropriate column (`artists.deezer` or `artists.spotify`)
- `searchForArtistByName` now includes `deezer` in SELECT

**add-artist page:**
- Accepts `?deezer=ID` or `?spotify=ID` query params
- `AddArtistContent` uses `MusicPlatformArtist` type (platform-agnostic)
- "followers on Spotify" → "followers"

**Known risks:**
- Only ~390/41971 artists have `deezer` column populated, so most Deezer search results show as addable external results
- Deezer search recall may differ from Spotify for some queries
- Image enrichment latency slightly higher (individual calls vs batch)

## Test plan
- [x] Type check passes
- [x] Lint passes (pre-existing warnings only)
- [x] 96 test suites / 992 tests pass
- [x] Build succeeds
- [x] searchArtists test updated for musicPlatformData mocks
- [x] SearchBarAddArtist test updated for platform-aware fixtures
- [x] AddArtist test includes Deezer URL test case
- [x] addArtist action test covers both platforms
- [x] url-params test covers ?deezer=ID param
- [x] protected-routes test updated for musicPlatformData mocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)