### PR TITLE
feat: Phase 5 — MCP + API Deezer awareness (keep Spotify fallback)

### DIFF
--- a/docs/deezer-cutover-plan.md
+++ b/docs/deezer-cutover-plan.md
@@ -295,30 +295,35 @@ const numReleases = data?.albumCount ?? 0;
 
 ---
 
-## Phase 5: Spotify API Removal
+## Phase 5: MCP + API Updates for Deezer Migration
 
-**Goal**: Delete Spotify API code. `ArtistMusicPlatformDataProvider` becomes a thin wrapper around DeezerProvider only.
+**Goal**: Update MCP tools and API routes so external consumers (agents, tools) are Deezer-aware. Keep Spotify fallback to let Deezer bake in production.
 
-### Files to remove/modify
+**NOT in this phase**: Spotify API removal. SpotifyProvider, externalApiQueries.ts, and all fallback paths stay until Deezer stability is confirmed.
+
+### Files to create/modify
 
 | File | Change |
 |------|--------|
-| `src/server/utils/queries/externalApiQueries.ts` | Delete entirely. |
-| `src/server/utils/queries/wikiQueries.ts` | **Create** — move `getArtistWiki` here from `externalApiQueries.ts`. Update all imports. |
-| `src/server/utils/musicPlatform/spotifyProvider.ts` | Delete |
-| `src/server/utils/musicPlatform/artistMusicPlatformDataProvider.ts` | Remove fallback paths (only DeezerProvider remains) |
-| `src/env.ts` | Remove `SPOTIFY_WEB_CLIENT_ID`, `SPOTIFY_WEB_CLIENT_SECRET` |
-| `src/app/api/getSpotifyData/route.ts` | Delete |
-| `package.json` | Remove `querystring` (audit usage in Phase 4 so Phase 5 is purely mechanical) |
-| `CLAUDE.md` | Update tech stack, env vars, API docs |
-| ~10 test files | Remove Spotify mocks |
+| `src/app/api/mcp/types.ts` | Add `deezerId: string \| null` to `ArtistDetail` interface |
+| `src/app/api/mcp/transformers/artist-detail.ts` | Return `deezerId: artist.deezer ?? null` alongside existing `spotifyId` |
+| `src/server/utils/idMappingService.ts` | `getUnmappedArtists`: add `basePlatform` param (default `'spotify'`). When `'deezer'`, use `WHERE a.deezer IS NOT NULL`. Return both `spotify` and `deezer` fields. `getMappingStats`: add `totalArtistsWithDeezer` count alongside existing `totalArtistsWithSpotify`. |
+| `src/app/api/mcp/server.ts` | Update `get_unmapped_artists` tool: add optional `basePlatform` input param. Update description. |
+| `src/app/api/findArtistByDeezerID/route.ts` | **Create** — mirror `findArtistBySpotifyID` pattern, query on `artists.deezer` column |
+| `src/app/api/mcp/__tests__/transformers.test.ts` | Assert `deezerId` in ArtistDetail output |
+| `src/app/api/mcp/__tests__/get-unmapped-artists.test.ts` | Test `basePlatform: 'deezer'` |
+| `src/app/api/mcp/__tests__/get-mapping-stats.test.ts` | Assert `totalArtistsWithDeezer` |
+| `src/app/api/findArtistByDeezerID/__tests__/route.test.ts` | **Create** — mirror findArtistBySpotifyID tests |
 
-### Keep
-- `artists.spotify` column — artist metadata (we know everything about an artist)
-- `artists.spotifyusername` — platform link field
-- `src/app/api/findArtistBySpotifyID/route.ts` — backwards compat
-- `src/app/api/findArtistByDeezerID/route.ts` — **Create** new route mirroring `findArtistBySpotifyID` but querying on `artists.deezer`. External tools/agents will need this since Deezer is now the primary platform.
-- MCP transformer: expose both `spotifyId` and `deezerId`
+### Deferred to Phase 6 (Spotify API Removal)
+
+Only after Deezer stability is confirmed in production:
+- Delete `externalApiQueries.ts`, `spotifyProvider.ts`, `getSpotifyData/route.ts`
+- Move `getArtistWiki` to `wikiQueries.ts`
+- Remove Spotify env vars from `env.ts`
+- Simplify `ArtistMusicPlatformDataProvider` (remove fallback paths)
+- Remove `querystring` package
+- Update CLAUDE.md tech stack
 
 ---
 

