### PR TITLE
fix(artist): add Deezer icon and link to artist's Deezer profile

### DIFF
--- a/public/siteIcons/deezer_icon.svg
+++ b/public/siteIcons/deezer_icon.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" version="1.1">
+  <title>Deezer</title>
+  <g>
+    <rect x="376" y="118" width="120" height="56" fill="#40AB5D"/>
+    <rect x="376" y="194" width="120" height="56" fill="#FFCD03"/>
+    <rect x="252" y="194" width="120" height="56" fill="#F47820"/>
+    <rect x="376" y="270" width="120" height="56" fill="#F15B40"/>
+    <rect x="252" y="270" width="120" height="56" fill="#BE3D6B"/>
+    <rect x="128" y="270" width="120" height="56" fill="#952F8F"/>
+    <rect x="376" y="346" width="120" height="56" fill="#4F2E7E"/>
+    <rect x="252" y="346" width="120" height="56" fill="#2D6AB4"/>
+    <rect x="128" y="346" width="120" height="56" fill="#1B95C1"/>
+    <rect x="4" y="346" width="120" height="56" fill="#1FB7A4"/>
+  </g>
+</svg>

--- a/src/__tests__/components/ArtistLinks.test.tsx
+++ b/src/__tests__/components/ArtistLinks.test.tsx
@@ -274,6 +274,85 @@ describe('ArtistLinks YouTube Rendering', () => {
         expect(screen.getByText(/this artist has no links in this section yet/i)).toBeInTheDocument();
     });
 
