### PR TITLE
feat: Artist Vault gallery, bio versioning, og:image thumbnails

### DIFF
--- a/drizzle/0007_confused_blonde_phantom.sql
+++ b/drizzle/0007_confused_blonde_phantom.sql
@@ -8,7 +8,7 @@ CREATE TABLE "artist_bio_versions" (
 --> statement-breakpoint
 ALTER TABLE "artist_bio_versions" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
 ALTER TABLE "artist_vault_sources" ADD COLUMN "og_image" text;--> statement-breakpoint
-ALTER TABLE "artist_bio_versions" ADD CONSTRAINT "artist_bio_versions_artist_id_fkey" FOREIGN KEY ("artist_id") REFERENCES "public"."artists"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "artist_bio_versions" ADD CONSTRAINT "artist_bio_versions_artist_id_fkey" FOREIGN KEY ("artist_id") REFERENCES "public"."artists"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "idx_artist_bio_versions_artist_id" ON "artist_bio_versions" USING btree ("artist_id" uuid_ops);--> statement-breakpoint
 CREATE POLICY "mnweb_select_artist_bio_versions" ON "artist_bio_versions" AS PERMISSIVE FOR SELECT TO "mnweb" USING (true);--> statement-breakpoint
 CREATE POLICY "mnweb_insert_artist_bio_versions" ON "artist_bio_versions" AS PERMISSIVE FOR INSERT TO "mnweb";--> statement-breakpoint

--- a/drizzle/0007_confused_blonde_phantom.sql
+++ b/drizzle/0007_confused_blonde_phantom.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "artist_bio_versions" (
+	"id" uuid PRIMARY KEY DEFAULT uuid_generate_v4() NOT NULL,
+	"artist_id" uuid NOT NULL,
+	"bio_text" text NOT NULL,
+	"is_pinned" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT (now() AT TIME ZONE 'utc'::text) NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "artist_bio_versions" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "artist_vault_sources" ADD COLUMN "og_image" text;--> statement-breakpoint
+ALTER TABLE "artist_bio_versions" ADD CONSTRAINT "artist_bio_versions_artist_id_fkey" FOREIGN KEY ("artist_id") REFERENCES "public"."artists"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_artist_bio_versions_artist_id" ON "artist_bio_versions" USING btree ("artist_id" uuid_ops);--> statement-breakpoint
+CREATE POLICY "mnweb_select_artist_bio_versions" ON "artist_bio_versions" AS PERMISSIVE FOR SELECT TO "mnweb" USING (true);--> statement-breakpoint
+CREATE POLICY "mnweb_insert_artist_bio_versions" ON "artist_bio_versions" AS PERMISSIVE FOR INSERT TO "mnweb";--> statement-breakpoint
+CREATE POLICY "mnweb_update_artist_bio_versions" ON "artist_bio_versions" AS PERMISSIVE FOR UPDATE TO "mnweb";--> statement-breakpoint
+CREATE POLICY "mnweb_delete_artist_bio_versions" ON "artist_bio_versions" AS PERMISSIVE FOR DELETE TO "mnweb" USING (true);

--- a/drizzle/0008_third_terrax.sql
+++ b/drizzle/0008_third_terrax.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "artist_bio_versions" DROP CONSTRAINT "artist_bio_versions_artist_id_fkey";
+--> statement-breakpoint
+ALTER TABLE "artist_bio_versions" ADD CONSTRAINT "artist_bio_versions_artist_id_fkey" FOREIGN KEY ("artist_id") REFERENCES "public"."artists"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,3258 @@
+{
+  "id": "fe03b9e3-9bef-43da-830b-04b6b7fc35f2",
+  "prevId": "1fe38ca4-00fd-49cf-a0c4-ae578e4fc73a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_heartbeats": {
+      "name": "agent_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starting'"
+        },
+        "current_run": {
+          "name": "current_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_platform": {
+          "name": "batch_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_size": {
+          "name": "batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_heartbeats_updated_at": {
+          "name": "idx_agent_heartbeats_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_heartbeats_worker_id_unique": {
+          "name": "agent_heartbeats_worker_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "worker_id"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_select_agent_heartbeats": {
+          "name": "mnweb_select_agent_heartbeats",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_agent_heartbeats": {
+          "name": "mnweb_insert_agent_heartbeats",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        },
+        "mnweb_update_agent_heartbeats": {
+          "name": "mnweb_update_agent_heartbeats",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_number": {
+          "name": "run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deezer'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wall_time_secs": {
+          "name": "wall_time_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claude_time_secs": {
+          "name": "claude_time_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_time_secs": {
+          "name": "api_time_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turns": {
+          "name": "turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_size": {
+          "name": "batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "excluded": {
+          "name": "excluded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "high_confidence": {
+          "name": "high_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "medium_confidence": {
+          "name": "medium_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "conflicts": {
+          "name": "conflicts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "name_mismatches": {
+          "name": "name_mismatches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "too_ambiguous": {
+          "name": "too_ambiguous",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fail_category": {
+          "name": "fail_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fail_reason": {
+          "name": "fail_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_worker_run": {
+          "name": "idx_agent_runs_worker_run",
+          "columns": [
+            {
+              "expression": "worker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_started_at": {
+          "name": "idx_agent_runs_started_at",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_select_agent_runs": {
+          "name": "mnweb_select_agent_runs",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_agent_runs": {
+          "name": "mnweb_insert_agent_runs",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        },
+        "mnweb_update_agent_runs": {
+          "name": "mnweb_update_agent_runs",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.aiprompts": {
+      "name": "aiprompts",
+      "schema": "",
+      "columns": {
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_before_name": {
+          "name": "prompt_before_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "prompt_after_name": {
+          "name": "prompt_after_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_delete_aiprompts": {
+          "name": "mnweb_delete_aiprompts",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_aiprompts": {
+          "name": "mnweb_insert_aiprompts",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_aiprompts": {
+          "name": "mnweb_select_aiprompts",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_aiprompts": {
+          "name": "mnweb_update_aiprompts",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_bio_versions": {
+      "name": "artist_bio_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio_text": {
+          "name": "bio_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        }
+      },
+      "indexes": {
+        "idx_artist_bio_versions_artist_id": {
+          "name": "idx_artist_bio_versions_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_bio_versions_artist_id_fkey": {
+          "name": "artist_bio_versions_artist_id_fkey",
+          "tableFrom": "artist_bio_versions",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_select_artist_bio_versions": {
+          "name": "mnweb_select_artist_bio_versions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_artist_bio_versions": {
+          "name": "mnweb_insert_artist_bio_versions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_artist_bio_versions": {
+          "name": "mnweb_update_artist_bio_versions",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_delete_artist_bio_versions": {
+          "name": "mnweb_delete_artist_bio_versions",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_claims": {
+      "name": "artist_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reference_code": {
+          "name": "reference_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        }
+      },
+      "indexes": {
+        "idx_artist_claims_user_id": {
+          "name": "idx_artist_claims_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artist_claims_artist_id": {
+          "name": "idx_artist_claims_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_claims_user_id_fkey": {
+          "name": "artist_claims_user_id_fkey",
+          "tableFrom": "artist_claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artist_claims_artist_id_fkey": {
+          "name": "artist_claims_artist_id_fkey",
+          "tableFrom": "artist_claims",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artist_claims_artist_id_key": {
+          "name": "artist_claims_artist_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "artist_id"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_delete_artist_claims": {
+          "name": "mnweb_delete_artist_claims",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_artist_claims": {
+          "name": "mnweb_insert_artist_claims",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_artist_claims": {
+          "name": "mnweb_select_artist_claims",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_artist_claims": {
+          "name": "mnweb_update_artist_claims",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_id_mappings": {
+      "name": "artist_id_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "confidence_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_artist_id_mappings_platform_artist": {
+          "name": "idx_artist_id_mappings_platform_artist",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artist_id_mappings_confidence": {
+          "name": "idx_artist_id_mappings_confidence",
+          "columns": [
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_id_mappings_artist_id_fkey": {
+          "name": "artist_id_mappings_artist_id_fkey",
+          "tableFrom": "artist_id_mappings",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artist_id_mappings_artist_platform_uniq": {
+          "name": "artist_id_mappings_artist_platform_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "artist_id",
+            "platform"
+          ]
+        },
+        "artist_id_mappings_platform_id_uniq": {
+          "name": "artist_id_mappings_platform_id_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "platform",
+            "platform_id"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_select_artist_id_mappings": {
+          "name": "mnweb_select_artist_id_mappings",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_artist_id_mappings": {
+          "name": "mnweb_insert_artist_id_mappings",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        },
+        "mnweb_update_artist_id_mappings": {
+          "name": "mnweb_update_artist_id_mappings",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_mapping_exclusions": {
+      "name": "artist_mapping_exclusions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "exclusion_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_artist_mapping_exclusions_platform": {
+          "name": "idx_artist_mapping_exclusions_platform",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_mapping_exclusions_artist_id_fkey": {
+          "name": "artist_mapping_exclusions_artist_id_fkey",
+          "tableFrom": "artist_mapping_exclusions",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artist_mapping_exclusions_artist_platform_uniq": {
+          "name": "artist_mapping_exclusions_artist_platform_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "artist_id",
+            "platform"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_select_artist_mapping_exclusions": {
+          "name": "mnweb_select_artist_mapping_exclusions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_artist_mapping_exclusions": {
+          "name": "mnweb_insert_artist_mapping_exclusions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        },
+        "mnweb_update_artist_mapping_exclusions": {
+          "name": "mnweb_update_artist_mapping_exclusions",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_vault_sources": {
+      "name": "artist_vault_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "source_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image": {
+          "name": "og_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        }
+      },
+      "indexes": {
+        "idx_artist_vault_sources_artist_id": {
+          "name": "idx_artist_vault_sources_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_vault_sources_artist_id_fkey": {
+          "name": "artist_vault_sources_artist_id_fkey",
+          "tableFrom": "artist_vault_sources",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_delete_artist_vault_sources": {
+          "name": "mnweb_delete_artist_vault_sources",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_artist_vault_sources": {
+          "name": "mnweb_insert_artist_vault_sources",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_artist_vault_sources": {
+          "name": "mnweb_select_artist_vault_sources",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_artist_vault_sources": {
+          "name": "mnweb_update_artist_vault_sources",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artists": {
+      "name": "artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp": {
+          "name": "bandcamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facebook": {
+          "name": "facebook",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud": {
+          "name": "soundcloud",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patreon": {
+          "name": "patreon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram": {
+          "name": "instagram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube": {
+          "name": "youtube",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtubechannel": {
+          "name": "youtubechannel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lcname": {
+          "name": "lcname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloudID": {
+          "name": "soundcloudID",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify": {
+          "name": "spotify",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitch": {
+          "name": "twitch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imdb": {
+          "name": "imdb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz": {
+          "name": "musicbrainz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata": {
+          "name": "wikidata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mixcloud": {
+          "name": "mixcloud",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facebookID": {
+          "name": "facebookID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs": {
+          "name": "discogs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tiktok": {
+          "name": "tiktok",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tiktokID": {
+          "name": "tiktokID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jaxsta": {
+          "name": "jaxsta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "famousbirthdays": {
+          "name": "famousbirthdays",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "songexploder": {
+          "name": "songexploder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "colorsxstudios": {
+          "name": "colorsxstudios",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandsintown": {
+          "name": "bandsintown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linktree": {
+          "name": "linktree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onlyfans": {
+          "name": "onlyfans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikipedia": {
+          "name": "wikipedia",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audius": {
+          "name": "audius",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zora": {
+          "name": "zora",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catalog": {
+          "name": "catalog",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opensea": {
+          "name": "opensea",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "foundation": {
+          "name": "foundation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastfm": {
+          "name": "lastfm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundxyz": {
+          "name": "soundxyz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror": {
+          "name": "mirror",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "glassnode": {
+          "name": "glassnode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collectsNFTs": {
+          "name": "collectsNFTs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotifyusername": {
+          "name": "spotifyusername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcampfan": {
+          "name": "bandcampfan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tellie": {
+          "name": "tellie",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallets": {
+          "name": "wallets",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ens": {
+          "name": "ens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens": {
+          "name": "lens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cameo": {
+          "name": "cameo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "farcaster": {
+          "name": "farcaster",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "supercollector": {
+          "name": "supercollector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_image": {
+          "name": "custom_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webmapdata": {
+          "name": "webmapdata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_pfp": {
+          "name": "node_pfp",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deezer": {
+          "name": "deezer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artists_added_by_created_at_idx": {
+          "name": "artists_added_by_created_at_idx",
+          "columns": [
+            {
+              "expression": "added_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artists_lcname_btree_idx": {
+          "name": "artists_lcname_btree_idx",
+          "columns": [
+            {
+              "expression": "lcname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artists_lcname_trgm_gin": {
+          "name": "artists_lcname_trgm_gin",
+          "columns": [
+            {
+              "expression": "lcname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "artists_lcname_trgm_idx": {
+          "name": "artists_lcname_trgm_idx",
+          "columns": [
+            {
+              "expression": "lcname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "artists_name_trgm_idx": {
+          "name": "artists_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "artists_spotify_uniq": {
+          "name": "artists_spotify_uniq",
+          "columns": [
+            {
+              "expression": "spotify",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "(spotify IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artists_deezer_uniq": {
+          "name": "artists_deezer_uniq",
+          "columns": [
+            {
+              "expression": "deezer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deezer IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artists_added_by": {
+          "name": "idx_artists_added_by",
+          "columns": [
+            {
+              "expression": "added_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artists_name": {
+          "name": "idx_artists_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artists_name_gin": {
+          "name": "idx_artists_name_gin",
+          "columns": [
+            {
+              "expression": "to_tsvector('english'::regconfig, name)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_artists_created_at": {
+          "name": "idx_artists_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artists_added_by_fkey": {
+          "name": "artists_added_by_fkey",
+          "tableFrom": "artists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Allow webmapdata_editor to see all rows": {
+          "name": "Allow webmapdata_editor to see all rows",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "webmapdata_editor"
+          ],
+          "using": "true"
+        },
+        "Allow webmapdata_editor to update webmapdata column": {
+          "name": "Allow webmapdata_editor to update webmapdata column",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "webmapdata_editor"
+          ]
+        },
+        "mnweb_delete_artists": {
+          "name": "mnweb_delete_artists",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_insert_artists": {
+          "name": "mnweb_insert_artists",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_artists": {
+          "name": "mnweb_select_artists",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_artists": {
+          "name": "mnweb_update_artists",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_prompts": {
+      "name": "bot_prompts",
+      "schema": "",
+      "columns": {
+        "slow": {
+          "name": "slow",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderate": {
+          "name": "moderate",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "busy": {
+          "name": "busy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fun_fact": {
+          "name": "fun_fact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shaming": {
+          "name": "shaming",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_fact": {
+          "name": "track_fact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mn_bot_bot_prompts_sel": {
+          "name": "mn_bot_bot_prompts_sel",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mn_bot"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.featured": {
+      "name": "featured",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "featured_artist": {
+          "name": "featured_artist",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured_collector": {
+          "name": "featured_collector",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "featured_featured_artist_fkey": {
+          "name": "featured_featured_artist_fkey",
+          "tableFrom": "featured",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "featured_artist"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "featured_featured_collector_fkey": {
+          "name": "featured_featured_collector_fkey",
+          "tableFrom": "featured",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "featured_collector"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_delete_featured": {
+          "name": "mnweb_delete_featured",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_featured": {
+          "name": "mnweb_insert_featured",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_featured": {
+          "name": "mnweb_select_featured",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_featured": {
+          "name": "mnweb_update_featured",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funfacts": {
+      "name": "funfacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "funfacts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854776000",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "lore_drop": {
+          "name": "lore_drop",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "behind_the_scenes": {
+          "name": "behind_the_scenes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recent_activity": {
+          "name": "recent_activity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surprise_me": {
+          "name": "surprise_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.history": {
+      "name": "history",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_artist": {
+          "name": "top_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_track": {
+          "name": "top_track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mn_bot_history_ins": {
+          "name": "mn_bot_history_ins",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mn_bot"
+          ],
+          "withCheck": "true"
+        },
+        "mn_bot_history_sel": {
+          "name": "mn_bot_history_sel",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mn_bot"
+          ]
+        },
+        "mn_bot_history_upd": {
+          "name": "mn_bot_history_upd",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mn_bot"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_api_keys": {
+      "name": "mcp_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_api_keys_key_hash_unique": {
+          "name": "mcp_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_select_mcp_api_keys": {
+          "name": "mnweb_select_mcp_api_keys",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_mcp_api_keys": {
+          "name": "mnweb_insert_mcp_api_keys",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        },
+        "mnweb_update_mcp_api_keys": {
+          "name": "mnweb_update_mcp_api_keys",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_url": {
+          "name": "submitted_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_audit_log_artist_id": {
+          "name": "idx_mcp_audit_log_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_audit_log_created_at": {
+          "name": "idx_mcp_audit_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_audit_log_api_key_hash_created_at": {
+          "name": "idx_mcp_audit_log_api_key_hash_created_at",
+          "columns": [
+            {
+              "expression": "api_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_audit_log_artist_id_fkey": {
+          "name": "mcp_audit_log_artist_id_fkey",
+          "tableFrom": "mcp_audit_log",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_select_mcp_audit_log": {
+          "name": "mnweb_select_mcp_audit_log",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_mcp_audit_log": {
+          "name": "mnweb_insert_mcp_audit_log",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ugcresearch": {
+      "name": "ugcresearch",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "artist_uri": {
+          "name": "artist_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted": {
+          "name": "accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ugc_url": {
+          "name": "ugc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_username": {
+          "name": "site_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_processed": {
+          "name": "date_processed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ugcresearch_user_id": {
+          "name": "idx_ugcresearch_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ugcresearch_user_created_at_idx": {
+          "name": "ugcresearch_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamp_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamp_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ugcresearch_date_processed": {
+          "name": "idx_ugcresearch_date_processed",
+          "columns": [
+            {
+              "expression": "date_processed",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ugcresearch_artist_id_fkey": {
+          "name": "ugcresearch_artist_id_fkey",
+          "tableFrom": "ugcresearch",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ugcresearch_user_id_fkey": {
+          "name": "ugcresearch_user_id_fkey",
+          "tableFrom": "ugcresearch",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_delete_ugcresearch": {
+          "name": "mnweb_delete_ugcresearch",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_ugcresearch": {
+          "name": "mnweb_insert_ugcresearch",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_ugcresearch": {
+          "name": "mnweb_select_ugcresearch",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_ugcresearch": {
+          "name": "mnweb_update_ugcresearch",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.urlmap": {
+      "name": "urlmap",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "example": {
+          "name": "example",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_string_format": {
+          "name": "app_string_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_iframe_enabled": {
+          "name": "is_iframe_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_embed_enabled": {
+          "name": "is_embed_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "card_description": {
+          "name": "card_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_platform_name": {
+          "name": "card_platform_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_web3_site": {
+          "name": "is_web3_site",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "site_image": {
+          "name": "site_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regex": {
+          "name": "regex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'\"\"'"
+        },
+        "regex_matcher": {
+          "name": "regex_matcher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_monetized": {
+          "name": "is_monetized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "regex_options": {
+          "name": "regex_options",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#000000'"
+        },
+        "platform_type_list": {
+          "name": "platform_type_list",
+          "type": "platform_type[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"social\"}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "urlmap_siteurl_key": {
+          "name": "urlmap_siteurl_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "site_url"
+          ]
+        },
+        "urlmap_sitename_key": {
+          "name": "urlmap_sitename_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "site_name"
+          ]
+        },
+        "urlmap_example_key": {
+          "name": "urlmap_example_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "example"
+          ]
+        },
+        "urlmap_appstringformat_key": {
+          "name": "urlmap_appstringformat_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_string_format"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_delete_urlmap": {
+          "name": "mnweb_delete_urlmap",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_urlmap": {
+          "name": "mnweb_insert_urlmap",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_urlmap": {
+          "name": "mnweb_select_urlmap",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_urlmap": {
+          "name": "mnweb_update_urlmap",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_tracks": {
+      "name": "user_tracks",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracks": {
+          "name": "tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "top_track": {
+          "name": "top_track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_artist": {
+          "name": "top_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artists": {
+          "name": "artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_user_tracks_guild_id": {
+          "name": "idx_user_tracks_guild_id",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_tracks_user_id": {
+          "name": "idx_user_tracks_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mn_bot_user_tracks_ins": {
+          "name": "mn_bot_user_tracks_ins",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mn_bot"
+          ],
+          "withCheck": "true"
+        },
+        "mn_bot_user_tracks_sel": {
+          "name": "mn_bot_user_tracks_sel",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mn_bot"
+          ]
+        },
+        "mn_bot_user_tracks_upd": {
+          "name": "mn_bot_user_tracks_upd",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mn_bot"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet": {
+          "name": "wallet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privy_user_id": {
+          "name": "privy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_white_listed": {
+          "name": "is_white_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_super_admin": {
+          "name": "is_super_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "legacy_link_dismissed": {
+          "name": "legacy_link_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepted_ugc_count": {
+          "name": "accepted_ugc_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_wallet_key": {
+          "name": "users_wallet_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet"
+          ]
+        },
+        "users_privy_user_id_key": {
+          "name": "users_privy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "privy_user_id"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_delete_users": {
+          "name": "mnweb_delete_users",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_users": {
+          "name": "mnweb_insert_users",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_users": {
+          "name": "mnweb_select_users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_users": {
+          "name": "mnweb_update_users",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wrap_guilds": {
+      "name": "wrap_guilds",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "local_time": {
+          "name": "local_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted": {
+          "name": "posted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wrap_up": {
+          "name": "wrap_up",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shame": {
+          "name": "shame",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wrap_tracks": {
+          "name": "wrap_tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wrap_artists": {
+          "name": "wrap_artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mn_bot_wrap_guilds_del": {
+          "name": "mn_bot_wrap_guilds_del",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mn_bot"
+          ],
+          "using": "true"
+        },
+        "mn_bot_wrap_guilds_ins": {
+          "name": "mn_bot_wrap_guilds_ins",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mn_bot"
+          ]
+        },
+        "mn_bot_wrap_guilds_sel": {
+          "name": "mn_bot_wrap_guilds_sel",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mn_bot"
+          ]
+        },
+        "mn_bot_wrap_guilds_upd": {
+          "name": "mn_bot_wrap_guilds_upd",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mn_bot"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.confidence_level": {
+      "name": "confidence_level",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low",
+        "manual"
+      ]
+    },
+    "public.exclusion_reason": {
+      "name": "exclusion_reason",
+      "schema": "public",
+      "values": [
+        "conflict",
+        "name_mismatch",
+        "too_ambiguous"
+      ]
+    },
+    "public.platform_type": {
+      "name": "platform_type",
+      "schema": "public",
+      "values": [
+        "social",
+        "web3",
+        "listen"
+      ]
+    },
+    "public.source_status": {
+      "name": "source_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,3258 @@
+{
+  "id": "c979e6ef-9b82-4210-918c-2db2bab3fb1b",
+  "prevId": "fe03b9e3-9bef-43da-830b-04b6b7fc35f2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_heartbeats": {
+      "name": "agent_heartbeats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starting'"
+        },
+        "current_run": {
+          "name": "current_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_platform": {
+          "name": "batch_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_size": {
+          "name": "batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_heartbeats_updated_at": {
+          "name": "idx_agent_heartbeats_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_heartbeats_worker_id_unique": {
+          "name": "agent_heartbeats_worker_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "worker_id"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_select_agent_heartbeats": {
+          "name": "mnweb_select_agent_heartbeats",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_agent_heartbeats": {
+          "name": "mnweb_insert_agent_heartbeats",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        },
+        "mnweb_update_agent_heartbeats": {
+          "name": "mnweb_update_agent_heartbeats",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_number": {
+          "name": "run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deezer'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wall_time_secs": {
+          "name": "wall_time_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claude_time_secs": {
+          "name": "claude_time_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_time_secs": {
+          "name": "api_time_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turns": {
+          "name": "turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_size": {
+          "name": "batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "excluded": {
+          "name": "excluded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "high_confidence": {
+          "name": "high_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "medium_confidence": {
+          "name": "medium_confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "conflicts": {
+          "name": "conflicts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "name_mismatches": {
+          "name": "name_mismatches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "too_ambiguous": {
+          "name": "too_ambiguous",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fail_category": {
+          "name": "fail_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fail_reason": {
+          "name": "fail_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_worker_run": {
+          "name": "idx_agent_runs_worker_run",
+          "columns": [
+            {
+              "expression": "worker_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_started_at": {
+          "name": "idx_agent_runs_started_at",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_select_agent_runs": {
+          "name": "mnweb_select_agent_runs",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_agent_runs": {
+          "name": "mnweb_insert_agent_runs",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        },
+        "mnweb_update_agent_runs": {
+          "name": "mnweb_update_agent_runs",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.aiprompts": {
+      "name": "aiprompts",
+      "schema": "",
+      "columns": {
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_before_name": {
+          "name": "prompt_before_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "prompt_after_name": {
+          "name": "prompt_after_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_delete_aiprompts": {
+          "name": "mnweb_delete_aiprompts",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_aiprompts": {
+          "name": "mnweb_insert_aiprompts",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_aiprompts": {
+          "name": "mnweb_select_aiprompts",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_aiprompts": {
+          "name": "mnweb_update_aiprompts",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_bio_versions": {
+      "name": "artist_bio_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio_text": {
+          "name": "bio_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        }
+      },
+      "indexes": {
+        "idx_artist_bio_versions_artist_id": {
+          "name": "idx_artist_bio_versions_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_bio_versions_artist_id_fkey": {
+          "name": "artist_bio_versions_artist_id_fkey",
+          "tableFrom": "artist_bio_versions",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_select_artist_bio_versions": {
+          "name": "mnweb_select_artist_bio_versions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_artist_bio_versions": {
+          "name": "mnweb_insert_artist_bio_versions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_artist_bio_versions": {
+          "name": "mnweb_update_artist_bio_versions",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_delete_artist_bio_versions": {
+          "name": "mnweb_delete_artist_bio_versions",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_claims": {
+      "name": "artist_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reference_code": {
+          "name": "reference_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        }
+      },
+      "indexes": {
+        "idx_artist_claims_user_id": {
+          "name": "idx_artist_claims_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artist_claims_artist_id": {
+          "name": "idx_artist_claims_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_claims_user_id_fkey": {
+          "name": "artist_claims_user_id_fkey",
+          "tableFrom": "artist_claims",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "artist_claims_artist_id_fkey": {
+          "name": "artist_claims_artist_id_fkey",
+          "tableFrom": "artist_claims",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artist_claims_artist_id_key": {
+          "name": "artist_claims_artist_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "artist_id"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_delete_artist_claims": {
+          "name": "mnweb_delete_artist_claims",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_artist_claims": {
+          "name": "mnweb_insert_artist_claims",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_artist_claims": {
+          "name": "mnweb_select_artist_claims",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_artist_claims": {
+          "name": "mnweb_update_artist_claims",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_id_mappings": {
+      "name": "artist_id_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "confidence_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_artist_id_mappings_platform_artist": {
+          "name": "idx_artist_id_mappings_platform_artist",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artist_id_mappings_confidence": {
+          "name": "idx_artist_id_mappings_confidence",
+          "columns": [
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_id_mappings_artist_id_fkey": {
+          "name": "artist_id_mappings_artist_id_fkey",
+          "tableFrom": "artist_id_mappings",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artist_id_mappings_artist_platform_uniq": {
+          "name": "artist_id_mappings_artist_platform_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "artist_id",
+            "platform"
+          ]
+        },
+        "artist_id_mappings_platform_id_uniq": {
+          "name": "artist_id_mappings_platform_id_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "platform",
+            "platform_id"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_select_artist_id_mappings": {
+          "name": "mnweb_select_artist_id_mappings",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_artist_id_mappings": {
+          "name": "mnweb_insert_artist_id_mappings",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        },
+        "mnweb_update_artist_id_mappings": {
+          "name": "mnweb_update_artist_id_mappings",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_mapping_exclusions": {
+      "name": "artist_mapping_exclusions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "exclusion_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_artist_mapping_exclusions_platform": {
+          "name": "idx_artist_mapping_exclusions_platform",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_mapping_exclusions_artist_id_fkey": {
+          "name": "artist_mapping_exclusions_artist_id_fkey",
+          "tableFrom": "artist_mapping_exclusions",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artist_mapping_exclusions_artist_platform_uniq": {
+          "name": "artist_mapping_exclusions_artist_platform_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "artist_id",
+            "platform"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_select_artist_mapping_exclusions": {
+          "name": "mnweb_select_artist_mapping_exclusions",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_artist_mapping_exclusions": {
+          "name": "mnweb_insert_artist_mapping_exclusions",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        },
+        "mnweb_update_artist_mapping_exclusions": {
+          "name": "mnweb_update_artist_mapping_exclusions",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_vault_sources": {
+      "name": "artist_vault_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "source_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_text": {
+          "name": "extracted_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image": {
+          "name": "og_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        }
+      },
+      "indexes": {
+        "idx_artist_vault_sources_artist_id": {
+          "name": "idx_artist_vault_sources_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_vault_sources_artist_id_fkey": {
+          "name": "artist_vault_sources_artist_id_fkey",
+          "tableFrom": "artist_vault_sources",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_delete_artist_vault_sources": {
+          "name": "mnweb_delete_artist_vault_sources",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_artist_vault_sources": {
+          "name": "mnweb_insert_artist_vault_sources",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_artist_vault_sources": {
+          "name": "mnweb_select_artist_vault_sources",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_artist_vault_sources": {
+          "name": "mnweb_update_artist_vault_sources",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artists": {
+      "name": "artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcamp": {
+          "name": "bandcamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facebook": {
+          "name": "facebook",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x": {
+          "name": "x",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloud": {
+          "name": "soundcloud",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patreon": {
+          "name": "patreon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram": {
+          "name": "instagram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtube": {
+          "name": "youtube",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "youtubechannel": {
+          "name": "youtubechannel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lcname": {
+          "name": "lcname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundcloudID": {
+          "name": "soundcloudID",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify": {
+          "name": "spotify",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitch": {
+          "name": "twitch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imdb": {
+          "name": "imdb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicbrainz": {
+          "name": "musicbrainz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata": {
+          "name": "wikidata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mixcloud": {
+          "name": "mixcloud",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facebookID": {
+          "name": "facebookID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs": {
+          "name": "discogs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tiktok": {
+          "name": "tiktok",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tiktokID": {
+          "name": "tiktokID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jaxsta": {
+          "name": "jaxsta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "famousbirthdays": {
+          "name": "famousbirthdays",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "songexploder": {
+          "name": "songexploder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "colorsxstudios": {
+          "name": "colorsxstudios",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandsintown": {
+          "name": "bandsintown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linktree": {
+          "name": "linktree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onlyfans": {
+          "name": "onlyfans",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikipedia": {
+          "name": "wikipedia",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audius": {
+          "name": "audius",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zora": {
+          "name": "zora",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "catalog": {
+          "name": "catalog",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opensea": {
+          "name": "opensea",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "foundation": {
+          "name": "foundation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastfm": {
+          "name": "lastfm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soundxyz": {
+          "name": "soundxyz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirror": {
+          "name": "mirror",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "glassnode": {
+          "name": "glassnode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collectsNFTs": {
+          "name": "collectsNFTs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotifyusername": {
+          "name": "spotifyusername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bandcampfan": {
+          "name": "bandcampfan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tellie": {
+          "name": "tellie",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallets": {
+          "name": "wallets",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ens": {
+          "name": "ens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lens": {
+          "name": "lens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cameo": {
+          "name": "cameo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "farcaster": {
+          "name": "farcaster",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "supercollector": {
+          "name": "supercollector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_image": {
+          "name": "custom_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webmapdata": {
+          "name": "webmapdata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_pfp": {
+          "name": "node_pfp",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deezer": {
+          "name": "deezer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "artists_added_by_created_at_idx": {
+          "name": "artists_added_by_created_at_idx",
+          "columns": [
+            {
+              "expression": "added_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamptz_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artists_lcname_btree_idx": {
+          "name": "artists_lcname_btree_idx",
+          "columns": [
+            {
+              "expression": "lcname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artists_lcname_trgm_gin": {
+          "name": "artists_lcname_trgm_gin",
+          "columns": [
+            {
+              "expression": "lcname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "artists_lcname_trgm_idx": {
+          "name": "artists_lcname_trgm_idx",
+          "columns": [
+            {
+              "expression": "lcname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "artists_name_trgm_idx": {
+          "name": "artists_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "artists_spotify_uniq": {
+          "name": "artists_spotify_uniq",
+          "columns": [
+            {
+              "expression": "spotify",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "(spotify IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artists_deezer_uniq": {
+          "name": "artists_deezer_uniq",
+          "columns": [
+            {
+              "expression": "deezer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "where": "(deezer IS NOT NULL)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artists_added_by": {
+          "name": "idx_artists_added_by",
+          "columns": [
+            {
+              "expression": "added_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artists_name": {
+          "name": "idx_artists_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artists_name_gin": {
+          "name": "idx_artists_name_gin",
+          "columns": [
+            {
+              "expression": "to_tsvector('english'::regconfig, name)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_artists_created_at": {
+          "name": "idx_artists_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artists_added_by_fkey": {
+          "name": "artists_added_by_fkey",
+          "tableFrom": "artists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Allow webmapdata_editor to see all rows": {
+          "name": "Allow webmapdata_editor to see all rows",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "webmapdata_editor"
+          ],
+          "using": "true"
+        },
+        "Allow webmapdata_editor to update webmapdata column": {
+          "name": "Allow webmapdata_editor to update webmapdata column",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "webmapdata_editor"
+          ]
+        },
+        "mnweb_delete_artists": {
+          "name": "mnweb_delete_artists",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_insert_artists": {
+          "name": "mnweb_insert_artists",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_artists": {
+          "name": "mnweb_select_artists",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_artists": {
+          "name": "mnweb_update_artists",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_prompts": {
+      "name": "bot_prompts",
+      "schema": "",
+      "columns": {
+        "slow": {
+          "name": "slow",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderate": {
+          "name": "moderate",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "busy": {
+          "name": "busy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fun_fact": {
+          "name": "fun_fact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shaming": {
+          "name": "shaming",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_fact": {
+          "name": "track_fact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mn_bot_bot_prompts_sel": {
+          "name": "mn_bot_bot_prompts_sel",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mn_bot"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.featured": {
+      "name": "featured",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "featured_artist": {
+          "name": "featured_artist",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured_collector": {
+          "name": "featured_collector",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "featured_featured_artist_fkey": {
+          "name": "featured_featured_artist_fkey",
+          "tableFrom": "featured",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "featured_artist"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "featured_featured_collector_fkey": {
+          "name": "featured_featured_collector_fkey",
+          "tableFrom": "featured",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "featured_collector"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_delete_featured": {
+          "name": "mnweb_delete_featured",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_featured": {
+          "name": "mnweb_insert_featured",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_featured": {
+          "name": "mnweb_select_featured",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_featured": {
+          "name": "mnweb_update_featured",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funfacts": {
+      "name": "funfacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "funfacts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854776000",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "lore_drop": {
+          "name": "lore_drop",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "behind_the_scenes": {
+          "name": "behind_the_scenes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recent_activity": {
+          "name": "recent_activity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surprise_me": {
+          "name": "surprise_me",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Enable read access for all users": {
+          "name": "Enable read access for all users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.history": {
+      "name": "history",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_artist": {
+          "name": "top_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_track": {
+          "name": "top_track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mn_bot_history_ins": {
+          "name": "mn_bot_history_ins",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mn_bot"
+          ],
+          "withCheck": "true"
+        },
+        "mn_bot_history_sel": {
+          "name": "mn_bot_history_sel",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mn_bot"
+          ]
+        },
+        "mn_bot_history_upd": {
+          "name": "mn_bot_history_upd",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mn_bot"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_api_keys": {
+      "name": "mcp_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_api_keys_key_hash_unique": {
+          "name": "mcp_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_select_mcp_api_keys": {
+          "name": "mnweb_select_mcp_api_keys",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_mcp_api_keys": {
+          "name": "mnweb_insert_mcp_api_keys",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        },
+        "mnweb_update_mcp_api_keys": {
+          "name": "mnweb_update_mcp_api_keys",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_audit_log": {
+      "name": "mcp_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_url": {
+          "name": "submitted_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_hash": {
+          "name": "api_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_audit_log_artist_id": {
+          "name": "idx_mcp_audit_log_artist_id",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_audit_log_created_at": {
+          "name": "idx_mcp_audit_log_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_audit_log_api_key_hash_created_at": {
+          "name": "idx_mcp_audit_log_api_key_hash_created_at",
+          "columns": [
+            {
+              "expression": "api_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_audit_log_artist_id_fkey": {
+          "name": "mcp_audit_log_artist_id_fkey",
+          "tableFrom": "mcp_audit_log",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_select_mcp_audit_log": {
+          "name": "mnweb_select_mcp_audit_log",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_mcp_audit_log": {
+          "name": "mnweb_insert_mcp_audit_log",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ],
+          "withCheck": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ugcresearch": {
+      "name": "ugcresearch",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "artist_uri": {
+          "name": "artist_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted": {
+          "name": "accepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ugc_url": {
+          "name": "ugc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_username": {
+          "name": "site_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_processed": {
+          "name": "date_processed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ugcresearch_user_id": {
+          "name": "idx_ugcresearch_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "uuid_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ugcresearch_user_created_at_idx": {
+          "name": "ugcresearch_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamp_ops"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamp_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ugcresearch_date_processed": {
+          "name": "idx_ugcresearch_date_processed",
+          "columns": [
+            {
+              "expression": "date_processed",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ugcresearch_artist_id_fkey": {
+          "name": "ugcresearch_artist_id_fkey",
+          "tableFrom": "ugcresearch",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ugcresearch_user_id_fkey": {
+          "name": "ugcresearch_user_id_fkey",
+          "tableFrom": "ugcresearch",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mnweb_delete_ugcresearch": {
+          "name": "mnweb_delete_ugcresearch",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_ugcresearch": {
+          "name": "mnweb_insert_ugcresearch",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_ugcresearch": {
+          "name": "mnweb_select_ugcresearch",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_ugcresearch": {
+          "name": "mnweb_update_ugcresearch",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.urlmap": {
+      "name": "urlmap",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "example": {
+          "name": "example",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_string_format": {
+          "name": "app_string_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_iframe_enabled": {
+          "name": "is_iframe_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_embed_enabled": {
+          "name": "is_embed_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "card_description": {
+          "name": "card_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_platform_name": {
+          "name": "card_platform_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_web3_site": {
+          "name": "is_web3_site",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "site_image": {
+          "name": "site_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regex": {
+          "name": "regex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'\"\"'"
+        },
+        "regex_matcher": {
+          "name": "regex_matcher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_monetized": {
+          "name": "is_monetized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "regex_options": {
+          "name": "regex_options",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#000000'"
+        },
+        "platform_type_list": {
+          "name": "platform_type_list",
+          "type": "platform_type[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"social\"}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "urlmap_siteurl_key": {
+          "name": "urlmap_siteurl_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "site_url"
+          ]
+        },
+        "urlmap_sitename_key": {
+          "name": "urlmap_sitename_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "site_name"
+          ]
+        },
+        "urlmap_example_key": {
+          "name": "urlmap_example_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "example"
+          ]
+        },
+        "urlmap_appstringformat_key": {
+          "name": "urlmap_appstringformat_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_string_format"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_delete_urlmap": {
+          "name": "mnweb_delete_urlmap",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_urlmap": {
+          "name": "mnweb_insert_urlmap",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_urlmap": {
+          "name": "mnweb_select_urlmap",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_urlmap": {
+          "name": "mnweb_update_urlmap",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_tracks": {
+      "name": "user_tracks",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracks": {
+          "name": "tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "top_track": {
+          "name": "top_track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_artist": {
+          "name": "top_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artists": {
+          "name": "artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_user_tracks_guild_id": {
+          "name": "idx_user_tracks_guild_id",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_tracks_user_id": {
+          "name": "idx_user_tracks_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mn_bot_user_tracks_ins": {
+          "name": "mn_bot_user_tracks_ins",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mn_bot"
+          ],
+          "withCheck": "true"
+        },
+        "mn_bot_user_tracks_sel": {
+          "name": "mn_bot_user_tracks_sel",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mn_bot"
+          ]
+        },
+        "mn_bot_user_tracks_upd": {
+          "name": "mn_bot_user_tracks_upd",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mn_bot"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet": {
+          "name": "wallet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privy_user_id": {
+          "name": "privy_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'utc'::text)"
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_white_listed": {
+          "name": "is_white_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_super_admin": {
+          "name": "is_super_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "legacy_link_dismissed": {
+          "name": "legacy_link_dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepted_ugc_count": {
+          "name": "accepted_ugc_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_wallet_key": {
+          "name": "users_wallet_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet"
+          ]
+        },
+        "users_privy_user_id_key": {
+          "name": "users_privy_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "privy_user_id"
+          ]
+        }
+      },
+      "policies": {
+        "mnweb_delete_users": {
+          "name": "mnweb_delete_users",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mnweb"
+          ],
+          "using": "true"
+        },
+        "mnweb_insert_users": {
+          "name": "mnweb_insert_users",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_select_users": {
+          "name": "mnweb_select_users",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mnweb"
+          ]
+        },
+        "mnweb_update_users": {
+          "name": "mnweb_update_users",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mnweb"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wrap_guilds": {
+      "name": "wrap_guilds",
+      "schema": "",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "local_time": {
+          "name": "local_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted": {
+          "name": "posted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wrap_up": {
+          "name": "wrap_up",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shame": {
+          "name": "shame",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wrap_tracks": {
+          "name": "wrap_tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wrap_artists": {
+          "name": "wrap_artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "mn_bot_wrap_guilds_del": {
+          "name": "mn_bot_wrap_guilds_del",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "mn_bot"
+          ],
+          "using": "true"
+        },
+        "mn_bot_wrap_guilds_ins": {
+          "name": "mn_bot_wrap_guilds_ins",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "mn_bot"
+          ]
+        },
+        "mn_bot_wrap_guilds_sel": {
+          "name": "mn_bot_wrap_guilds_sel",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "mn_bot"
+          ]
+        },
+        "mn_bot_wrap_guilds_upd": {
+          "name": "mn_bot_wrap_guilds_upd",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "mn_bot"
+          ]
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.confidence_level": {
+      "name": "confidence_level",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low",
+        "manual"
+      ]
+    },
+    "public.exclusion_reason": {
+      "name": "exclusion_reason",
+      "schema": "public",
+      "values": [
+        "conflict",
+        "name_mismatch",
+        "too_ambiguous"
+      ]
+    },
+    "public.platform_type": {
+      "name": "platform_type",
+      "schema": "public",
+      "values": [
+        "social",
+        "web3",
+        "listen"
+      ]
+    },
+    "public.source_status": {
+      "name": "source_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1775782709272,
       "tag": "0007_confused_blonde_phantom",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1775784854646,
+      "tag": "0008_third_terrax",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1775445241257,
       "tag": "0006_careless_ravenous",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1775782709272,
+      "tag": "0007_confused_blonde_phantom",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/_components/EditModeToggle.tsx
+++ b/src/app/_components/EditModeToggle.tsx
@@ -15,7 +15,7 @@ export default function EditModeToggle() {
             size="sm"
             onClick={toggle}
             data-testid="edit-mode-toggle"
-            className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors duration-200"
+            className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors duration-200 border-pastypink/50 text-pastypink hover:bg-pastypink hover:text-white"
         >
             {isEditing ? <Check size={14} /> : <Pencil size={14} />}
             {isEditing ? "Done" : "Edit"}

--- a/src/app/actions/dashboardActions.ts
+++ b/src/app/actions/dashboardActions.ts
@@ -15,6 +15,10 @@ import {
     deleteVaultSource,
     deleteVaultSources,
     deleteClaim,
+    getBioVersionsByArtistId,
+    saveBioVersion,
+    pinBioVersion,
+    deleteBioVersion,
 } from "@/server/utils/queries/dashboardQueries";
 import { inferTypeFromUrl, SOURCE_TYPES } from "@/lib/sourceTypes";
 import { searchAndPopulateVault } from "@/server/utils/queries/vaultWebSearch";
@@ -210,6 +214,7 @@ export async function addVaultSource(
                     title: content.title,
                     snippet: content.snippet,
                     extractedText: content.extractedText,
+                    ogImage: content.ogImage,
                 }).catch(e => console.error("[addVaultSource] Background content update failed:", e));
             }).catch(e => console.error("[addVaultSource] Background fetch failed:", e));
         }
@@ -285,5 +290,71 @@ export async function removeVaultSources(
     } catch (error) {
         console.error("[removeVaultSources] Error:", error);
         return { success: false, error: "Failed to delete sources" };
+    }
+}
+
+// ------ Bio Versions ------
+
+export async function getArtistBioVersions(): Promise<{ success: boolean; versions?: Awaited<ReturnType<typeof getBioVersionsByArtistId>>; error?: string }> {
+    const session = await getServerAuthSession() ?? await getDevSession();
+    if (!session) return { success: false, error: "Not authenticated" };
+
+    try {
+        const claim = await getApprovedClaimByUserId(session.user.id);
+        if (!claim) return { success: false, error: "No claimed artist profile" };
+
+        const versions = await getBioVersionsByArtistId(claim.artistId);
+        return { success: true, versions };
+    } catch (error) {
+        console.error("[getArtistBioVersions] Error:", error);
+        return { success: false, error: "Failed to load bio versions" };
+    }
+}
+
+export async function saveCurrentBio(bioText: string): Promise<{ success: boolean; error?: string }> {
+    const session = await getServerAuthSession() ?? await getDevSession();
+    if (!session) return { success: false, error: "Not authenticated" };
+
+    try {
+        const claim = await getApprovedClaimByUserId(session.user.id);
+        if (!claim) return { success: false, error: "No claimed artist profile" };
+
+        await saveBioVersion(claim.artistId, bioText, false);
+        return { success: true };
+    } catch (error) {
+        console.error("[saveCurrentBio] Error:", error);
+        return { success: false, error: "Failed to save bio" };
+    }
+}
+
+export async function pinBioVersionAction(versionId: string): Promise<{ success: boolean; error?: string }> {
+    const session = await getServerAuthSession() ?? await getDevSession();
+    if (!session) return { success: false, error: "Not authenticated" };
+
+    try {
+        const claim = await getApprovedClaimByUserId(session.user.id);
+        if (!claim) return { success: false, error: "No claimed artist profile" };
+
+        await pinBioVersion(versionId, claim.artistId);
+        return { success: true };
+    } catch (error) {
+        console.error("[pinBioVersionAction] Error:", error);
+        return { success: false, error: "Failed to pin bio version" };
+    }
+}
+
+export async function deleteBioVersionAction(versionId: string): Promise<{ success: boolean; error?: string }> {
+    const session = await getServerAuthSession() ?? await getDevSession();
+    if (!session) return { success: false, error: "Not authenticated" };
+
+    try {
+        const claim = await getApprovedClaimByUserId(session.user.id);
+        if (!claim) return { success: false, error: "No claimed artist profile" };
+
+        await deleteBioVersion(versionId);
+        return { success: true };
+    } catch (error) {
+        console.error("[deleteBioVersionAction] Error:", error);
+        return { success: false, error: "Failed to delete bio version" };
     }
 }

--- a/src/app/actions/dashboardActions.ts
+++ b/src/app/actions/dashboardActions.ts
@@ -2,6 +2,7 @@
 
 import { getServerAuthSession } from "@/server/auth";
 import { getDevSession } from "@/server/utils/dev-auth";
+import { getUserById } from "@/server/utils/queries/userQueries";
 import {
     createClaim,
     getClaimByArtistId,
@@ -326,7 +327,6 @@ export async function saveCurrentBio(bioText: string, targetArtistId?: string): 
 
         if (targetArtistId) {
             // Admin can save bio for any artist; claimed artist can save for their own
-            const { getUserById } = await import("@/server/utils/queries/userQueries");
             const user = await getUserById(session.user.id);
             const isAdmin = !!user?.isAdmin;
 
@@ -345,7 +345,7 @@ export async function saveCurrentBio(bioText: string, targetArtistId?: string): 
             artistId = claim.artistId;
         }
 
-        await saveBioVersion(artistId, bioText, false);
+        await saveBioVersion(artistId, bioText);
         return { success: true };
     } catch (error) {
         console.error("[saveCurrentBio] Error:", error);
@@ -353,15 +353,29 @@ export async function saveCurrentBio(bioText: string, targetArtistId?: string): 
     }
 }
 
-export async function pinBioVersionAction(versionId: string): Promise<{ success: boolean; error?: string }> {
+/** Resolve the artistId for bio version actions — admin can target any artist via the version's owner */
+async function resolveBioArtistId(userId: string, targetArtistId?: string): Promise<{ artistId: string } | { error: string }> {
+    if (targetArtistId) {
+        const user = await getUserById(userId);
+        if (user?.isAdmin) return { artistId: targetArtistId };
+        const claim = await getApprovedClaimByUserId(userId);
+        if (!claim || claim.artistId !== targetArtistId) return { error: "Not authorized for this artist" };
+        return { artistId: claim.artistId };
+    }
+    const claim = await getApprovedClaimByUserId(userId);
+    if (!claim) return { error: "No claimed artist profile" };
+    return { artistId: claim.artistId };
+}
+
+export async function pinBioVersionAction(versionId: string, targetArtistId?: string): Promise<{ success: boolean; error?: string }> {
     const session = await getServerAuthSession() ?? await getDevSession();
     if (!session) return { success: false, error: "Not authenticated" };
 
     try {
-        const claim = await getApprovedClaimByUserId(session.user.id);
-        if (!claim) return { success: false, error: "No claimed artist profile" };
+        const resolved = await resolveBioArtistId(session.user.id, targetArtistId);
+        if ("error" in resolved) return { success: false, error: resolved.error };
 
-        await pinBioVersion(versionId, claim.artistId);
+        await pinBioVersion(versionId, resolved.artistId);
         return { success: true };
     } catch (error) {
         console.error("[pinBioVersionAction] Error:", error);
@@ -369,15 +383,15 @@ export async function pinBioVersionAction(versionId: string): Promise<{ success:
     }
 }
 
-export async function deleteBioVersionAction(versionId: string): Promise<{ success: boolean; error?: string }> {
+export async function deleteBioVersionAction(versionId: string, targetArtistId?: string): Promise<{ success: boolean; error?: string }> {
     const session = await getServerAuthSession() ?? await getDevSession();
     if (!session) return { success: false, error: "Not authenticated" };
 
     try {
-        const claim = await getApprovedClaimByUserId(session.user.id);
-        if (!claim) return { success: false, error: "No claimed artist profile" };
+        const resolved = await resolveBioArtistId(session.user.id, targetArtistId);
+        if ("error" in resolved) return { success: false, error: resolved.error };
 
-        await deleteBioVersion(versionId, claim.artistId);
+        await deleteBioVersion(versionId, resolved.artistId);
         return { success: true };
     } catch (error) {
         console.error("[deleteBioVersionAction] Error:", error);

--- a/src/app/actions/dashboardActions.ts
+++ b/src/app/actions/dashboardActions.ts
@@ -330,7 +330,8 @@ export async function saveCurrentBio(bioText: string, targetArtistId?: string): 
         return { success: true };
     } catch (error) {
         console.error("[saveCurrentBio] Error:", error);
-        return { success: false, error: "Failed to save bio" };
+        const message = error instanceof Error ? error.message : "Failed to save bio";
+        return { success: false, error: message };
     }
 }
 
@@ -378,6 +379,7 @@ export async function deleteBioVersionAction(versionId: string, targetArtistId?:
         return { success: true };
     } catch (error) {
         console.error("[deleteBioVersionAction] Error:", error);
-        return { success: false, error: "Failed to delete bio version" };
+        const message = error instanceof Error ? error.message : "Failed to delete bio version";
+        return { success: false, error: message };
     }
 }

--- a/src/app/actions/dashboardActions.ts
+++ b/src/app/actions/dashboardActions.ts
@@ -313,7 +313,7 @@ export async function getArtistBioVersions(): Promise<{ success: boolean; versio
 
 const MAX_BIO_LENGTH = 10_000;
 
-export async function saveCurrentBio(bioText: string): Promise<{ success: boolean; error?: string }> {
+export async function saveCurrentBio(bioText: string, targetArtistId?: string): Promise<{ success: boolean; error?: string }> {
     const session = await getServerAuthSession() ?? await getDevSession();
     if (!session) return { success: false, error: "Not authenticated" };
 
@@ -322,10 +322,30 @@ export async function saveCurrentBio(bioText: string): Promise<{ success: boolea
     }
 
     try {
-        const claim = await getApprovedClaimByUserId(session.user.id);
-        if (!claim) return { success: false, error: "No claimed artist profile" };
+        let artistId: string;
 
-        await saveBioVersion(claim.artistId, bioText, false);
+        if (targetArtistId) {
+            // Admin can save bio for any artist; claimed artist can save for their own
+            const { getUserById } = await import("@/server/utils/queries/userQueries");
+            const user = await getUserById(session.user.id);
+            const isAdmin = !!user?.isAdmin;
+
+            if (isAdmin) {
+                artistId = targetArtistId;
+            } else {
+                const claim = await getApprovedClaimByUserId(session.user.id);
+                if (!claim || claim.artistId !== targetArtistId) {
+                    return { success: false, error: "Not authorized for this artist" };
+                }
+                artistId = claim.artistId;
+            }
+        } else {
+            const claim = await getApprovedClaimByUserId(session.user.id);
+            if (!claim) return { success: false, error: "No claimed artist profile" };
+            artistId = claim.artistId;
+        }
+
+        await saveBioVersion(artistId, bioText, false);
         return { success: true };
     } catch (error) {
         console.error("[saveCurrentBio] Error:", error);

--- a/src/app/actions/dashboardActions.ts
+++ b/src/app/actions/dashboardActions.ts
@@ -323,29 +323,10 @@ export async function saveCurrentBio(bioText: string, targetArtistId?: string): 
     }
 
     try {
-        let artistId: string;
+        const resolved = await resolveBioArtistId(session.user.id, targetArtistId);
+        if ("error" in resolved) return { success: false, error: resolved.error };
 
-        if (targetArtistId) {
-            // Admin can save bio for any artist; claimed artist can save for their own
-            const user = await getUserById(session.user.id);
-            const isAdmin = !!user?.isAdmin;
-
-            if (isAdmin) {
-                artistId = targetArtistId;
-            } else {
-                const claim = await getApprovedClaimByUserId(session.user.id);
-                if (!claim || claim.artistId !== targetArtistId) {
-                    return { success: false, error: "Not authorized for this artist" };
-                }
-                artistId = claim.artistId;
-            }
-        } else {
-            const claim = await getApprovedClaimByUserId(session.user.id);
-            if (!claim) return { success: false, error: "No claimed artist profile" };
-            artistId = claim.artistId;
-        }
-
-        await saveBioVersion(artistId, bioText);
+        await saveBioVersion(resolved.artistId, bioText);
         return { success: true };
     } catch (error) {
         console.error("[saveCurrentBio] Error:", error);

--- a/src/app/actions/dashboardActions.ts
+++ b/src/app/actions/dashboardActions.ts
@@ -311,9 +311,15 @@ export async function getArtistBioVersions(): Promise<{ success: boolean; versio
     }
 }
 
+const MAX_BIO_LENGTH = 10_000;
+
 export async function saveCurrentBio(bioText: string): Promise<{ success: boolean; error?: string }> {
     const session = await getServerAuthSession() ?? await getDevSession();
     if (!session) return { success: false, error: "Not authenticated" };
+
+    if (!bioText || bioText.length > MAX_BIO_LENGTH) {
+        return { success: false, error: `Bio must be between 1 and ${MAX_BIO_LENGTH} characters` };
+    }
 
     try {
         const claim = await getApprovedClaimByUserId(session.user.id);
@@ -351,7 +357,7 @@ export async function deleteBioVersionAction(versionId: string): Promise<{ succe
         const claim = await getApprovedClaimByUserId(session.user.id);
         if (!claim) return { success: false, error: "No claimed artist profile" };
 
-        await deleteBioVersion(versionId);
+        await deleteBioVersion(versionId, claim.artistId);
         return { success: true };
     } catch (error) {
         console.error("[deleteBioVersionAction] Error:", error);

--- a/src/app/actions/dashboardActions.ts
+++ b/src/app/actions/dashboardActions.ts
@@ -356,7 +356,8 @@ export async function pinBioVersionAction(versionId: string, targetArtistId?: st
         const resolved = await resolveBioArtistId(session.user.id, targetArtistId);
         if ("error" in resolved) return { success: false, error: resolved.error };
 
-        await pinBioVersion(versionId, resolved.artistId);
+        const pinned = await pinBioVersion(versionId, resolved.artistId);
+        if (!pinned) return { success: false, error: "Bio version not found" };
         return { success: true };
     } catch (error) {
         console.error("[pinBioVersionAction] Error:", error);
@@ -372,7 +373,8 @@ export async function deleteBioVersionAction(versionId: string, targetArtistId?:
         const resolved = await resolveBioArtistId(session.user.id, targetArtistId);
         if ("error" in resolved) return { success: false, error: resolved.error };
 
-        await deleteBioVersion(versionId, resolved.artistId);
+        const deleted = await deleteBioVersion(versionId, resolved.artistId);
+        if (!deleted) return { success: false, error: "Bio version not found" };
         return { success: true };
     } catch (error) {
         console.error("[deleteBioVersionAction] Error:", error);

--- a/src/app/actions/dashboardActions.ts
+++ b/src/app/actions/dashboardActions.ts
@@ -296,15 +296,15 @@ export async function removeVaultSources(
 
 // ------ Bio Versions ------
 
-export async function getArtistBioVersions(): Promise<{ success: boolean; versions?: Awaited<ReturnType<typeof getBioVersionsByArtistId>>; error?: string }> {
+export async function getArtistBioVersions(targetArtistId?: string): Promise<{ success: boolean; versions?: Awaited<ReturnType<typeof getBioVersionsByArtistId>>; error?: string }> {
     const session = await getServerAuthSession() ?? await getDevSession();
     if (!session) return { success: false, error: "Not authenticated" };
 
     try {
-        const claim = await getApprovedClaimByUserId(session.user.id);
-        if (!claim) return { success: false, error: "No claimed artist profile" };
+        const resolved = await resolveBioArtistId(session.user.id, targetArtistId);
+        if ("error" in resolved) return { success: false, error: resolved.error };
 
-        const versions = await getBioVersionsByArtistId(claim.artistId);
+        const versions = await getBioVersionsByArtistId(resolved.artistId);
         return { success: true, versions };
     } catch (error) {
         console.error("[getArtistBioVersions] Error:", error);

--- a/src/app/artist/[id]/_components/BlurbSection.tsx
+++ b/src/app/artist/[id]/_components/BlurbSection.tsx
@@ -107,7 +107,7 @@ export default function BlurbSection({ artistName, artistId, initialBio }: Blurb
     if (!aiBlurb || isSavingToVault) return;
     setIsSavingToVault(true);
     try {
-      const result = await saveCurrentBio(aiBlurb);
+      const result = await saveCurrentBio(aiBlurb, artistId);
       if (result.success) {
         setSavedToVault(true);
         toast({ title: "Bio saved to vault" });

--- a/src/app/artist/[id]/_components/BlurbSection.tsx
+++ b/src/app/artist/[id]/_components/BlurbSection.tsx
@@ -5,7 +5,8 @@ import { EditModeContext } from "@/app/_components/EditModeContext";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { useArtistBio } from "@/hooks/useArtistBio";
-import { RefreshCw, ChevronDown } from "lucide-react";
+import { RefreshCw, ChevronDown, Pin, Check } from "lucide-react";
+import { saveCurrentBio } from "@/app/actions/dashboardActions";
 
 interface BlurbSectionProps {
   artistName: string;
@@ -35,6 +36,8 @@ export default function BlurbSection({ artistName, artistId, initialBio }: Blurb
   const [editText, setEditText] = useState<string>("");
   const [isSaving, setIsSaving] = useState(false);
   const [isRegenerating, setIsRegenerating] = useState(false);
+  const [isSavingToVault, setIsSavingToVault] = useState(false);
+  const [savedToVault, setSavedToVault] = useState(false);
   const [originalBio, setOriginalBio] = useState<string>("");
 
   // Update edit text when bio changes
@@ -98,6 +101,25 @@ export default function BlurbSection({ artistName, artistId, initialBio }: Blurb
 
   function handleDiscard() {
     setEditText(originalBio);
+  }
+
+  async function handleSaveToVault() {
+    if (!aiBlurb || isSavingToVault) return;
+    setIsSavingToVault(true);
+    try {
+      const result = await saveCurrentBio(aiBlurb);
+      if (result.success) {
+        setSavedToVault(true);
+        toast({ title: "Bio saved to vault" });
+        setTimeout(() => setSavedToVault(false), 3000);
+      } else {
+        toast({ title: "Error", description: result.error, variant: "destructive" });
+      }
+    } catch {
+      toast({ title: "Error", description: "Failed to save bio", variant: "destructive" });
+    } finally {
+      setIsSavingToVault(false);
+    }
   }
 
   async function handleRegenerate() {
@@ -210,16 +232,39 @@ export default function BlurbSection({ artistName, artistId, initialBio }: Blurb
         )}
       </div>
 
-      {/* Controls row: Read More / Show Less + Regenerate */}
+      {/* Controls row */}
       <div className="flex items-center justify-between px-1">
-        <button
-          onClick={handleRegenerate}
-          disabled={isRegenerating}
-          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-pastypink transition-colors"
-        >
-          <RefreshCw size={11} className={isRegenerating ? "animate-spin" : ""} />
-          {isRegenerating ? "Regenerating..." : "Regenerate summary"}
-        </button>
+        <div className="flex items-center gap-3">
+          {canEdit && (
+            <button
+              onClick={handleRegenerate}
+              disabled={isRegenerating}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-pastypink transition-colors"
+            >
+              <RefreshCw size={11} className={isRegenerating ? "animate-spin" : ""} />
+              {isRegenerating ? "Regenerating..." : "Regenerate"}
+            </button>
+          )}
+          {canEdit && aiBlurb && (
+            <button
+              onClick={handleSaveToVault}
+              disabled={isSavingToVault || savedToVault}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-pastypink transition-colors"
+            >
+              {savedToVault ? (
+                <>
+                  <Check size={11} className="text-green-500" />
+                  <span className="text-green-500">Saved</span>
+                </>
+              ) : (
+                <>
+                  <Pin size={11} />
+                  {isSavingToVault ? "Saving..." : "Save to vault"}
+                </>
+              )}
+            </button>
+          )}
+        </div>
 
         {needsTruncation && (
           <button

--- a/src/app/artist/[id]/_components/BlurbSection.tsx
+++ b/src/app/artist/[id]/_components/BlurbSection.tsx
@@ -38,6 +38,7 @@ export default function BlurbSection({ artistName, artistId, initialBio }: Blurb
   const [isRegenerating, setIsRegenerating] = useState(false);
   const [isSavingToVault, setIsSavingToVault] = useState(false);
   const [savedToVault, setSavedToVault] = useState(false);
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [originalBio, setOriginalBio] = useState<string>("");
 
   // Update edit text when bio changes
@@ -65,6 +66,11 @@ export default function BlurbSection({ artistName, artistId, initialBio }: Blurb
       setNeedsTruncation(true);
     }
   }, [aiBlurb]);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => { if (savedTimerRef.current) clearTimeout(savedTimerRef.current); };
+  }, []);
 
   async function handleSave() {
     // Prevent saving empty bios – restore original text instead
@@ -111,7 +117,8 @@ export default function BlurbSection({ artistName, artistId, initialBio }: Blurb
       if (result.success) {
         setSavedToVault(true);
         toast({ title: "Bio saved to vault" });
-        setTimeout(() => setSavedToVault(false), 3000);
+        if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+        savedTimerRef.current = setTimeout(() => setSavedToVault(false), 3000);
       } else {
         toast({ title: "Error", description: result.error, variant: "destructive" });
       }

--- a/src/app/artist/[id]/_components/PressAndFeatures.tsx
+++ b/src/app/artist/[id]/_components/PressAndFeatures.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useMemo } from "react";
 import { SOURCE_TYPE_COLORS, type SourceType } from "@/lib/sourceTypes";
 import { ExternalLink, ChevronLeft, ChevronRight } from "lucide-react";
 
@@ -127,17 +127,20 @@ export default function PressAndFeatures({ sources, artistName }: PressAndFeatur
 
     if (sources.length === 0) return null;
 
-    // Build type counts for filter chips
-    const typeCounts = sources.reduce<Record<string, number>>((acc, s) => {
-        const t = s.type ?? "article";
-        acc[t] = (acc[t] ?? 0) + 1;
-        return acc;
-    }, {});
-
-    const types = Object.entries(typeCounts).sort((a, b) => b[1] - a[1]);
-    const filtered = activeFilter
-        ? sources.filter(s => (s.type ?? "article") === activeFilter)
-        : sources;
+    // Build type counts + filtered list (memoized)
+    const { types, filtered } = useMemo(() => {
+        const counts: Record<string, number> = {};
+        const items: typeof sources = [];
+        for (const s of sources) {
+            const t = s.type ?? "article";
+            counts[t] = (counts[t] ?? 0) + 1;
+            if (!activeFilter || t === activeFilter) items.push(s);
+        }
+        return {
+            types: Object.entries(counts).sort((a, b) => b[1] - a[1]),
+            filtered: items,
+        };
+    }, [sources, activeFilter]);
 
     const scroll = (direction: "left" | "right") => {
         if (!scrollRef.current) return;
@@ -191,7 +194,7 @@ export default function PressAndFeatures({ sources, artistName }: PressAndFeatur
                 {/* Left arrow */}
                 <button
                     onClick={() => scroll("left")}
-                    className="absolute -left-3 top-1/2 -translate-y-1/2 z-10 w-9 h-9 rounded-full bg-black/60 backdrop-blur-md flex items-center justify-center text-white opacity-0 group-hover/carousel:opacity-100 transition-opacity hover:bg-black/80 shadow-lg"
+                    className="absolute -left-3 top-1/2 -translate-y-1/2 z-10 w-9 h-9 rounded-full bg-black/60 backdrop-blur-md flex items-center justify-center text-white opacity-60 md:opacity-0 md:group-hover/carousel:opacity-100 transition-opacity hover:bg-black/80 shadow-lg"
                     aria-label="Scroll left"
                 >
                     <ChevronLeft size={18} />
@@ -213,7 +216,7 @@ export default function PressAndFeatures({ sources, artistName }: PressAndFeatur
                 {/* Right arrow */}
                 <button
                     onClick={() => scroll("right")}
-                    className="absolute -right-3 top-1/2 -translate-y-1/2 z-10 w-9 h-9 rounded-full bg-black/60 backdrop-blur-md flex items-center justify-center text-white opacity-0 group-hover/carousel:opacity-100 transition-opacity hover:bg-black/80 shadow-lg"
+                    className="absolute -right-3 top-1/2 -translate-y-1/2 z-10 w-9 h-9 rounded-full bg-black/60 backdrop-blur-md flex items-center justify-center text-white opacity-60 md:opacity-0 md:group-hover/carousel:opacity-100 transition-opacity hover:bg-black/80 shadow-lg"
                     aria-label="Scroll right"
                 >
                     <ChevronRight size={18} />

--- a/src/app/artist/[id]/_components/PressAndFeatures.tsx
+++ b/src/app/artist/[id]/_components/PressAndFeatures.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { useState, useRef } from "react";
 import { SOURCE_TYPE_COLORS, type SourceType } from "@/lib/sourceTypes";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, ChevronLeft, ChevronRight } from "lucide-react";
 
 interface VaultSource {
     id: string;
@@ -9,6 +10,7 @@ interface VaultSource {
     title?: string | null;
     snippet?: string | null;
     type?: string | null;
+    ogImage?: string | null;
 }
 
 interface PressAndFeaturesProps {
@@ -21,6 +23,15 @@ function getSourceDomain(url: string): string {
         return new URL(url).hostname.replace("www.", "");
     } catch {
         return url;
+    }
+}
+
+function getFaviconUrl(url: string): string {
+    try {
+        const domain = new URL(url).hostname;
+        return `https://www.google.com/s2/favicons?domain=${domain}&sz=32`;
+    } catch {
+        return "";
     }
 }
 
@@ -38,49 +49,172 @@ const TYPE_LABELS: Record<string, string> = {
     data: "Data",
 };
 
+function SourceCard({ source }: { source: VaultSource }) {
+    const type = (source.type ?? "article") as SourceType;
+    const colors = SOURCE_TYPE_COLORS[type] ?? SOURCE_TYPE_COLORS.article;
+    const domain = getSourceDomain(source.url);
+    const favicon = getFaviconUrl(source.url);
+    const hasImage = !!source.ogImage;
+
+    return (
+        <a
+            href={source.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group flex-shrink-0 w-[320px] h-[320px] glass-subtle overflow-hidden flex flex-col transition-all duration-300 hover:shadow-[0_0_30px_rgba(239,149,255,0.35)]"
+        >
+            {/* Thumbnail — fixed height, gradient always behind as fallback */}
+            <div className="relative w-full h-[180px] shrink-0 overflow-hidden bg-gradient-to-br from-pastypink/10 via-purple-900/20 to-transparent">
+                {/* Favicon centered as fallback (visible when no image or image fails) */}
+                {favicon && (
+                    <div className="absolute inset-0 flex items-center justify-center">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                            src={favicon}
+                            alt=""
+                            className="w-10 h-10 rounded-lg opacity-50"
+                            onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                        />
+                    </div>
+                )}
+                {/* OG image on top — hides favicon when loaded */}
+                {hasImage && (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                        src={source.ogImage!}
+                        alt=""
+                        className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+                        onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                    />
+                )}
+
+                {/* Type badge */}
+                <span
+                    className={`absolute top-3 left-3 inline-flex px-2 py-0.5 rounded-md text-[10px] font-bold uppercase tracking-wide backdrop-blur-md ${colors.bg} ${colors.text} ${colors.border} border`}
+                >
+                    {TYPE_LABELS[type] ?? "Article"}
+                </span>
+            </div>
+
+            {/* Content — fills remaining space */}
+            <div className="p-4 flex flex-col flex-1 min-h-0">
+                <h3 className="text-sm font-semibold text-black dark:text-white leading-snug line-clamp-2">
+                    {source.title ?? "Untitled"}
+                </h3>
+
+                <div className="flex items-center gap-1.5 mt-auto pt-2">
+                    {favicon && (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                            src={favicon}
+                            alt=""
+                            className="w-4 h-4 rounded-sm shrink-0"
+                            onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                        />
+                    )}
+                    <span className="text-[11px] text-muted-foreground/60 truncate">
+                        {domain}
+                    </span>
+                </div>
+            </div>
+        </a>
+    );
+}
+
 export default function PressAndFeatures({ sources, artistName }: PressAndFeaturesProps) {
+    const [activeFilter, setActiveFilter] = useState<string | null>(null);
+    const scrollRef = useRef<HTMLDivElement>(null);
+
     if (sources.length === 0) return null;
+
+    // Build type counts for filter chips
+    const typeCounts = sources.reduce<Record<string, number>>((acc, s) => {
+        const t = s.type ?? "article";
+        acc[t] = (acc[t] ?? 0) + 1;
+        return acc;
+    }, {});
+
+    const types = Object.entries(typeCounts).sort((a, b) => b[1] - a[1]);
+    const filtered = activeFilter
+        ? sources.filter(s => (s.type ?? "article") === activeFilter)
+        : sources;
+
+    const scroll = (direction: "left" | "right") => {
+        if (!scrollRef.current) return;
+        scrollRef.current.scrollBy({
+            left: direction === "left" ? -320 : 320,
+            behavior: "smooth",
+        });
+    };
 
     return (
         <div className="space-y-3">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                {sources.map((source) => {
-                    const type = (source.type ?? "article") as SourceType;
-                    const colors = SOURCE_TYPE_COLORS[type] ?? SOURCE_TYPE_COLORS.article;
+            {/* Filter chips */}
+            {types.length > 1 && (
+                <div className="flex flex-wrap gap-2">
+                    <button
+                        onClick={() => setActiveFilter(null)}
+                        aria-pressed={activeFilter === null}
+                        className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                            activeFilter === null
+                                ? "bg-pastypink text-white"
+                                : "glass-subtle text-muted-foreground hover:text-foreground"
+                        }`}
+                    >
+                        All ({sources.length})
+                    </button>
+                    {types.map(([type, count]) => {
+                        const colors = SOURCE_TYPE_COLORS[type as SourceType] ?? SOURCE_TYPE_COLORS.article;
+                        return (
+                            <button
+                                key={type}
+                                onClick={() => setActiveFilter(activeFilter === type ? null : type)}
+                                aria-pressed={activeFilter === type}
+                                className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                                    activeFilter === type
+                                        ? `${colors.bg} ${colors.text}`
+                                        : "glass-subtle text-muted-foreground hover:text-foreground"
+                                }`}
+                            >
+                                {TYPE_LABELS[type] ?? type} ({count})
+                            </button>
+                        );
+                    })}
+                </div>
+            )}
 
-                    return (
-                        <a
-                            key={source.id}
-                            href={source.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="group glass-subtle p-4 rounded-xl flex flex-col gap-2 hover:scale-[1.02] transition-all duration-300 hover:shadow-[0_0_20px_rgba(239,149,255,0.4)]"
-                        >
-                            <div className="flex items-start justify-between gap-2">
-                                <span
-                                    className={`inline-flex px-2 py-0.5 rounded-md text-[10px] font-bold uppercase tracking-wide ${colors.bg} ${colors.text} ${colors.border} border`}
-                                >
-                                    {TYPE_LABELS[type] ?? "Article"}
-                                </span>
-                                <ExternalLink
-                                    size={14}
-                                    className="text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0 mt-0.5"
-                                />
-                            </div>
-                            <h3 className="text-sm font-semibold text-black dark:text-white leading-snug line-clamp-2">
-                                {source.title ?? "Untitled"}
-                            </h3>
-                            {source.snippet && (
-                                <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2">
-                                    {source.snippet}
-                                </p>
-                            )}
-                            <span className="text-[11px] text-muted-foreground/60 mt-auto">
-                                {getSourceDomain(source.url)}
-                            </span>
-                        </a>
-                    );
-                })}
+            {/* Carousel */}
+            <div className="relative group/carousel">
+                {/* Left arrow */}
+                <button
+                    onClick={() => scroll("left")}
+                    className="absolute -left-3 top-1/2 -translate-y-1/2 z-10 w-9 h-9 rounded-full bg-black/60 backdrop-blur-md flex items-center justify-center text-white opacity-0 group-hover/carousel:opacity-100 transition-opacity hover:bg-black/80 shadow-lg"
+                    aria-label="Scroll left"
+                >
+                    <ChevronLeft size={18} />
+                </button>
+
+                {/* Scrollable container — extra padding for hover scale */}
+                <div
+                    ref={scrollRef}
+                    className="flex gap-4 overflow-x-auto overflow-y-visible py-4 px-2 -mx-2 scrollbar-none snap-x snap-mandatory"
+                    style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+                >
+                    {filtered.map((source) => (
+                        <div key={source.id} className="snap-start">
+                            <SourceCard source={source} />
+                        </div>
+                    ))}
+                </div>
+
+                {/* Right arrow */}
+                <button
+                    onClick={() => scroll("right")}
+                    className="absolute -right-3 top-1/2 -translate-y-1/2 z-10 w-9 h-9 rounded-full bg-black/60 backdrop-blur-md flex items-center justify-center text-white opacity-0 group-hover/carousel:opacity-100 transition-opacity hover:bg-black/80 shadow-lg"
+                    aria-label="Scroll right"
+                >
+                    <ChevronRight size={18} />
+                </button>
             </div>
         </div>
     );

--- a/src/app/artist/[id]/_components/PressAndFeatures.tsx
+++ b/src/app/artist/[id]/_components/PressAndFeatures.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useMemo } from "react";
 import { SOURCE_TYPE_COLORS, type SourceType } from "@/lib/sourceTypes";
-import { ExternalLink, ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
 interface VaultSource {
     id: string;

--- a/src/app/artist/[id]/_components/PressAndFeatures.tsx
+++ b/src/app/artist/[id]/_components/PressAndFeatures.tsx
@@ -140,8 +140,6 @@ export default function PressAndFeatures({ sources, artistName }: PressAndFeatur
         };
     }, [sources, activeFilter]);
 
-    if (sources.length === 0) return null;
-
     const scroll = (direction: "left" | "right") => {
         if (!scrollRef.current) return;
         // Use first card's width + gap for scroll amount, fallback to container width
@@ -152,6 +150,8 @@ export default function PressAndFeatures({ sources, artistName }: PressAndFeatur
             behavior: "smooth",
         });
     };
+
+    if (sources.length === 0) return null;
 
     return (
         <div className="space-y-3">

--- a/src/app/artist/[id]/_components/PressAndFeatures.tsx
+++ b/src/app/artist/[id]/_components/PressAndFeatures.tsx
@@ -26,6 +26,8 @@ function getSourceDomain(url: string): string {
     }
 }
 
+// Privacy note: Google favicon service sees which domains are rendered.
+// Consider self-hosted proxy if this becomes a concern.
 function getFaviconUrl(url: string): string {
     try {
         const domain = new URL(url).hostname;

--- a/src/app/artist/[id]/_components/PressAndFeatures.tsx
+++ b/src/app/artist/[id]/_components/PressAndFeatures.tsx
@@ -125,9 +125,7 @@ export default function PressAndFeatures({ sources, artistName }: PressAndFeatur
     const [activeFilter, setActiveFilter] = useState<string | null>(null);
     const scrollRef = useRef<HTMLDivElement>(null);
 
-    if (sources.length === 0) return null;
-
-    // Build type counts + filtered list (memoized)
+    // Build type counts + filtered list (memoized) — must be before early return
     const { types, filtered } = useMemo(() => {
         const counts: Record<string, number> = {};
         const items: typeof sources = [];
@@ -141,6 +139,8 @@ export default function PressAndFeatures({ sources, artistName }: PressAndFeatur
             filtered: items,
         };
     }, [sources, activeFilter]);
+
+    if (sources.length === 0) return null;
 
     const scroll = (direction: "left" | "right") => {
         if (!scrollRef.current) return;

--- a/src/app/artist/[id]/_components/PressAndFeatures.tsx
+++ b/src/app/artist/[id]/_components/PressAndFeatures.tsx
@@ -141,8 +141,11 @@ export default function PressAndFeatures({ sources, artistName }: PressAndFeatur
 
     const scroll = (direction: "left" | "right") => {
         if (!scrollRef.current) return;
+        // Use first card's width + gap for scroll amount, fallback to container width
+        const firstCard = scrollRef.current.querySelector<HTMLElement>("[data-vault-card]");
+        const amount = firstCard ? firstCard.offsetWidth + 16 : scrollRef.current.clientWidth;
         scrollRef.current.scrollBy({
-            left: direction === "left" ? -320 : 320,
+            left: direction === "left" ? -amount : amount,
             behavior: "smooth",
         });
     };
@@ -201,7 +204,7 @@ export default function PressAndFeatures({ sources, artistName }: PressAndFeatur
                     style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
                 >
                     {filtered.map((source) => (
-                        <div key={source.id} className="snap-start">
+                        <div key={source.id} className="snap-start" data-vault-card>
                             <SourceCard source={source} />
                         </div>
                     ))}

--- a/src/app/artist/[id]/page.tsx
+++ b/src/app/artist/[id]/page.tsx
@@ -111,9 +111,7 @@ export default async function ArtistProfile({ params }: ArtistProfileProps) {
                     <h1 className="text-black dark:text-white text-2xl font-bold">
                         {artist.name}
                     </h1>
-                    <div className="text-black dark:text-gray-300 text-sm">
-                        {artist && getArtistDetailsText(artist, numReleases)}
-                    </div>
+                    {/* Release count hidden for now — revisit when discography feature is built */}
                     <div className="flex justify-center gap-2 pt-1">
                         <ClaimButton
                             artistId={artist.id}
@@ -185,7 +183,7 @@ export default async function ArtistProfile({ params }: ArtistProfileProps) {
                 {/* 7. Press & Features (vault sources) */}
                 {approvedSources.length > 0 && (
                     <RevealSection className="glass p-5 space-y-3">
-                        <h2 className="text-black dark:text-white text-xl font-bold">Press & Features</h2>
+                        <h2 className="text-black dark:text-white text-xl font-bold">Artist Vault</h2>
                         <PressAndFeatures sources={approvedSources} artistName={artist.name ?? ""} />
                     </RevealSection>
                 )}

--- a/src/app/artist/[id]/page.tsx
+++ b/src/app/artist/[id]/page.tsx
@@ -3,7 +3,7 @@ import { musicPlatformData } from "@/server/utils/musicPlatform";
 import ArtistLinksGrid from "@/app/_components/ArtistLinksGrid";
 import BookmarkButton from "@/app/_components/BookmarkButton";
 import ClaimButton from "./_components/ClaimButton";
-import { getArtistDetailsText } from "@/server/utils/services";
+// import { getArtistDetailsText } from "@/server/utils/services"; // Hidden until discography feature
 import { getServerAuthSession } from "@/server/auth";
 import { getDevSession } from "@/server/utils/dev-auth";
 import { getUserById } from "@/server/utils/queries/userQueries";
@@ -87,7 +87,7 @@ export default async function ArtistProfile({ params }: ArtistProfileProps) {
     ]);
 
     const platformImage = platformData?.imageUrl ?? null;
-    const numReleases = platformData?.albumCount ?? 0;
+    // const numReleases = platformData?.albumCount ?? 0; // Hidden until discography feature
 
     const isClaimed = !!existingClaim && existingClaim.status === "approved";
     const isPending = !!existingClaim && existingClaim.status === "pending";

--- a/src/app/dashboard/_components/BioVersionsSection.tsx
+++ b/src/app/dashboard/_components/BioVersionsSection.tsx
@@ -6,16 +6,13 @@ import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { Pin, Trash2, Save, ChevronDown } from "lucide-react";
 import { getArtistBioVersions, saveCurrentBio, pinBioVersionAction, deleteBioVersionAction } from "@/app/actions/dashboardActions";
+import type { InferSelectModel } from "drizzle-orm";
+import type { artistBioVersions } from "@/server/db/schema";
+
+type BioVersion = InferSelectModel<typeof artistBioVersions>;
 
 interface BioVersionsSectionProps {
     currentBio: string | null;
-}
-
-interface BioVersion {
-    id: string;
-    bioText: string;
-    isPinned: boolean;
-    createdAt: string;
 }
 
 export default function BioVersionsSection({ currentBio }: BioVersionsSectionProps) {
@@ -30,7 +27,7 @@ export default function BioVersionsSection({ currentBio }: BioVersionsSectionPro
     useEffect(() => {
         getArtistBioVersions().then(result => {
             if (result.success && result.versions) {
-                setVersions(result.versions as BioVersion[]);
+                setVersions(result.versions);
             }
             setLoading(false);
         });
@@ -44,7 +41,7 @@ export default function BioVersionsSection({ currentBio }: BioVersionsSectionPro
             toast({ title: "Bio saved to versions" });
             // Refresh versions list
             const updated = await getArtistBioVersions();
-            if (updated.success && updated.versions) setVersions(updated.versions as BioVersion[]);
+            if (updated.success && updated.versions) setVersions(updated.versions);
         } else {
             toast({ title: "Error", description: result.error, variant: "destructive" });
         }
@@ -57,7 +54,7 @@ export default function BioVersionsSection({ currentBio }: BioVersionsSectionPro
         if (result.success) {
             toast({ title: "Bio pinned — now showing on your profile" });
             const updated = await getArtistBioVersions();
-            if (updated.success && updated.versions) setVersions(updated.versions as BioVersion[]);
+            if (updated.success && updated.versions) setVersions(updated.versions);
             router.refresh();
         } else {
             toast({ title: "Error", description: result.error, variant: "destructive" });

--- a/src/app/dashboard/_components/BioVersionsSection.tsx
+++ b/src/app/dashboard/_components/BioVersionsSection.tsx
@@ -75,7 +75,7 @@ export default function BioVersionsSection({ currentBio }: BioVersionsSectionPro
     };
 
     const formatDate = (dateStr: string) => {
-        const d = new Date(dateStr.endsWith("Z") ? dateStr : `${dateStr}Z`);
+        const d = new Date(dateStr);
         return d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
     };
 

--- a/src/app/dashboard/_components/BioVersionsSection.tsx
+++ b/src/app/dashboard/_components/BioVersionsSection.tsx
@@ -32,7 +32,8 @@ export default function BioVersionsSection({ currentBio }: BioVersionsSectionPro
         }).catch(() => {
             toast({ title: "Error", description: "Failed to load bio versions", variant: "destructive" });
         }).finally(() => setLoading(false));
-    }, [toast]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const handleSaveCurrent = async () => {
         if (!currentBio) return;
@@ -150,15 +151,17 @@ export default function BioVersionsSection({ currentBio }: BioVersionsSectionPro
                                             Pin
                                         </Button>
                                     )}
-                                    <Button
-                                        variant="ghost"
-                                        size="sm"
-                                        onClick={() => handleDelete(version.id)}
-                                        disabled={actionId === version.id}
-                                        className="h-7 w-7 p-0 text-muted-foreground hover:text-red-500"
-                                    >
-                                        <Trash2 size={12} />
-                                    </Button>
+                                    {!version.isPinned && (
+                                        <Button
+                                            variant="ghost"
+                                            size="sm"
+                                            onClick={() => handleDelete(version.id)}
+                                            disabled={actionId === version.id}
+                                            className="h-7 w-7 p-0 text-muted-foreground hover:text-red-500"
+                                        >
+                                            <Trash2 size={12} />
+                                        </Button>
+                                    )}
                                 </div>
                             </div>
                             <p className="text-xs text-muted-foreground leading-relaxed line-clamp-3">

--- a/src/app/dashboard/_components/BioVersionsSection.tsx
+++ b/src/app/dashboard/_components/BioVersionsSection.tsx
@@ -9,7 +9,6 @@ import { getArtistBioVersions, saveCurrentBio, pinBioVersionAction, deleteBioVer
 
 interface BioVersionsSectionProps {
     currentBio: string | null;
-    artistId: string;
 }
 
 interface BioVersion {
@@ -19,7 +18,7 @@ interface BioVersion {
     createdAt: string;
 }
 
-export default function BioVersionsSection({ currentBio, artistId }: BioVersionsSectionProps) {
+export default function BioVersionsSection({ currentBio }: BioVersionsSectionProps) {
     const router = useRouter();
     const { toast } = useToast();
     const [versions, setVersions] = useState<BioVersion[]>([]);

--- a/src/app/dashboard/_components/BioVersionsSection.tsx
+++ b/src/app/dashboard/_components/BioVersionsSection.tsx
@@ -29,49 +29,64 @@ export default function BioVersionsSection({ currentBio }: BioVersionsSectionPro
             if (result.success && result.versions) {
                 setVersions(result.versions);
             }
-            setLoading(false);
-        });
-    }, []);
+        }).catch(() => {
+            toast({ title: "Error", description: "Failed to load bio versions", variant: "destructive" });
+        }).finally(() => setLoading(false));
+    }, [toast]);
 
     const handleSaveCurrent = async () => {
         if (!currentBio) return;
         setSaving(true);
-        const result = await saveCurrentBio(currentBio);
-        if (result.success) {
-            toast({ title: "Bio saved to versions" });
-            // Refresh versions list
-            const updated = await getArtistBioVersions();
-            if (updated.success && updated.versions) setVersions(updated.versions);
-        } else {
-            toast({ title: "Error", description: result.error, variant: "destructive" });
+        try {
+            const result = await saveCurrentBio(currentBio);
+            if (result.success) {
+                toast({ title: "Bio saved to versions" });
+                const updated = await getArtistBioVersions();
+                if (updated.success && updated.versions) setVersions(updated.versions);
+            } else {
+                toast({ title: "Error", description: result.error, variant: "destructive" });
+            }
+        } catch {
+            toast({ title: "Error", description: "Failed to save bio", variant: "destructive" });
+        } finally {
+            setSaving(false);
         }
-        setSaving(false);
     };
 
     const handlePin = async (versionId: string) => {
         setActionId(versionId);
-        const result = await pinBioVersionAction(versionId);
-        if (result.success) {
-            toast({ title: "Bio pinned — now showing on your profile" });
-            const updated = await getArtistBioVersions();
-            if (updated.success && updated.versions) setVersions(updated.versions);
-            router.refresh();
-        } else {
-            toast({ title: "Error", description: result.error, variant: "destructive" });
+        try {
+            const result = await pinBioVersionAction(versionId);
+            if (result.success) {
+                toast({ title: "Bio pinned — now showing on your profile" });
+                const updated = await getArtistBioVersions();
+                if (updated.success && updated.versions) setVersions(updated.versions);
+                router.refresh();
+            } else {
+                toast({ title: "Error", description: result.error, variant: "destructive" });
+            }
+        } catch {
+            toast({ title: "Error", description: "Failed to pin bio", variant: "destructive" });
+        } finally {
+            setActionId(null);
         }
-        setActionId(null);
     };
 
     const handleDelete = async (versionId: string) => {
         setActionId(versionId);
-        const result = await deleteBioVersionAction(versionId);
-        if (result.success) {
-            toast({ title: "Bio version deleted" });
-            setVersions(prev => prev.filter(v => v.id !== versionId));
-        } else {
-            toast({ title: "Error", description: result.error, variant: "destructive" });
+        try {
+            const result = await deleteBioVersionAction(versionId);
+            if (result.success) {
+                toast({ title: "Bio version deleted" });
+                setVersions(prev => prev.filter(v => v.id !== versionId));
+            } else {
+                toast({ title: "Error", description: result.error, variant: "destructive" });
+            }
+        } catch {
+            toast({ title: "Error", description: "Failed to delete bio version", variant: "destructive" });
+        } finally {
+            setActionId(null);
         }
-        setActionId(null);
     };
 
     const formatDate = (dateStr: string) => {

--- a/src/app/dashboard/_components/BioVersionsSection.tsx
+++ b/src/app/dashboard/_components/BioVersionsSection.tsx
@@ -11,6 +11,11 @@ import type { artistBioVersions } from "@/server/db/schema";
 
 type BioVersion = InferSelectModel<typeof artistBioVersions>;
 
+function formatDate(dateStr: string): string {
+    const d = new Date(dateStr);
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}
+
 interface BioVersionsSectionProps {
     currentBio: string | null;
 }
@@ -88,11 +93,6 @@ export default function BioVersionsSection({ currentBio }: BioVersionsSectionPro
         } finally {
             setActionId(null);
         }
-    };
-
-    const formatDate = (dateStr: string) => {
-        const d = new Date(dateStr);
-        return d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
     };
 
     return (

--- a/src/app/dashboard/_components/BioVersionsSection.tsx
+++ b/src/app/dashboard/_components/BioVersionsSection.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+import { Pin, Trash2, Save, ChevronDown } from "lucide-react";
+import { getArtistBioVersions, saveCurrentBio, pinBioVersionAction, deleteBioVersionAction } from "@/app/actions/dashboardActions";
+
+interface BioVersionsSectionProps {
+    currentBio: string | null;
+    artistId: string;
+}
+
+interface BioVersion {
+    id: string;
+    bioText: string;
+    isPinned: boolean;
+    createdAt: string;
+}
+
+export default function BioVersionsSection({ currentBio, artistId }: BioVersionsSectionProps) {
+    const router = useRouter();
+    const { toast } = useToast();
+    const [versions, setVersions] = useState<BioVersion[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [expanded, setExpanded] = useState(false);
+    const [actionId, setActionId] = useState<string | null>(null);
+
+    useEffect(() => {
+        getArtistBioVersions().then(result => {
+            if (result.success && result.versions) {
+                setVersions(result.versions as BioVersion[]);
+            }
+            setLoading(false);
+        });
+    }, []);
+
+    const handleSaveCurrent = async () => {
+        if (!currentBio) return;
+        setSaving(true);
+        const result = await saveCurrentBio(currentBio);
+        if (result.success) {
+            toast({ title: "Bio saved to versions" });
+            // Refresh versions list
+            const updated = await getArtistBioVersions();
+            if (updated.success && updated.versions) setVersions(updated.versions as BioVersion[]);
+        } else {
+            toast({ title: "Error", description: result.error, variant: "destructive" });
+        }
+        setSaving(false);
+    };
+
+    const handlePin = async (versionId: string) => {
+        setActionId(versionId);
+        const result = await pinBioVersionAction(versionId);
+        if (result.success) {
+            toast({ title: "Bio pinned — now showing on your profile" });
+            const updated = await getArtistBioVersions();
+            if (updated.success && updated.versions) setVersions(updated.versions as BioVersion[]);
+            router.refresh();
+        } else {
+            toast({ title: "Error", description: result.error, variant: "destructive" });
+        }
+        setActionId(null);
+    };
+
+    const handleDelete = async (versionId: string) => {
+        setActionId(versionId);
+        const result = await deleteBioVersionAction(versionId);
+        if (result.success) {
+            toast({ title: "Bio version deleted" });
+            setVersions(prev => prev.filter(v => v.id !== versionId));
+        } else {
+            toast({ title: "Error", description: result.error, variant: "destructive" });
+        }
+        setActionId(null);
+    };
+
+    const formatDate = (dateStr: string) => {
+        const d = new Date(dateStr.endsWith("Z") ? dateStr : `${dateStr}Z`);
+        return d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+    };
+
+    return (
+        <div className="glass p-5 space-y-4">
+            <div className="flex items-center justify-between">
+                <h3 className="text-lg font-bold text-foreground">Saved Bios</h3>
+                <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleSaveCurrent}
+                    disabled={saving || !currentBio}
+                    className="text-xs border-pastypink/50 text-pastypink hover:bg-pastypink hover:text-white"
+                >
+                    <Save size={14} className="mr-1" />
+                    {saving ? "Saving..." : "Save Current Bio"}
+                </Button>
+            </div>
+
+            <p className="text-xs text-muted-foreground">
+                Save your current bio before regenerating so you can switch back anytime.
+            </p>
+
+            {loading ? (
+                <p className="text-sm text-muted-foreground">Loading...</p>
+            ) : versions.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No saved bios yet. Click &quot;Save Current Bio&quot; to save your first version.</p>
+            ) : (
+                <div className="space-y-2">
+                    {(expanded ? versions : versions.slice(0, 3)).map((version) => (
+                        <div
+                            key={version.id}
+                            className={`glass-subtle p-3 rounded-xl space-y-2 ${version.isPinned ? "ring-1 ring-pastypink/40" : ""}`}
+                        >
+                            <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-2">
+                                    {version.isPinned && (
+                                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-pastypink/15 text-pastypink text-[10px] font-semibold">
+                                            <Pin size={10} />
+                                            Active
+                                        </span>
+                                    )}
+                                    <span className="text-[11px] text-muted-foreground">
+                                        {formatDate(version.createdAt)}
+                                    </span>
+                                </div>
+                                <div className="flex gap-1">
+                                    {!version.isPinned && (
+                                        <Button
+                                            variant="ghost"
+                                            size="sm"
+                                            onClick={() => handlePin(version.id)}
+                                            disabled={actionId === version.id}
+                                            className="h-7 px-2 text-xs text-muted-foreground hover:text-pastypink"
+                                        >
+                                            <Pin size={12} className="mr-1" />
+                                            Pin
+                                        </Button>
+                                    )}
+                                    <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={() => handleDelete(version.id)}
+                                        disabled={actionId === version.id}
+                                        className="h-7 w-7 p-0 text-muted-foreground hover:text-red-500"
+                                    >
+                                        <Trash2 size={12} />
+                                    </Button>
+                                </div>
+                            </div>
+                            <p className="text-xs text-muted-foreground leading-relaxed line-clamp-3">
+                                {version.bioText}
+                            </p>
+                        </div>
+                    ))}
+
+                    {versions.length > 3 && (
+                        <button
+                            onClick={() => setExpanded(!expanded)}
+                            className="w-full flex items-center justify-center gap-1 py-1.5 text-xs text-muted-foreground hover:text-pastypink transition-colors"
+                        >
+                            <ChevronDown size={14} className={`transition-transform ${expanded ? "rotate-180" : ""}`} />
+                            {expanded ? "Show less" : `Show ${versions.length - 3} more`}
+                        </button>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/dashboard/_components/DashboardContent.tsx
+++ b/src/app/dashboard/_components/DashboardContent.tsx
@@ -346,7 +346,6 @@ export default function DashboardContent({
                 />
                 <BioVersionsSection
                     currentBio={artistBio ?? null}
-                    artistId={artistId}
                 />
             </div>
 

--- a/src/app/dashboard/_components/DashboardContent.tsx
+++ b/src/app/dashboard/_components/DashboardContent.tsx
@@ -14,6 +14,7 @@ import { SOURCE_TYPE_COLORS, type SourceType } from "@/lib/sourceTypes";
 import type { ArtistVaultSource, UrlMap } from "@/server/db/DbTypes";
 import type { ArtistLink } from "@/server/utils/queries/artistQueries";
 import DashboardLinksSection from "./DashboardLinksSection";
+import BioVersionsSection from "./BioVersionsSection";
 
 interface FileUploadStatus {
     name: string;
@@ -26,6 +27,7 @@ interface DashboardContentProps {
     artistId: string;
     artistImage: string;
     artistSpotify?: string | null;
+    artistBio?: string | null;
     pendingSources: ArtistVaultSource[];
     approvedSources: ArtistVaultSource[];
     artistLinks: ArtistLink[];
@@ -37,6 +39,7 @@ export default function DashboardContent({
     artistId,
     artistImage,
     artistSpotify,
+    artistBio,
     pendingSources,
     approvedSources,
     artistLinks,
@@ -333,13 +336,19 @@ export default function DashboardContent({
             {/* Two-column layout on desktop */}
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
 
-            {/* Left column: Manage Links */}
-            <DashboardLinksSection
-                artistId={artistId}
-                artistSpotify={artistSpotify}
-                artistLinks={artistLinks}
-                availableLinks={availableLinks}
-            />
+            {/* Left column: Manage Links + Bio Versions */}
+            <div className="space-y-6">
+                <DashboardLinksSection
+                    artistId={artistId}
+                    artistSpotify={artistSpotify}
+                    artistLinks={artistLinks}
+                    availableLinks={availableLinks}
+                />
+                <BioVersionsSection
+                    currentBio={artistBio ?? null}
+                    artistId={artistId}
+                />
+            </div>
 
             {/* Right column: Vault Sources */}
             <div className="space-y-6">
@@ -367,6 +376,19 @@ export default function DashboardContent({
                         {loading ? "Seeding..." : "Seed Mock Data"}
                     </Button>
                 )}
+            </div>
+
+            {/* Context note */}
+            <div className="glass-subtle p-4 flex gap-3 items-start">
+                <div className="shrink-0 w-8 h-8 rounded-full bg-pastypink/10 flex items-center justify-center">
+                    <Globe size={16} className="text-pastypink" />
+                </div>
+                <div>
+                    <p className="text-sm font-medium text-black dark:text-white">Your vault powers your profile</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                        Approved sources are used as context for your <strong>Artist Summary</strong> and the <strong>Ask About</strong> section on your profile. The more quality sources you add, the better your AI-generated content will be.
+                    </p>
+                </div>
             </div>
 
             {/* Add Source: URL + File Upload */}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -98,6 +98,7 @@ export default async function Dashboard() {
                 artistId={claim.artistId}
                 artistImage={currentImage}
                 artistSpotify={artist?.spotify ?? null}
+                artistBio={artist?.bio ?? null}
                 pendingSources={pendingSources}
                 approvedSources={approvedSources}
                 artistLinks={artistLinks}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -369,6 +369,7 @@ export const artistVaultSources = pgTable("artist_vault_sources", {
 	filePath: text("file_path"),
 	contentType: text("content_type"),
 	extractedText: text("extracted_text"),
+	ogImage: text("og_image"),
 	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).default(sql`(now() AT TIME ZONE 'utc'::text)`).notNull(),
 	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }).default(sql`(now() AT TIME ZONE 'utc'::text)`).notNull(),
 }, (table) => [
@@ -382,6 +383,25 @@ export const artistVaultSources = pgTable("artist_vault_sources", {
 	pgPolicy("mnweb_insert_artist_vault_sources", { as: "permissive", for: "insert", to: ["mnweb"] }),
 	pgPolicy("mnweb_select_artist_vault_sources", { as: "permissive", for: "select", to: ["mnweb"] }),
 	pgPolicy("mnweb_update_artist_vault_sources", { as: "permissive", for: "update", to: ["mnweb"] }),
+]);
+
+export const artistBioVersions = pgTable("artist_bio_versions", {
+	id: uuid().default(sql`uuid_generate_v4()`).primaryKey().notNull(),
+	artistId: uuid("artist_id").notNull(),
+	bioText: text("bio_text").notNull(),
+	isPinned: boolean("is_pinned").default(false).notNull(),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).default(sql`(now() AT TIME ZONE 'utc'::text)`).notNull(),
+}, (table) => [
+	index("idx_artist_bio_versions_artist_id").using("btree", table.artistId.asc().nullsLast().op("uuid_ops")),
+	foreignKey({
+		columns: [table.artistId],
+		foreignColumns: [artists.id],
+		name: "artist_bio_versions_artist_id_fkey"
+	}),
+	pgPolicy("mnweb_select_artist_bio_versions", { as: "permissive", for: "select", to: ["mnweb"], using: sql`true` }),
+	pgPolicy("mnweb_insert_artist_bio_versions", { as: "permissive", for: "insert", to: ["mnweb"] }),
+	pgPolicy("mnweb_update_artist_bio_versions", { as: "permissive", for: "update", to: ["mnweb"] }),
+	pgPolicy("mnweb_delete_artist_bio_versions", { as: "permissive", for: "delete", to: ["mnweb"], using: sql`true` }),
 ]);
 
 export const exclusionReason = pgEnum("exclusion_reason", [
@@ -504,6 +524,14 @@ export const artistsRelations = relations(artists, ({one, many}) => ({
 	}),
 	artistClaims: many(artistClaims),
 	artistVaultSources: many(artistVaultSources),
+	artistBioVersions: many(artistBioVersions),
+}));
+
+export const artistBioVersionsRelations = relations(artistBioVersions, ({one}) => ({
+	artist: one(artists, {
+		fields: [artistBioVersions.artistId],
+		references: [artists.id]
+	}),
 }));
 
 export const usersRelations = relations(users, ({many}) => ({

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -397,7 +397,7 @@ export const artistBioVersions = pgTable("artist_bio_versions", {
 		columns: [table.artistId],
 		foreignColumns: [artists.id],
 		name: "artist_bio_versions_artist_id_fkey"
-	}),
+	}).onDelete("cascade"),
 	pgPolicy("mnweb_select_artist_bio_versions", { as: "permissive", for: "select", to: ["mnweb"], using: sql`true` }),
 	pgPolicy("mnweb_insert_artist_bio_versions", { as: "permissive", for: "insert", to: ["mnweb"] }),
 	pgPolicy("mnweb_update_artist_bio_versions", { as: "permissive", for: "update", to: ["mnweb"] }),

--- a/src/server/utils/fetchPageContent.ts
+++ b/src/server/utils/fetchPageContent.ts
@@ -2,6 +2,7 @@ export interface PageContent {
     title: string;
     snippet?: string;
     extractedText: string | null;
+    ogImage?: string;
 }
 
 /** Decode HTML entities (&#8217; → ', &amp; → &, etc.) */
@@ -77,6 +78,7 @@ export async function fetchPageContent(url: string): Promise<PageContent> {
     let title = "Untitled Source";
     let snippet: string | undefined;
     let extractedText: string | null = null;
+    let ogImage: string | undefined;
 
     if (isUnsafeUrl(url)) {
         return { title, extractedText: null };
@@ -109,6 +111,15 @@ export async function fetchPageContent(url: string): Promise<PageContent> {
                 if (ogMatch?.[1]) snippet = decodeEntities(ogMatch[1].trim());
             }
 
+            // Extract og:image
+            const ogImgMatch = html.match(/<meta[^>]*property=["']og:image["'][^>]*content=["']([^"']+)["']/i)
+                ?? html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']og:image["']/i);
+            if (ogImgMatch?.[1]) {
+                const imgUrl = ogImgMatch[1].trim();
+                // Only use https images, skip data URIs and relative paths
+                if (imgUrl.startsWith("https://")) ogImage = imgUrl;
+            }
+
             // Extract body text (strip tags, collapse whitespace)
             const bodyMatch = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
             if (bodyMatch?.[1]) {
@@ -127,5 +138,5 @@ export async function fetchPageContent(url: string): Promise<PageContent> {
         // Fetch failed — return what we have
     }
 
-    return { title, snippet, extractedText };
+    return { title, snippet, extractedText, ogImage };
 }

--- a/src/server/utils/queries/dashboardQueries.ts
+++ b/src/server/utils/queries/dashboardQueries.ts
@@ -455,14 +455,16 @@ export async function pinBioVersion(versionId: string, artistId: string) {
 
 export async function deleteBioVersion(versionId: string, artistId: string) {
     try {
-        // Only delete if version belongs to this artist and is not pinned
+        // Check if version exists and its state
+        const version = await db.query.artistBioVersions.findFirst({
+            where: and(eq(artistBioVersions.id, versionId), eq(artistBioVersions.artistId, artistId)),
+        });
+        if (!version) return undefined; // not found
+        if (version.isPinned) throw new Error("Cannot delete a pinned bio version");
+
         const [deleted] = await db
             .delete(artistBioVersions)
-            .where(and(
-                eq(artistBioVersions.id, versionId),
-                eq(artistBioVersions.artistId, artistId),
-                eq(artistBioVersions.isPinned, false),
-            ))
+            .where(and(eq(artistBioVersions.id, versionId), eq(artistBioVersions.artistId, artistId)))
             .returning();
         return deleted;
     } catch (e) {

--- a/src/server/utils/queries/dashboardQueries.ts
+++ b/src/server/utils/queries/dashboardQueries.ts
@@ -455,18 +455,20 @@ export async function pinBioVersion(versionId: string, artistId: string) {
 
 export async function deleteBioVersion(versionId: string, artistId: string) {
     try {
-        // Check if version exists and its state
-        const version = await db.query.artistBioVersions.findFirst({
-            where: and(eq(artistBioVersions.id, versionId), eq(artistBioVersions.artistId, artistId)),
-        });
-        if (!version) return undefined; // not found
-        if (version.isPinned) throw new Error("Cannot delete a pinned bio version");
+        // Atomic check + delete to prevent TOCTOU race with concurrent pin
+        return await db.transaction(async (tx) => {
+            const version = await tx.query.artistBioVersions.findFirst({
+                where: and(eq(artistBioVersions.id, versionId), eq(artistBioVersions.artistId, artistId)),
+            });
+            if (!version) return undefined;
+            if (version.isPinned) throw new Error("Cannot delete a pinned bio version");
 
-        const [deleted] = await db
-            .delete(artistBioVersions)
-            .where(and(eq(artistBioVersions.id, versionId), eq(artistBioVersions.artistId, artistId)))
-            .returning();
-        return deleted;
+            const [deleted] = await tx
+                .delete(artistBioVersions)
+                .where(and(eq(artistBioVersions.id, versionId), eq(artistBioVersions.artistId, artistId)))
+                .returning();
+            return deleted;
+        });
     } catch (e) {
         console.error("[deleteBioVersion] Error:", e);
         throw e;

--- a/src/server/utils/queries/dashboardQueries.ts
+++ b/src/server/utils/queries/dashboardQueries.ts
@@ -393,12 +393,20 @@ export async function getBioVersionsByArtistId(artistId: string) {
 
 export async function saveBioVersion(artistId: string, bioText: string, isPinned = false) {
     try {
-        // If pinning, unpin all others first
         if (isPinned) {
-            await db
-                .update(artistBioVersions)
-                .set({ isPinned: false })
-                .where(eq(artistBioVersions.artistId, artistId));
+            // Atomic: unpin all → insert pinned
+            return await db.transaction(async (tx) => {
+                await tx
+                    .update(artistBioVersions)
+                    .set({ isPinned: false })
+                    .where(eq(artistBioVersions.artistId, artistId));
+
+                const [version] = await tx
+                    .insert(artistBioVersions)
+                    .values({ artistId, bioText, isPinned })
+                    .returning();
+                return version;
+            });
         }
 
         const [version] = await db
@@ -414,39 +422,46 @@ export async function saveBioVersion(artistId: string, bioText: string, isPinned
 
 export async function pinBioVersion(versionId: string, artistId: string) {
     try {
-        // Unpin all versions for this artist
-        await db
-            .update(artistBioVersions)
-            .set({ isPinned: false })
-            .where(eq(artistBioVersions.artistId, artistId));
+        // Verify version belongs to this artist
+        const version = await db.query.artistBioVersions.findFirst({
+            where: and(eq(artistBioVersions.id, versionId), eq(artistBioVersions.artistId, artistId)),
+        });
+        if (!version) throw new Error("Version not found or does not belong to this artist");
 
-        // Pin the selected version
-        const [pinned] = await db
-            .update(artistBioVersions)
-            .set({ isPinned: true })
-            .where(eq(artistBioVersions.id, versionId))
-            .returning();
+        // Atomic: unpin all → pin selected → update artist bio
+        return await db.transaction(async (tx) => {
+            await tx
+                .update(artistBioVersions)
+                .set({ isPinned: false })
+                .where(eq(artistBioVersions.artistId, artistId));
 
-        // Update the artist's active bio
-        if (pinned) {
-            await db
-                .update(artists)
-                .set({ bio: pinned.bioText })
-                .where(eq(artists.id, artistId));
-        }
+            const [pinned] = await tx
+                .update(artistBioVersions)
+                .set({ isPinned: true })
+                .where(and(eq(artistBioVersions.id, versionId), eq(artistBioVersions.artistId, artistId)))
+                .returning();
 
-        return pinned;
+            if (pinned) {
+                await tx
+                    .update(artists)
+                    .set({ bio: pinned.bioText })
+                    .where(eq(artists.id, artistId));
+            }
+
+            return pinned;
+        });
     } catch (e) {
         console.error("[pinBioVersion] Error:", e);
         throw e;
     }
 }
 
-export async function deleteBioVersion(versionId: string) {
+export async function deleteBioVersion(versionId: string, artistId: string) {
     try {
+        // Only delete if version belongs to this artist
         const [deleted] = await db
             .delete(artistBioVersions)
-            .where(eq(artistBioVersions.id, versionId))
+            .where(and(eq(artistBioVersions.id, versionId), eq(artistBioVersions.artistId, artistId)))
             .returning();
         return deleted;
     } catch (e) {

--- a/src/server/utils/queries/dashboardQueries.ts
+++ b/src/server/utils/queries/dashboardQueries.ts
@@ -393,40 +393,28 @@ export async function getBioVersionsByArtistId(artistId: string) {
 
 const MAX_BIO_VERSIONS = 50;
 
-export async function saveBioVersion(artistId: string, bioText: string, isPinned = false) {
+export async function saveBioVersion(artistId: string, bioText: string) {
     try {
-        // Enforce version cap — delete oldest unpinned if at limit
-        const existing = await db.query.artistBioVersions.findMany({
-            where: eq(artistBioVersions.artistId, artistId),
-            orderBy: (v, { asc }) => [asc(v.createdAt)],
-        });
-        if (existing.length >= MAX_BIO_VERSIONS) {
-            const oldest = existing.find(v => !v.isPinned);
-            if (oldest) {
-                await db.delete(artistBioVersions).where(eq(artistBioVersions.id, oldest.id));
-            }
-        }
-
-        if (isPinned) {
-            return await db.transaction(async (tx) => {
-                await tx
-                    .update(artistBioVersions)
-                    .set({ isPinned: false })
-                    .where(eq(artistBioVersions.artistId, artistId));
-
-                const [version] = await tx
-                    .insert(artistBioVersions)
-                    .values({ artistId, bioText, isPinned })
-                    .returning();
-                return version;
+        // All operations in a single transaction to prevent TOCTOU race on version cap
+        return await db.transaction(async (tx) => {
+            // Enforce version cap — delete oldest unpinned if at limit
+            const existing = await tx.query.artistBioVersions.findMany({
+                where: eq(artistBioVersions.artistId, artistId),
+                orderBy: (v, { asc }) => [asc(v.createdAt)],
             });
-        }
+            if (existing.length >= MAX_BIO_VERSIONS) {
+                const oldest = existing.find(v => !v.isPinned);
+                if (oldest) {
+                    await tx.delete(artistBioVersions).where(eq(artistBioVersions.id, oldest.id));
+                }
+            }
 
-        const [version] = await db
-            .insert(artistBioVersions)
-            .values({ artistId, bioText, isPinned })
-            .returning();
-        return version;
+            const [version] = await tx
+                .insert(artistBioVersions)
+                .values({ artistId, bioText, isPinned: false })
+                .returning();
+            return version;
+        });
     } catch (e) {
         console.error("[saveBioVersion] Error:", e);
         throw e;

--- a/src/server/utils/queries/dashboardQueries.ts
+++ b/src/server/utils/queries/dashboardQueries.ts
@@ -455,10 +455,14 @@ export async function pinBioVersion(versionId: string, artistId: string) {
 
 export async function deleteBioVersion(versionId: string, artistId: string) {
     try {
-        // Only delete if version belongs to this artist
+        // Only delete if version belongs to this artist and is not pinned
         const [deleted] = await db
             .delete(artistBioVersions)
-            .where(and(eq(artistBioVersions.id, versionId), eq(artistBioVersions.artistId, artistId)))
+            .where(and(
+                eq(artistBioVersions.id, versionId),
+                eq(artistBioVersions.artistId, artistId),
+                eq(artistBioVersions.isPinned, false),
+            ))
             .returning();
         return deleted;
     } catch (e) {

--- a/src/server/utils/queries/dashboardQueries.ts
+++ b/src/server/utils/queries/dashboardQueries.ts
@@ -1,6 +1,6 @@
 import { db } from "@/server/db/drizzle";
 import { eq, and, sql } from "drizzle-orm";
-import { artistClaims, artistVaultSources } from "@/server/db/schema";
+import { artistClaims, artistVaultSources, artistBioVersions, artists } from "@/server/db/schema";
 
 export async function getClaimByArtistId(artistId: string) {
     try {
@@ -304,6 +304,7 @@ export async function updateVaultSourceContent(sourceId: string, data: {
     title?: string;
     snippet?: string;
     extractedText?: string | null;
+    ogImage?: string;
 }) {
     try {
         const [updated] = await db
@@ -312,6 +313,7 @@ export async function updateVaultSourceContent(sourceId: string, data: {
                 ...(data.title !== undefined ? { title: data.title } : {}),
                 ...(data.snippet !== undefined ? { snippet: data.snippet } : {}),
                 ...(data.extractedText !== undefined ? { extractedText: data.extractedText } : {}),
+                ...(data.ogImage !== undefined ? { ogImage: data.ogImage } : {}),
                 updatedAt: sql`(now() AT TIME ZONE 'utc'::text)`,
             })
             .where(eq(artistVaultSources.id, sourceId))
@@ -371,6 +373,84 @@ export async function seedMockVaultSources(artistId: string) {
         return await db.insert(artistVaultSources).values(mockSources).returning();
     } catch (e) {
         console.error("[seedMockVaultSources] Error:", e);
+        throw e;
+    }
+}
+
+// ------ Bio Versions ------
+
+export async function getBioVersionsByArtistId(artistId: string) {
+    try {
+        return await db.query.artistBioVersions.findMany({
+            where: eq(artistBioVersions.artistId, artistId),
+            orderBy: (versions, { desc }) => [desc(versions.createdAt)],
+        });
+    } catch (e) {
+        console.error("[getBioVersionsByArtistId] Error:", e);
+        return [];
+    }
+}
+
+export async function saveBioVersion(artistId: string, bioText: string, isPinned = false) {
+    try {
+        // If pinning, unpin all others first
+        if (isPinned) {
+            await db
+                .update(artistBioVersions)
+                .set({ isPinned: false })
+                .where(eq(artistBioVersions.artistId, artistId));
+        }
+
+        const [version] = await db
+            .insert(artistBioVersions)
+            .values({ artistId, bioText, isPinned })
+            .returning();
+        return version;
+    } catch (e) {
+        console.error("[saveBioVersion] Error:", e);
+        throw e;
+    }
+}
+
+export async function pinBioVersion(versionId: string, artistId: string) {
+    try {
+        // Unpin all versions for this artist
+        await db
+            .update(artistBioVersions)
+            .set({ isPinned: false })
+            .where(eq(artistBioVersions.artistId, artistId));
+
+        // Pin the selected version
+        const [pinned] = await db
+            .update(artistBioVersions)
+            .set({ isPinned: true })
+            .where(eq(artistBioVersions.id, versionId))
+            .returning();
+
+        // Update the artist's active bio
+        if (pinned) {
+            await db
+                .update(artists)
+                .set({ bio: pinned.bioText })
+                .where(eq(artists.id, artistId));
+        }
+
+        return pinned;
+    } catch (e) {
+        console.error("[pinBioVersion] Error:", e);
+        throw e;
+    }
+}
+
+export async function deleteBioVersion(versionId: string) {
+    try {
+        const [deleted] = await db
+            .delete(artistBioVersions)
+            .where(eq(artistBioVersions.id, versionId))
+            .returning();
+        return deleted;
+    } catch (e) {
+        console.error("[deleteBioVersion] Error:", e);
         throw e;
     }
 }

--- a/src/server/utils/queries/dashboardQueries.ts
+++ b/src/server/utils/queries/dashboardQueries.ts
@@ -391,10 +391,23 @@ export async function getBioVersionsByArtistId(artistId: string) {
     }
 }
 
+const MAX_BIO_VERSIONS = 50;
+
 export async function saveBioVersion(artistId: string, bioText: string, isPinned = false) {
     try {
+        // Enforce version cap — delete oldest unpinned if at limit
+        const existing = await db.query.artistBioVersions.findMany({
+            where: eq(artistBioVersions.artistId, artistId),
+            orderBy: (v, { asc }) => [asc(v.createdAt)],
+        });
+        if (existing.length >= MAX_BIO_VERSIONS) {
+            const oldest = existing.find(v => !v.isPinned);
+            if (oldest) {
+                await db.delete(artistBioVersions).where(eq(artistBioVersions.id, oldest.id));
+            }
+        }
+
         if (isPinned) {
-            // Atomic: unpin all → insert pinned
             return await db.transaction(async (tx) => {
                 await tx
                     .update(artistBioVersions)

--- a/src/server/utils/queries/dashboardQueries.ts
+++ b/src/server/utils/queries/dashboardQueries.ts
@@ -404,9 +404,10 @@ export async function saveBioVersion(artistId: string, bioText: string) {
             });
             if (existing.length >= MAX_BIO_VERSIONS) {
                 const oldest = existing.find(v => !v.isPinned);
-                if (oldest) {
-                    await tx.delete(artistBioVersions).where(eq(artistBioVersions.id, oldest.id));
+                if (!oldest) {
+                    throw new Error("Bio version limit reached — unpin or delete a version first");
                 }
+                await tx.delete(artistBioVersions).where(eq(artistBioVersions.id, oldest.id));
             }
 
             const [version] = await tx
@@ -423,13 +424,8 @@ export async function saveBioVersion(artistId: string, bioText: string) {
 
 export async function pinBioVersion(versionId: string, artistId: string) {
     try {
-        // Verify version belongs to this artist
-        const version = await db.query.artistBioVersions.findFirst({
-            where: and(eq(artistBioVersions.id, versionId), eq(artistBioVersions.artistId, artistId)),
-        });
-        if (!version) throw new Error("Version not found or does not belong to this artist");
-
         // Atomic: unpin all → pin selected → update artist bio
+        // Ownership is enforced by the WHERE clause (artistId match)
         return await db.transaction(async (tx) => {
             await tx
                 .update(artistBioVersions)

--- a/src/server/utils/queries/vaultWebSearch.ts
+++ b/src/server/utils/queries/vaultWebSearch.ts
@@ -172,6 +172,7 @@ If you cannot find any results specifically about this artist, return an empty a
                             title: content.title,
                             snippet: content.snippet,
                             extractedText: content.extractedText,
+                            ogImage: content.ogImage,
                         }).catch(e => console.error("[vaultWebSearch] Background content update failed:", e));
                     }).catch(e => console.error("[vaultWebSearch] Background fetch failed:", e));
                 }


### PR DESCRIPTION
## Summary
- **Artist Vault carousel**: Redesigned "Press & Features" as "Artist Vault" with horizontal scrollable carousel, filter chips by type, and magazine-style cards with og:image thumbnails
- **og:image extraction**: `fetchPageContent` now extracts Open Graph images from source URLs, stored in `og_image` column on `artist_vault_sources`
- **Bio versioning**: Artists can save, pin, and manage multiple bio versions from their dashboard. Pin sets the active bio on the profile.
- **Save/pin from profile**: Claimed artists and admins can save the current bio to vault and regenerate directly from the artist profile page
- **Access control**: Regenerate and Save buttons only visible for admin/claimed artist (gated by `canEdit`)
- **Dashboard context note**: Explains that approved vault sources power the AI summary and Ask About sections
- **UI polish**: Edit button dark mode fix, release count hidden, Artist Vault rename

## DB Migration Required
Run in Supabase SQL Editor before deploying:
```sql
ALTER TABLE artist_vault_sources ADD COLUMN IF NOT EXISTS og_image text;

CREATE TABLE IF NOT EXISTS artist_bio_versions (
    id uuid DEFAULT extensions.uuid_generate_v4() PRIMARY KEY NOT NULL,
    artist_id uuid NOT NULL REFERENCES artists(id),
    bio_text text NOT NULL,
    is_pinned boolean DEFAULT false NOT NULL,
    created_at timestamptz DEFAULT (now() AT TIME ZONE 'utc'::text) NOT NULL
);
CREATE INDEX IF NOT EXISTS idx_artist_bio_versions_artist_id ON artist_bio_versions USING btree (artist_id);
ALTER TABLE artist_bio_versions ENABLE ROW LEVEL SECURITY;
CREATE POLICY mnweb_select_artist_bio_versions ON artist_bio_versions FOR SELECT TO mnweb USING (true);
CREATE POLICY mnweb_insert_artist_bio_versions ON artist_bio_versions FOR INSERT TO mnweb WITH CHECK (true);
CREATE POLICY mnweb_update_artist_bio_versions ON artist_bio_versions FOR UPDATE TO mnweb USING (true) WITH CHECK (true);
CREATE POLICY mnweb_delete_artist_bio_versions ON artist_bio_versions FOR DELETE TO mnweb USING (true);
```

## Test plan
- [ ] Artist profile → Artist Vault section shows carousel with thumbnail cards and filter chips
- [ ] Cards with broken og:image show gradient + favicon fallback
- [ ] Dashboard → Saved Bios → Save Current Bio → pin/delete versions
- [ ] Artist profile → Save to vault button works for claimed artist
- [ ] Regenerate button only visible for admin/claimed artist
- [ ] Seed Mock Data button not visible on staging
- [ ] `npm run test` — 97/97 suites pass