--- a/src/app/api/findArtistByDeezerID/__tests__/route.test.ts
+++ b/src/app/api/findArtistByDeezerID/__tests__/route.test.ts
@@ -1,0 +1,74 @@
+import '@/test/setup/testEnv';
+import { POST } from '../route';
+import { getArtistByProperty } from '@/server/utils/queries/artistQueries';
+import { artists } from '@/server/db/schema';
+
+jest.mock('@/server/utils/queries/artistQueries');
+
+if (typeof (Response as any).json !== 'function') {
+  (Response as any).json = (data: any, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), {
+      ...init,
+      headers: { 'Content-Type': 'application/json', ...(init?.headers || {}) },
+    });
+}
+
+function createTestRequest(body: any = {}, method: string = 'POST') {
+  const init: RequestInit = {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+  };
+  if (method !== 'GET' && method !== 'HEAD') {
+    init.body = JSON.stringify(body);
+  }
+  return new Request('http://localhost/api/findArtistByDeezerID', init);
+}
+
+describe('findArtistByDeezerID API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 405 for non-POST requests', async () => {
+    const res = await POST(createTestRequest({}, 'GET'));
+    expect(res.status).toBe(405);
+    const text = await res.text();
+    expect(text).toBe('Method not allowed');
+  });
+
+  it('returns 400 when deezerID is missing', async () => {
+    const res = await POST(createTestRequest({}));
+    expect(res.status).toBe(400);
+    const text = await res.text();
+    expect(text).toContain('Missing or invalid required parameters: deezerID');
+  });
+
+  it('returns artist data when found', async () => {
+    (getArtistByProperty as jest.Mock).mockResolvedValue({
+      status: 200,
+      data: { id: '1', name: 'David Morales', deezer: '11600' },
+      message: '',
+      isError: false,
+    });
+
+    const res = await POST(createTestRequest({ deezerID: '11600' }));
+    expect(getArtistByProperty).toHaveBeenCalledWith(artists.deezer, '11600');
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ result: { id: '1', name: 'David Morales', deezer: '11600' } });
+  });
+
+  it('propagates error status and message from getArtistByProperty', async () => {
+    (getArtistByProperty as jest.Mock).mockResolvedValue({
+      status: 404,
+      data: null,
+      message: 'not found',
+      isError: true,
+    });
+
+    const res = await POST(createTestRequest({ deezerID: '99999' }));
+    expect(res.status).toBe(404);
+    const text = await res.text();
+    expect(text).toBe('not found');
+  });
+});

--- a/src/app/api/findArtistByDeezerID/route.ts
+++ b/src/app/api/findArtistByDeezerID/route.ts
@@ -1,6 +1,8 @@
 import { getArtistByProperty } from '@/server/utils/queries/artistQueries';
 import { artists } from '@/server/db/schema';
 