+    it('renders Deezer link with profile URL and icon when artist has deezer id', async () => {
+        const artistWithDeezer = { ...mockArtist, deezer: '4738512' };
+
+        (getArtistLinks as jest.Mock).mockResolvedValue([]);
+
+        const Component = await ArtistLinks({
+            isMonetized: false,
+            artist: artistWithDeezer,
+            spotifyImg: 'test-spotify-image.jpg',
+            availableLinks: mockAvailableLinks,
+            isOpenOnLoad: false,
+            canEdit: false,
+            showAddButton: false,
+        });
+
+        render(Component);
+
+        const deezerLink = screen.getByRole('link', { name: /listen on deezer/i });
+        expect(deezerLink).toBeInTheDocument();
+        expect(deezerLink).toHaveAttribute('href', 'https://www.deezer.com/artist/4738512');
+
+        const deezerIcon = deezerLink.querySelector('img[src="/siteIcons/deezer_icon.svg"]');
+        expect(deezerIcon).toBeInTheDocument();
+    });
+
+    it('does not render Deezer link when artist has no deezer id', async () => {
+        const artistWithoutDeezer = { ...mockArtist, deezer: null };
+
+        (getArtistLinks as jest.Mock).mockResolvedValue([]);
+
+        const Component = await ArtistLinks({
+            isMonetized: false,
+            artist: artistWithoutDeezer,
+            spotifyImg: 'test-spotify-image.jpg',
+            availableLinks: mockAvailableLinks,
+            isOpenOnLoad: false,
+            canEdit: false,
+            showAddButton: false,
+        });
+
+        render(Component);
+
+        expect(screen.queryByRole('link', { name: /listen on deezer/i })).not.toBeInTheDocument();
+    });
+
+    it('skips urlmap-based deezer entries to avoid duplicating the hardcoded link', async () => {
+        const artistWithDeezer = { ...mockArtist, deezer: '4738512' };
+
+        // Simulate a stale/broken urlmap entry for deezer that should be filtered out
+        (getArtistLinks as jest.Mock).mockResolvedValue([
+            {
+                siteName: 'deezer',
+                cardPlatformName: 'Deezer',
+                cardDescription: 'Listen on %@',
+                artistUrl: 'https://example.com/wrong-url',
+                siteImage: '/siteIcons/wrong_icon.svg',
+                colorHex: '#000000',
+                order: 5,
+                isMonetized: false,
+            },
+        ]);
+
+        const Component = await ArtistLinks({
+            isMonetized: false,
+            artist: artistWithDeezer,
+            spotifyImg: 'test-spotify-image.jpg',
+            availableLinks: mockAvailableLinks,
+            isOpenOnLoad: false,
+            canEdit: false,
+            showAddButton: false,
+        });
+
+        render(Component);
+
+        const deezerLinks = screen.getAllByRole('link', { name: /deezer/i });
+        expect(deezerLinks).toHaveLength(1);
+        expect(deezerLinks[0]).toHaveAttribute('href', 'https://www.deezer.com/artist/4738512');
+    });
+
     it('renders YouTube links correctly in monetized section', async () => {
         const mockMonetizedYoutubeData = [
             {

--- a/src/app/_components/ArtistLinks.tsx
+++ b/src/app/_components/ArtistLinks.tsx
@@ -19,7 +19,7 @@ function StaticPlatformLink({ link, descriptor, image }: { link: string; descrip
 
 export default async function ArtistLinks({ isMonetized, artist, spotifyImg, availableLinks, isOpenOnLoad = false, canEdit = false, showAddButton = true }: { isMonetized: boolean; artist: Artist; spotifyImg: string; availableLinks: UrlMap[]; isOpenOnLoad: boolean; canEdit?: boolean; showAddButton?: boolean }) {
     let artistLinks = await getArtistLinks(artist);
-    artistLinks = artistLinks.filter((el) => el.isMonetized === isMonetized && el.siteName !== 'spotify');
+    artistLinks = artistLinks.filter((el) => el.isMonetized === isMonetized && el.siteName !== 'spotify' && el.siteName !== 'deezer');
     
     // Render differently depending on monetization flag
     if (isMonetized) {
@@ -71,6 +71,15 @@ export default async function ArtistLinks({ isMonetized, artist, spotifyImg, ava
                     descriptor="Listen on Spotify"
                     link={`https://open.spotify.com/artist/${artist.spotify}`}
                     image="/siteIcons/spotify_icon.svg"
+                />
+            )}
+
+            {artist.deezer && artist.deezer.trim() !== "" && (
+                <StaticPlatformLink
+                    key="deezer"
+                    descriptor="Listen on Deezer"
+                    link={`https://www.deezer.com/artist/${artist.deezer}`}
+                    image="/siteIcons/deezer_icon.svg"
                 />
             )}
 

--- a/src/app/_components/ArtistLinksGrid.tsx
+++ b/src/app/_components/ArtistLinksGrid.tsx
@@ -15,7 +15,7 @@ interface ArtistLinksGridProps {
 export default async function ArtistLinksGrid({ isMonetized, artist, canEdit = false }: ArtistLinksGridProps) {
     let artistLinks = await getArtistLinks(artist);
     artistLinks = artistLinks.filter((el) => {
-        if (el.siteName === "spotify") return false;
+        if (el.siteName === "spotify" || el.siteName === "deezer") return false;
         const forcedSupport = FORCE_SUPPORT_PLATFORMS.has(el.siteName);
         if (isMonetized) {
             return el.isMonetized || forcedSupport;
@@ -23,10 +23,11 @@ export default async function ArtistLinksGrid({ isMonetized, artist, canEdit = f
         return !el.isMonetized && !forcedSupport;
     });
 
-    // For non-monetized, prepend Spotify if it exists
+    // For non-monetized, prepend Spotify and Deezer if they exist
     const showSpotify = !isMonetized && artist.spotify && artist.spotify.trim() !== "";
+    const showDeezer = !isMonetized && artist.deezer && artist.deezer.trim() !== "";
 
-    if (!showSpotify && artistLinks.length === 0) {
+    if (!showSpotify && !showDeezer && artistLinks.length === 0) {
         return (
             <p className="text-sm text-muted-foreground">
                 {isMonetized
@@ -63,6 +64,35 @@ export default async function ArtistLinksGrid({ isMonetized, artist, canEdit = f
                         </div>
                         <span className="text-xs text-center text-muted-foreground leading-tight truncate w-full">
                             Spotify
+                        </span>
+                    </a>
+                )
+            )}
+            {showDeezer && (
+                canEdit ? (
+                    <EditableLinkIcon
+                        href={`https://www.deezer.com/artist/${artist.deezer}`}
+                        siteName="deezer"
+                        artistId={artist.id}
+                        iconSrc="/siteIcons/deezer_icon.svg"
+                        label="Deezer"
+                    />
+                ) : (
+                    <a
+                        href={`https://www.deezer.com/artist/${artist.deezer}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex flex-col items-center gap-1.5 group"
+                    >
+                        <div className="w-12 h-12 rounded-full backdrop-blur-sm bg-white/70 dark:bg-white/10 border border-white/40 dark:border-white/15 shadow-sm flex items-center justify-center overflow-hidden transition-all duration-300 group-hover:scale-110 group-hover:shadow-[0_0_15px_rgba(239,149,255,0.45)] group-hover:bg-white/90 dark:group-hover:bg-white/20">
+                            <img
+                                src="/siteIcons/deezer_icon.svg"
+                                alt="Deezer"
+                                className="w-7 h-7 object-contain"
+                            />
+                        </div>
+                        <span className="text-xs text-center text-muted-foreground leading-tight truncate w-full">
+                            Deezer
                         </span>
                     </a>
                 )

--- a/src/app/_components/ArtistLinksGrid.tsx
+++ b/src/app/_components/ArtistLinksGrid.tsx
@@ -84,7 +84,7 @@ export default async function ArtistLinksGrid({ isMonetized, artist, canEdit = f
                         rel="noopener noreferrer"
                         className="flex flex-col items-center gap-1.5 group"
                     >
-                        <div className="w-12 h-12 rounded-full backdrop-blur-sm bg-white/70 dark:bg-white/10 border border-white/40 dark:border-white/15 shadow-sm flex items-center justify-center overflow-hidden transition-all duration-300 group-hover:scale-110 group-hover:shadow-[0_0_15px_rgba(239,149,255,0.45)] group-hover:bg-white/90 dark:group-hover:bg-white/20">
+                        <div className="w-12 h-12 rounded-full backdrop-blur-sm bg-white/70 dark:bg-white/10 border border-white/40 dark:border-white/15 shadow-sm flex items-center justify-center overflow-hidden transition-all duration-300 group-hover:scale-110 group-hover:shadow-[0_0_15px_rgba(0,199,242,0.45)] group-hover:bg-white/90 dark:group-hover:bg-white/20">
                             <img
                                 src="/siteIcons/deezer_icon.svg"
                                 alt="Deezer"

--- a/src/app/artist/[id]/_components/SeoArtistLinks.tsx
+++ b/src/app/artist/[id]/_components/SeoArtistLinks.tsx
@@ -9,12 +9,12 @@ import { getArtistLinks } from "@/server/utils/queries/artistQueries";
 export default async function SeoArtistLinks({ artist }: { artist: Artist }) {
     const artistLinks = await getArtistLinks(artist);
 
-    // Filter to only non-monetized social links (excluding spotify which is handled separately)
+    // Filter to only non-monetized social links (excluding spotify and deezer, which are handled separately)
     const socialLinks = artistLinks.filter(
-        (link) => !link.isMonetized && link.siteName !== "spotify"
+        (link) => !link.isMonetized && link.siteName !== "spotify" && link.siteName !== "deezer"
     );
 
-    if (socialLinks.length === 0 && !artist.spotify) {
+    if (socialLinks.length === 0 && !artist.spotify && !artist.deezer) {
         return null;
     }
 
@@ -25,6 +25,13 @@ export default async function SeoArtistLinks({ artist }: { artist: Artist }) {
                     <li>
                         <a href={`https://open.spotify.com/artist/${artist.spotify}`}>
                             {artist.name} on Spotify
+                        </a>
+                    </li>
+                )}
+                {artist.deezer && (
+                    <li>
+                        <a href={`https://www.deezer.com/artist/${artist.deezer}`}>
+                            {artist.name} on Deezer
                         </a>
                     </li>
                 )}


### PR DESCRIPTION
Fixes #1114.

## Summary
- Adds a `deezer_icon.svg` asset (colorful equalizer-block design) to `public/siteIcons/`.
- Hardcodes the Deezer link in `ArtistLinksGrid`, `ArtistLinks`, and `SeoArtistLinks` — mirroring how Spotify is handled — so the icon and URL are correct regardless of the `urlmap` row configuration.
- The hardcoded URL is `https://www.deezer.com/artist/{artist.deezer}`, matching the canonical Deezer profile pattern (consistent with `DeezerProvider` and existing tests).
- Filters any `siteName === "deezer"` entries out of the urlmap-driven loop so a stale/broken urlmap row can't render a duplicate (or wrong) link.

## Why hardcode rather than fix the urlmap?
Spotify is already handled this exact way (`ArtistLinksGrid.tsx:41`, `ArtistLinks.tsx:68`). Following the same pattern keeps the two primary "listen on" platforms consistent and makes the rendering deterministic — independent of database state.

## Test plan
- [x] `npm run type-check` clean
- [x] `npm run lint` — no new errors (only pre-existing warnings)
- [x] `npm test src/__tests__/components/ArtistLinks.test.tsx` — all 8 tests pass, including 3 new ones:
  - renders Deezer link with profile URL and icon when artist has a deezer id
  - does not render Deezer link when artist has no deezer id
  - skips urlmap-based deezer entries to avoid duplicating the hardcoded link
- [ ] Manual smoke on an artist page with a populated `deezer` column to confirm icon + URL render as expected.

---
_Generated by [Claude Code](https://claude.ai/code/session_016GxpLnzrgZgsR42CMs4Vqx)_