+export const dynamic = "force-dynamic";
+
 async function handler(req: Request) {
   if (req.method !== 'POST') {
     return new Response('Method not allowed', {status : 405});

--- a/src/app/api/findArtistByDeezerID/route.ts
+++ b/src/app/api/findArtistByDeezerID/route.ts
@@ -1,0 +1,21 @@
+import { getArtistByProperty } from '@/server/utils/queries/artistQueries';
+import { artists } from '@/server/db/schema';
+
+async function handler(req: Request) {
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', {status : 405});
+  }
+
+  const {deezerID} = await req.json();
+
+  if (typeof deezerID !== 'string') {
+    return new Response('Missing or invalid required parameters: deezerID', {status : 400});
+  }
+
+  const artistResp = await getArtistByProperty(artists.deezer, deezerID);
+  if(artistResp.status === 200) return Response.json({ result : artistResp.data });
+
+  return new Response(artistResp.message, {status : artistResp.status});
+}
+
+export { handler as POST }

--- a/src/app/api/mcp/__tests__/get-mapping-stats.test.ts
+++ b/src/app/api/mcp/__tests__/get-mapping-stats.test.ts
@@ -5,7 +5,7 @@ import { jest } from "@jest/globals";
 jest.mock("@/server/utils/idMappingService", () => ({
   getUnmappedArtists: jest.fn(),
   resolveArtistMapping: jest.fn(),
-  getMappingStats: jest.fn().mockResolvedValue({ totalArtistsWithSpotify: 0, platformStats: [] }),
+  getMappingStats: jest.fn().mockResolvedValue({ totalArtistsWithSpotify: 0, totalArtistsWithDeezer: 0, platformStats: [] }),
   getArtistMappings: jest.fn(),
   VALID_MAPPING_PLATFORMS: new Set(["deezer", "apple_music", "musicbrainz", "wikidata", "tidal", "amazon_music", "youtube_music"]),
   VALID_SOURCES: new Set(["wikidata", "musicbrainz", "name_search", "manual"]),
@@ -49,6 +49,7 @@ describe("get_mapping_stats MCP tool", () => {
     const s = await setup();
     (s.getMappingStats as jest.Mock).mockResolvedValue({
       totalArtistsWithSpotify: 1000,
+      totalArtistsWithDeezer: 390,
       platformStats: [
         { platform: "deezer", mappedCount: 500, percentage: 50 },
         { platform: "apple_music", mappedCount: 300, percentage: 30 },
@@ -58,6 +59,7 @@ describe("get_mapping_stats MCP tool", () => {
     const result = await callTool(s);
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.totalArtistsWithSpotify).toBe(1000);
+    expect(parsed.totalArtistsWithDeezer).toBe(390);
     expect(parsed.platformStats).toHaveLength(2);
     expect(parsed.platformStats[0].platform).toBe("deezer");
     expect(parsed.platformStats[0].mappedCount).toBe(500);

--- a/src/app/api/mcp/__tests__/get-unmapped-artists.test.ts
+++ b/src/app/api/mcp/__tests__/get-unmapped-artists.test.ts
@@ -99,4 +99,17 @@ describe("get_unmapped_artists MCP tool", () => {
     expect(parsed.artists).toEqual([]);
     expect(parsed.totalUnmapped).toBe(0);
   });
+
+  it("passes basePlatform 'deezer' to getUnmappedArtists", async () => {
+    const s = await setup();
+    (s.getUnmappedArtists as jest.Mock).mockResolvedValue({
+      artists: [{ id: "a1", name: "Test", spotify: null, deezer: "11600" }],
+      totalUnmapped: 1,
+    });
+
+    const result = await callTool(s, { platform: "apple_music", limit: 10, offset: 0, basePlatform: "deezer" });
+    expect(s.getUnmappedArtists).toHaveBeenCalledWith("apple_music", 10, 0, "deezer");
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.artists[0].deezer).toBe("11600");
+  });
 });

--- a/src/app/api/mcp/__tests__/get-unmapped-artists.test.ts
+++ b/src/app/api/mcp/__tests__/get-unmapped-artists.test.ts
@@ -76,7 +76,7 @@ describe("get_unmapped_artists MCP tool", () => {
     (s.getUnmappedArtists as jest.Mock).mockResolvedValue({ artists: [], totalUnmapped: 100 });
 
     const result = await callTool(s, { platform: "deezer", limit: 25, offset: 50 });
-    expect(s.getUnmappedArtists).toHaveBeenCalledWith("deezer", 25, 50);
+    expect(s.getUnmappedArtists).toHaveBeenCalledWith("deezer", 25, 50, "spotify");
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.limit).toBe(25);
     expect(parsed.offset).toBe(50);
@@ -87,7 +87,7 @@ describe("get_unmapped_artists MCP tool", () => {
     (s.getUnmappedArtists as jest.Mock).mockResolvedValue({ artists: [], totalUnmapped: 0 });
 
     await callTool(s, { platform: "deezer", limit: 500, offset: 0 });
-    expect(s.getUnmappedArtists).toHaveBeenCalledWith("deezer", 200, 0);
+    expect(s.getUnmappedArtists).toHaveBeenCalledWith("deezer", 200, 0, "spotify");
   });
 
   it("returns empty array when all mapped", async () => {

--- a/src/app/api/mcp/__tests__/transformers.test.ts
+++ b/src/app/api/mcp/__tests__/transformers.test.ts
@@ -207,6 +207,7 @@ describe("toArtistDetail", () => {
       expect(result.name).toBe("Social Artist");
       expect(result.bio).toBe("Artist biography here");
       expect(result.spotifyId).toBe("spotify456");
+      expect(result.deezerId).toBeNull();
 
       expect(result.socialLinks).toHaveProperty("spotify");
       expect(result.socialLinks.spotify).toEqual({
@@ -364,6 +365,36 @@ describe("toArtistDetail", () => {
       const result = await toArtistDetail(artist);
 
       expect(result.spotifyId).toBeNull();
+    });
+  });
+
+  describe("maps deezerId from artist.deezer", () => {
+    it("returns deezerId from the deezer column", async () => {
+      const artist = createMockArtist({
+        id: "deezer-artist",
+        name: "Deezer Artist",
+        deezer: "11600",
+      });
+
+      mockedGetArtistLinks.mockResolvedValue([]);
+
+      const result = await toArtistDetail(artist);
+
+      expect(result.deezerId).toBe("11600");
+    });
+
+    it("returns null for deezerId when artist.deezer is null", async () => {
+      const artist = createMockArtist({
+        id: "no-deezer-artist",
+        name: "No Deezer Artist",
+        deezer: null,
+      });
+
+      mockedGetArtistLinks.mockResolvedValue([]);
+
+      const result = await toArtistDetail(artist);
+
+      expect(result.deezerId).toBeNull();
     });
   });
 });

--- a/src/app/api/mcp/server.ts
+++ b/src/app/api/mcp/server.ts
@@ -327,21 +327,23 @@ server.registerTool(
   "get_unmapped_artists",
   {
     title: "Get Unmapped Artists",
-    description: "Get artists that have a Spotify ID but no mapping for a given platform. Use this to find artists that need cross-platform ID resolution.",
+    description: "Get artists that have a platform ID but no mapping for a given target platform. Use basePlatform to select the source (default: spotify, use 'deezer' for Deezer-primary workflows).",
     inputSchema: {
       platform: z.string().describe("The target platform to check for missing mappings (e.g. deezer, apple_music, musicbrainz, wikidata, tidal, amazon_music, youtube_music)"),
       limit: z.number().optional().default(50).describe("Maximum number of results to return (default 50, max 200)"),
       offset: z.number().optional().default(0).describe("Offset for pagination (default 0)"),
+      basePlatform: z.enum(["spotify", "deezer"]).optional().default("spotify").describe("Which platform ID to require on source artists (default: spotify). Use 'deezer' to find artists with Deezer IDs that lack mappings."),
     },
   },
-  async ({ platform, limit, offset }) => {
-    console.log(`[MCP] get_unmapped_artists called with platform="${platform}", limit=${limit}, offset=${offset}`);
+  async ({ platform, limit, offset, basePlatform }) => {
+    console.log(`[MCP] get_unmapped_artists called with platform="${platform}", basePlatform="${basePlatform}", limit=${limit}, offset=${offset}`);
 
     try {
       const effectiveLimit = Math.min(Math.max(limit ?? 50, 1), 200);
       const effectiveOffset = Math.max(offset ?? 0, 0);
 
-      const result = await getUnmappedArtists(platform, effectiveLimit, effectiveOffset);
+      const effectiveBasePlatform = (basePlatform === 'deezer' ? 'deezer' : 'spotify') as 'spotify' | 'deezer';
+      const result = await getUnmappedArtists(platform, effectiveLimit, effectiveOffset, effectiveBasePlatform);
 
       return {
         content: [{

--- a/src/app/api/mcp/transformers/artist-detail.ts
+++ b/src/app/api/mcp/transformers/artist-detail.ts
@@ -31,6 +31,7 @@ export async function toArtistDetail(artist: Artist): Promise<ArtistDetail> {
     name: artist.name ?? "",
     bio: artist.bio ?? null,
     spotifyId: artist.spotify ?? null,
+    deezerId: artist.deezer ?? null,
     socialLinks,
   };
 }

--- a/src/app/api/mcp/types.ts
+++ b/src/app/api/mcp/types.ts
@@ -13,6 +13,7 @@ export interface ArtistDetail {
   name: string;
   bio: string | null;
   spotifyId: string | null;
+  deezerId: string | null;
   socialLinks: Record<string, SocialLink>;
 }
 

--- a/src/server/utils/__tests__/idMappingService.test.ts
+++ b/src/server/utils/__tests__/idMappingService.test.ts
@@ -225,10 +225,12 @@ describe("idMappingService", () => {
     const { db, getMappingStats } = await setup();
     (db as any).execute = jest.fn()
       .mockResolvedValueOnce([{ total: 100 }])
+      .mockResolvedValueOnce([{ total: 390 }])
       .mockResolvedValueOnce([{ platform: "deezer", mapped_count: 50 }]);
 
     const stats = await getMappingStats();
     expect(stats.totalArtistsWithSpotify).toBe(100);
+    expect(stats.totalArtistsWithDeezer).toBe(390);
     // All valid platforms should be present
     expect(stats.platformStats).toHaveLength(11);
     const deezer = stats.platformStats.find(s => s.platform === "deezer");

--- a/src/server/utils/idMappingService.ts
+++ b/src/server/utils/idMappingService.ts
@@ -74,16 +74,21 @@ export async function getUnmappedArtists(
   platform: string,
   limit: number,
   offset: number,
-): Promise<{ artists: { id: string; name: string | null; spotify: string | null }[]; totalUnmapped: number }> {
+  basePlatform: 'spotify' | 'deezer' = 'spotify',
+): Promise<{ artists: { id: string; name: string | null; spotify: string | null; deezer: string | null }[]; totalUnmapped: number }> {
   if (!VALID_MAPPING_PLATFORMS.has(platform)) {
     throw new MappingValidationError(`Invalid platform: ${platform}`);
   }
+
+  const baseFilter = basePlatform === 'deezer'
+    ? sql`a.deezer IS NOT NULL`
+    : sql`a.spotify IS NOT NULL`;
 
   const [countResult, result] = await Promise.all([
     db.execute<{ total: number }>(sql`
       SELECT COUNT(*)::int AS total
       FROM artists a
-      WHERE a.spotify IS NOT NULL
+      WHERE ${baseFilter}
         AND NOT EXISTS (
           SELECT 1 FROM artist_id_mappings m
           WHERE m.artist_id = a.id AND m.platform = ${platform}
@@ -93,10 +98,10 @@ export async function getUnmappedArtists(
           WHERE e.artist_id = a.id AND e.platform = ${platform}
         )
     `),
-    db.execute<{ id: string; name: string | null; spotify: string | null }>(sql`
-      SELECT a.id, a.name, a.spotify
+    db.execute<{ id: string; name: string | null; spotify: string | null; deezer: string | null }>(sql`
+      SELECT a.id, a.name, a.spotify, a.deezer
       FROM artists a
-      WHERE a.spotify IS NOT NULL
+      WHERE ${baseFilter}
         AND NOT EXISTS (
           SELECT 1 FROM artist_id_mappings m
           WHERE m.artist_id = a.id AND m.platform = ${platform}
@@ -206,11 +211,15 @@ export async function resolveArtistMapping(params: {
 
 export async function getMappingStats(): Promise<{
   totalArtistsWithSpotify: number;
+  totalArtistsWithDeezer: number;
   platformStats: { platform: string; mappedCount: number; percentage: number }[];
 }> {
-  const [totalResult, statsResult] = await Promise.all([
+  const [totalResult, totalDeezerResult, statsResult] = await Promise.all([
     db.execute<{ total: number }>(sql`
       SELECT COUNT(*)::int AS total FROM artists WHERE spotify IS NOT NULL
+    `),
+    db.execute<{ total: number }>(sql`
+      SELECT COUNT(*)::int AS total FROM artists WHERE deezer IS NOT NULL
     `),
     db.execute<{ platform: string; mapped_count: number }>(sql`
       SELECT platform, COUNT(*)::int AS mapped_count
@@ -221,6 +230,7 @@ export async function getMappingStats(): Promise<{
   ]);
 
   const totalArtistsWithSpotify = totalResult[0]?.total ?? 0;
+  const totalArtistsWithDeezer = totalDeezerResult[0]?.total ?? 0;
 
   // Build a map of DB results, then ensure all valid platforms are represented
   const dbStats = new Map([...statsResult].map(row => [row.platform, row.mapped_count]));
@@ -235,7 +245,7 @@ export async function getMappingStats(): Promise<{
     };
   });
 
-  return { totalArtistsWithSpotify, platformStats };
+  return { totalArtistsWithSpotify, totalArtistsWithDeezer, platformStats };
 }
 
 export async function getArtistMappings(artistId: string) {


### PR DESCRIPTION
## Summary

Updates MCP tools and API routes so external consumers (agents, tools) are Deezer-aware. Keeps Spotify fallback to let Deezer bake in production.

**MCP changes:**
- `get_artist` response now includes `deezerId` alongside `spotifyId`
- `get_unmapped_artists` accepts optional `basePlatform` param (`'spotify'` default, `'deezer'` for Deezer-primary workflows)
- `get_mapping_stats` returns `totalArtistsWithDeezer` alongside `totalArtistsWithSpotify`

**New API route:**
- `POST /api/findArtistByDeezerID` — mirrors `findArtistBySpotifyID` pattern, queries `artists.deezer` column

**Plan update:**
- Phase 5 revised to MCP/API updates (not Spotify removal)
- Spotify removal deferred to Phase 6 after Deezer stability is confirmed

## Test plan
- [x] Type check passes
- [x] Lint passes (pre-existing warnings only)
- [x] 96 test suites / 992 tests pass
- [x] Build succeeds
- [x] idMappingService test updated for 3-query getMappingStats mock
- [x] get-unmapped-artists test updated for basePlatform param

🤖 Generated with [Claude Code](https://claude.com/claude-code)