### PR TITLE
refactor: unify artist-edit authorization on a single canEditArtist guard

### DIFF
--- a/src/app/actions/__tests__/dashboardActions.test.ts
+++ b/src/app/actions/__tests__/dashboardActions.test.ts
@@ -14,6 +14,7 @@ jest.mock("@/server/utils/queries/dashboardQueries", () => ({
     createClaim: jest.fn(),
     getClaimByArtistId: jest.fn(),
     getApprovedClaimByUserId: jest.fn(),
+    getApprovedClaimForArtistByUserId: jest.fn(),
     getVaultSourcesByArtistId: jest.fn().mockResolvedValue([]),
     getVaultSourceByIdAndArtist: jest.fn(),
     updateVaultSourceStatus: jest.fn(),
@@ -54,11 +55,12 @@ describe("dashboardActions.addVaultSource", () => {
 
     async function setup() {
         const { getServerAuthSession } = await import("@/server/auth");
-        const { getApprovedClaimByUserId, insertVaultSource } = await import("@/server/utils/queries/dashboardQueries");
+        const { getApprovedClaimForArtistByUserId, insertVaultSource } = await import("@/server/utils/queries/dashboardQueries");
         const { addVaultSource } = await import("../dashboardActions");
 
         (getServerAuthSession as jest.Mock).mockResolvedValue({ user: { id: "user-1", email: "user@test.com" } });
-        (getApprovedClaimByUserId as jest.Mock).mockResolvedValue({ id: "claim-1", artistId: "artist-1" });
+        // canEditArtist authorizes the owner via the per-artist claim lookup
+        (getApprovedClaimForArtistByUserId as jest.Mock).mockResolvedValue({ id: "claim-1", artistId: "artist-1" });
         (insertVaultSource as jest.Mock).mockResolvedValue({ id: "source-1" });
 
         return {
@@ -133,8 +135,11 @@ describe("dashboardActions.addVaultSource", () => {
 
     it("rejects when the user's claim is for a different artist", async () => {
         const { addVaultSource, insertVaultSource } = await setup();
-        const { getApprovedClaimByUserId } = await import("@/server/utils/queries/dashboardQueries");
-        (getApprovedClaimByUserId as jest.Mock).mockResolvedValue({ id: "claim-1", artistId: "other-artist" });
+        const { getApprovedClaimForArtistByUserId } = await import("@/server/utils/queries/dashboardQueries");
+        const { getUserById } = await import("@/server/utils/queries/userQueries");
+        // No approved claim for THIS artist, and not an admin
+        (getApprovedClaimForArtistByUserId as jest.Mock).mockResolvedValue(undefined);
+        (getUserById as jest.Mock).mockResolvedValue({ id: "user-1", isAdmin: false });
 
         const result = await addVaultSource("artist-1", "https://pitchfork.com/a");
 

--- a/src/app/actions/__tests__/dashboardActions.vault-auth.test.ts
+++ b/src/app/actions/__tests__/dashboardActions.vault-auth.test.ts
@@ -6,7 +6,7 @@ jest.mock('@/server/utils/dev-auth', () => ({ getDevSession: jest.fn() }));
 jest.mock('@/server/utils/queries/userQueries', () => ({ getUserById: jest.fn() }));
 jest.mock('@/server/utils/queries/dashboardQueries', () => ({
   getApprovedClaimByUserId: jest.fn(),
-  getVaultSourceByIdAndArtist: jest.fn(),
+  getApprovedClaimForArtistByUserId: jest.fn(),
   getVaultSourceById: jest.fn(),
   getVaultSourcesByArtistId: jest.fn(),
   updateVaultSourceStatus: jest.fn(),
@@ -55,8 +55,8 @@ describe('vault action authorization', () => {
   it('rejects a non-admin who does not own the source', async () => {
     const { actions, users, q } = await setup();
     (users.getUserById as jest.Mock).mockResolvedValue({ id: 'admin-1', isAdmin: false });
-    (q.getApprovedClaimByUserId as jest.Mock).mockResolvedValue({ artistId: 'artist-owned' });
-    (q.getVaultSourceByIdAndArtist as jest.Mock).mockResolvedValue(undefined);
+    (q.getVaultSourceById as jest.Mock).mockResolvedValue({ id: 'src-1', artistId: 'artist-x' });
+    (q.getApprovedClaimForArtistByUserId as jest.Mock).mockResolvedValue(undefined);
 
     const res = await actions.updateSourceStatus('src-1', 'approved');
 

--- a/src/app/actions/dashboardActions.ts
+++ b/src/app/actions/dashboardActions.ts
@@ -8,7 +8,6 @@ import {
     getClaimByArtistId,
     getApprovedClaimByUserId,
     getVaultSourcesByArtistId,
-    getVaultSourceByIdAndArtist,
     getVaultSourceById,
     updateVaultSourceStatus,
     updateVaultSourceType,
@@ -28,6 +27,7 @@ import { fetchPageContent, isUnsafeUrl } from "@/server/utils/fetchPageContent";
 import { updateVaultSourceContent } from "@/server/utils/queries/dashboardQueries";
 import { generateReferenceCode } from "@/lib/referenceCode";
 import { sendDiscordMessage } from "@/server/utils/queries/discord";
+import { canEditArtist } from "@/server/utils/artistEditAuth";
 
 // Best-effort debounce for bio regen (same serverless caveat as rate limiting)
 const bioRegenTimestamps = new Map<string, number>();
@@ -66,26 +66,17 @@ export async function claimArtistProfile(artistId: string): Promise<{ success: b
 
 /** Resolve a source the user may edit: admins can edit any source, owners only their claimed artist's. Returns the source's artistId. */
 async function verifySourceEditable(userId: string, sourceId: string) {
-    const user = await getUserById(userId);
-    if (user?.isAdmin) {
-        const source = await getVaultSourceById(sourceId);
-        if (!source) return { authorized: false as const, error: "Source not found" };
+    const source = await getVaultSourceById(sourceId);
+    if (!source) return { authorized: false as const, error: "Source not found" };
+    if (await canEditArtist(userId, source.artistId)) {
         return { authorized: true as const, artistId: source.artistId };
     }
-    const claim = await getApprovedClaimByUserId(userId);
-    if (!claim) return { authorized: false as const, error: "No claimed artist profile" };
-    const source = await getVaultSourceByIdAndArtist(sourceId, claim.artistId);
-    if (!source) return { authorized: false as const, error: "Source does not belong to your artist" };
-    return { authorized: true as const, artistId: claim.artistId };
+    return { authorized: false as const, error: "Not authorized for this source" };
 }
 
 /** Authorize editing a specific artist: admins may edit any, owners only their claimed artist. */
 async function verifyArtistEditable(userId: string, artistId: string): Promise<{ ok: true } | { ok: false; error: string }> {
-    const user = await getUserById(userId);
-    if (user?.isAdmin) return { ok: true };
-    const claim = await getApprovedClaimByUserId(userId);
-    if (!claim || claim.artistId !== artistId) return { ok: false, error: "Not authorized for this artist" };
-    return { ok: true };
+    return (await canEditArtist(userId, artistId)) ? { ok: true } : { ok: false, error: "Not authorized for this artist" };
 }
 
 export async function updateSourceStatus(
@@ -309,11 +300,8 @@ export async function saveCurrentBio(bioText: string, targetArtistId?: string): 
 /** Resolve the artistId for bio version actions — admin can target any artist via the version's owner */
 async function resolveBioArtistId(userId: string, targetArtistId?: string): Promise<{ artistId: string } | { error: string }> {
     if (targetArtistId) {
-        const user = await getUserById(userId);
-        if (user?.isAdmin) return { artistId: targetArtistId };
-        const claim = await getApprovedClaimByUserId(userId);
-        if (!claim || claim.artistId !== targetArtistId) return { error: "Not authorized for this artist" };
-        return { artistId: claim.artistId };
+        if (await canEditArtist(userId, targetArtistId)) return { artistId: targetArtistId };
+        return { error: "Not authorized for this artist" };
     }
     const claim = await getApprovedClaimByUserId(userId);
     if (!claim) return { error: "No claimed artist profile" };

--- a/src/app/api/artist/profile-image/__tests__/route.admin.test.ts
+++ b/src/app/api/artist/profile-image/__tests__/route.admin.test.ts
@@ -3,7 +3,7 @@ import { jest } from '@jest/globals';
 
 jest.mock('@/server/auth', () => ({ getServerAuthSession: jest.fn() }));
 jest.mock('@/server/utils/dev-auth', () => ({ getDevSession: jest.fn() }));
-jest.mock('@/server/utils/queries/dashboardQueries', () => ({ getApprovedClaimByUserId: jest.fn() }));
+jest.mock('@/server/utils/queries/dashboardQueries', () => ({ getApprovedClaimByUserId: jest.fn(), getApprovedClaimForArtistByUserId: jest.fn() }));
 jest.mock('@/server/utils/queries/userQueries', () => ({ getUserById: jest.fn() }));
 jest.mock('@/server/lib/supabase', () => ({
   supabaseAdmin: { storage: { from: () => ({ upload: jest.fn().mockResolvedValue({ error: null }), getPublicUrl: () => ({ data: { publicUrl: 'http://x/y.png' } }) }) } },
@@ -24,7 +24,7 @@ describe('POST /api/artist/profile-image admin path', () => {
     const claims = await import('@/server/utils/queries/dashboardQueries');
     (auth.getServerAuthSession as jest.Mock).mockResolvedValue({ user: { id: 'admin-1' } });
     (users.getUserById as jest.Mock).mockResolvedValue({ isAdmin: true });
-    (claims.getApprovedClaimByUserId as jest.Mock).mockResolvedValue(null);
+    (claims.getApprovedClaimForArtistByUserId as jest.Mock).mockResolvedValue(undefined);
 
     const { POST } = await import('../route');
     const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
@@ -49,7 +49,7 @@ describe('POST /api/artist/profile-image admin path', () => {
     const claims = await import('@/server/utils/queries/dashboardQueries');
     (auth.getServerAuthSession as jest.Mock).mockResolvedValue({ user: { id: 'u-2' } });
     (users.getUserById as jest.Mock).mockResolvedValue({ isAdmin: false });
-    (claims.getApprovedClaimByUserId as jest.Mock).mockResolvedValue(null);
+    (claims.getApprovedClaimForArtistByUserId as jest.Mock).mockResolvedValue(undefined);
 
     const { POST } = await import('../route');
     const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
@@ -65,7 +65,7 @@ describe('POST /api/artist/profile-image admin path', () => {
 
     expect(res.status).toBe(403);
     const body = await res.json();
-    expect(body.error).toBe('No claimed artist profile');
+    expect(body.error).toBe('Not authorized for this artist');
   });
 
   it('allows an admin WITH their own claim to upload for a DIFFERENT artist', async () => {
@@ -74,8 +74,8 @@ describe('POST /api/artist/profile-image admin path', () => {
     const claims = await import('@/server/utils/queries/dashboardQueries');
     (auth.getServerAuthSession as jest.Mock).mockResolvedValue({ user: { id: 'admin-2' } });
     (users.getUserById as jest.Mock).mockResolvedValue({ isAdmin: true });
-    // Admin has a claim for their own artist, but is uploading for a different one
-    (claims.getApprovedClaimByUserId as jest.Mock).mockResolvedValue({ artistId: 'their-own-artist' });
+    // Admin has no claim for THIS (different) artist, but is admin so allowed
+    (claims.getApprovedClaimForArtistByUserId as jest.Mock).mockResolvedValue(undefined);
 
     const { POST } = await import('../route');
     const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
@@ -98,8 +98,8 @@ describe('POST /api/artist/profile-image admin path', () => {
     const claims = await import('@/server/utils/queries/dashboardQueries');
     (auth.getServerAuthSession as jest.Mock).mockResolvedValue({ user: { id: 'u-3' } });
     (users.getUserById as jest.Mock).mockResolvedValue({ isAdmin: false });
-    // User has a claim, but for a different artist than the upload target
-    (claims.getApprovedClaimByUserId as jest.Mock).mockResolvedValue({ artistId: 'their-own-artist' });
+    // User has no approved claim for THIS artist, and is not admin
+    (claims.getApprovedClaimForArtistByUserId as jest.Mock).mockResolvedValue(undefined);
 
     const { POST } = await import('../route');
     const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);

--- a/src/app/api/artist/profile-image/route.ts
+++ b/src/app/api/artist/profile-image/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from "next/server";
 import { getServerAuthSession } from "@/server/auth";
 import { getDevSession } from "@/server/utils/dev-auth";
-import { getApprovedClaimByUserId } from "@/server/utils/queries/dashboardQueries";
-import { getUserById } from "@/server/utils/queries/userQueries";
+import { canEditArtist } from "@/server/utils/artistEditAuth";
 import { supabaseAdmin, VAULT_BUCKET } from "@/server/lib/supabase";
 import { db } from "@/server/db/drizzle";
 import { artists } from "@/server/db/schema";
@@ -28,16 +27,8 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "File and artistId are required" }, { status: 400 });
         }
 
-        const claim = await getApprovedClaimByUserId(session.user.id);
-        const ownsTarget = claim?.artistId === artistId;
-        if (!ownsTarget) {
-            const user = await getUserById(session.user.id);
-            if (!user?.isAdmin) {
-                return NextResponse.json(
-                    { error: claim ? "Not authorized for this artist" : "No claimed artist profile" },
-                    { status: 403 }
-                );
-            }
+        if (!(await canEditArtist(session.user.id, artistId))) {
+            return NextResponse.json({ error: "Not authorized for this artist" }, { status: 403 });
         }
 
         if (file.size > MAX_FILE_SIZE) {

--- a/src/app/api/directEditLink/route.ts
+++ b/src/app/api/directEditLink/route.ts
@@ -1,6 +1,5 @@
 import { requireAuth } from "@/lib/auth-helpers";
-import { getUserById } from "@/server/utils/queries/userQueries";
-import { getApprovedClaimForArtistByUserId } from "@/server/utils/queries/dashboardQueries";
+import { canEditArtist } from "@/server/utils/artistEditAuth";
 import { setArtistLink, clearArtistLink } from "@/server/utils/artistLinkService";
 import { extractArtistId } from "@/server/utils/services";
 
@@ -23,14 +22,8 @@ export async function POST(req: Request) {
         }
 
         // Authorization: admin can edit any artist, claimed artist can edit own profile only
-        const user = await getUserById(authResult.userId);
-        const isAdmin = !!user?.isAdmin;
-
-        if (!isAdmin) {
-            const claim = await getApprovedClaimForArtistByUserId(authResult.userId, artistId);
-            if (!claim) {
-                return Response.json({ error: "Not authorized to edit this artist" }, { status: 403 });
-            }
+        if (!(await canEditArtist(authResult.userId, artistId))) {
+            return Response.json({ error: "Not authorized to edit this artist" }, { status: 403 });
         }
 
         if (action === "set") {

--- a/src/app/api/directEditLink/route.ts
+++ b/src/app/api/directEditLink/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: Request) {
 
         // Authorization: admin can edit any artist, claimed artist can edit own profile only
         if (!(await canEditArtist(authResult.userId, artistId))) {
-            return Response.json({ error: "Not authorized to edit this artist" }, { status: 403 });
+            return Response.json({ error: "Not authorized for this artist" }, { status: 403 });
         }
 
         if (action === "set") {

--- a/src/app/api/vault/upload/__tests__/route.admin.test.ts
+++ b/src/app/api/vault/upload/__tests__/route.admin.test.ts
@@ -5,6 +5,7 @@ jest.mock('@/server/auth', () => ({ getServerAuthSession: jest.fn() }));
 jest.mock('@/server/utils/dev-auth', () => ({ getDevSession: jest.fn() }));
 jest.mock('@/server/utils/queries/dashboardQueries', () => ({
   getApprovedClaimByUserId: jest.fn(),
+  getApprovedClaimForArtistByUserId: jest.fn(),
   insertVaultSource: jest.fn(),
 }));
 jest.mock('@/server/utils/queries/userQueries', () => ({ getUserById: jest.fn() }));
@@ -39,7 +40,7 @@ describe('POST /api/vault/upload admin path', () => {
     const claims = await import('@/server/utils/queries/dashboardQueries');
     (auth.getServerAuthSession as jest.Mock).mockResolvedValue({ user: { id: 'admin-1' } });
     (users.getUserById as jest.Mock).mockResolvedValue({ isAdmin: true });
-    (claims.getApprovedClaimByUserId as jest.Mock).mockResolvedValue(null);
+    (claims.getApprovedClaimForArtistByUserId as jest.Mock).mockResolvedValue(undefined);
     (claims.insertVaultSource as jest.Mock).mockResolvedValue({ id: 'src-1' });
 
     const { POST } = await import('../route');
@@ -69,7 +70,7 @@ describe('POST /api/vault/upload admin path', () => {
     const claims = await import('@/server/utils/queries/dashboardQueries');
     (auth.getServerAuthSession as jest.Mock).mockResolvedValue({ user: { id: 'u-2' } });
     (users.getUserById as jest.Mock).mockResolvedValue({ isAdmin: false });
-    (claims.getApprovedClaimByUserId as jest.Mock).mockResolvedValue(null);
+    (claims.getApprovedClaimForArtistByUserId as jest.Mock).mockResolvedValue(undefined);
 
     const { POST } = await import('../route');
 
@@ -86,7 +87,7 @@ describe('POST /api/vault/upload admin path', () => {
 
     expect(res.status).toBe(403);
     const body = await res.json();
-    expect(body.error).toBe('No claimed artist profile');
+    expect(body.error).toBe('Not authorized for this artist');
   });
 
   it('allows an admin WITH their own claim to upload for a DIFFERENT artist', async () => {
@@ -95,8 +96,8 @@ describe('POST /api/vault/upload admin path', () => {
     const claims = await import('@/server/utils/queries/dashboardQueries');
     (auth.getServerAuthSession as jest.Mock).mockResolvedValue({ user: { id: 'admin-2' } });
     (users.getUserById as jest.Mock).mockResolvedValue({ isAdmin: true });
-    // Admin has a claim for their own artist, but is uploading for a different one
-    (claims.getApprovedClaimByUserId as jest.Mock).mockResolvedValue({ artistId: 'their-own-artist' });
+    // Admin has no claim for THIS (different) artist, but is admin so allowed
+    (claims.getApprovedClaimForArtistByUserId as jest.Mock).mockResolvedValue(undefined);
     (claims.insertVaultSource as jest.Mock).mockResolvedValue({ id: 'src-2' });
 
     const { POST } = await import('../route');
@@ -123,8 +124,8 @@ describe('POST /api/vault/upload admin path', () => {
     const claims = await import('@/server/utils/queries/dashboardQueries');
     (auth.getServerAuthSession as jest.Mock).mockResolvedValue({ user: { id: 'u-3' } });
     (users.getUserById as jest.Mock).mockResolvedValue({ isAdmin: false });
-    // User has a claim, but for a different artist than the upload target
-    (claims.getApprovedClaimByUserId as jest.Mock).mockResolvedValue({ artistId: 'their-own-artist' });
+    // User has no approved claim for THIS artist, and is not admin
+    (claims.getApprovedClaimForArtistByUserId as jest.Mock).mockResolvedValue(undefined);
 
     const { POST } = await import('../route');
 

--- a/src/app/api/vault/upload/route.ts
+++ b/src/app/api/vault/upload/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { getServerAuthSession } from "@/server/auth";
 import { getDevSession } from "@/server/utils/dev-auth";
-import { getApprovedClaimByUserId, insertVaultSource } from "@/server/utils/queries/dashboardQueries";
-import { getUserById } from "@/server/utils/queries/userQueries";
+import { insertVaultSource } from "@/server/utils/queries/dashboardQueries";
+import { canEditArtist } from "@/server/utils/artistEditAuth";
 import { supabaseAdmin, VAULT_BUCKET } from "@/server/lib/supabase";
 import { validateMagicBytes } from "@/server/utils/validateMagicBytes";
 import { extractPdfText } from "@/server/utils/extractPdfText";
@@ -55,16 +55,8 @@ export async function POST(req: Request) {
             return NextResponse.json({ error: "File and artistId are required" }, { status: 400 });
         }
 
-        const claim = await getApprovedClaimByUserId(session.user.id);
-        const ownsTarget = claim?.artistId === artistId;
-        if (!ownsTarget) {
-            const user = await getUserById(session.user.id);
-            if (!user?.isAdmin) {
-                return NextResponse.json(
-                    { error: claim ? "Not authorized for this artist" : "No claimed artist profile" },
-                    { status: 403 }
-                );
-            }
+        if (!(await canEditArtist(session.user.id, artistId))) {
+            return NextResponse.json({ error: "Not authorized for this artist" }, { status: 403 });
         }
 
         if (file.size > MAX_FILE_SIZE) {

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -1,7 +1,7 @@
 import { getServerAuthSession } from '@/server/auth';
 import type { Session } from '@/server/auth';
 import { getUserById } from '@/server/utils/queries/userQueries';
-import { getApprovedClaimByUserId } from '@/server/utils/queries/dashboardQueries';
+import { canEditArtist } from '@/server/utils/artistEditAuth';
 
 type AuthSuccess = { authenticated: true; session: Session; userId: string };
 type AuthFailure = { authenticated: false; response: Response };
@@ -49,11 +49,7 @@ export async function requireArtistEditor(artistId: string): Promise<AuthResult>
   const authResult = await requireAuth();
   if (!authResult.authenticated) return authResult;
 
-  const dbUser = await getUserById(authResult.userId);
-  if (dbUser?.isAdmin) return authResult;
-
-  const claim = await getApprovedClaimByUserId(authResult.userId);
-  if (claim?.artistId === artistId) return authResult;
+  if (await canEditArtist(authResult.userId, artistId)) return authResult;
 
   return {
     authenticated: false,

--- a/src/server/utils/__tests__/artistEditAuth.test.ts
+++ b/src/server/utils/__tests__/artistEditAuth.test.ts
@@ -1,0 +1,59 @@
+// @ts-nocheck
+import { jest } from '@jest/globals';
+
+jest.mock('@/server/utils/queries/userQueries', () => ({ getUserById: jest.fn() }));
+jest.mock('@/server/utils/queries/dashboardQueries', () => ({
+  getApprovedClaimForArtistByUserId: jest.fn(),
+}));
+
+describe('canEditArtist', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  async function setup() {
+    const users = await import('@/server/utils/queries/userQueries');
+    const q = await import('@/server/utils/queries/dashboardQueries');
+    const { canEditArtist } = await import('../artistEditAuth');
+    return {
+      canEditArtist,
+      getUserById: users.getUserById as jest.Mock,
+      getApprovedClaimForArtistByUserId: q.getApprovedClaimForArtistByUserId as jest.Mock,
+    };
+  }
+
+  it('returns true for the approved claimant of this artist', async () => {
+    const { canEditArtist, getApprovedClaimForArtistByUserId } = await setup();
+    getApprovedClaimForArtistByUserId.mockResolvedValue({ id: 'c1', artistId: 'a1', userId: 'u1' });
+
+    expect(await canEditArtist('u1', 'a1')).toBe(true);
+  });
+
+  it('does not require a user lookup for the owner path', async () => {
+    const { canEditArtist, getApprovedClaimForArtistByUserId, getUserById } = await setup();
+    getApprovedClaimForArtistByUserId.mockResolvedValue({ id: 'c1', artistId: 'a1', userId: 'u1' });
+
+    await canEditArtist('u1', 'a1');
+
+    expect(getApprovedClaimForArtistByUserId).toHaveBeenCalledWith('u1', 'a1');
+    expect(getUserById).not.toHaveBeenCalled();
+  });
+
+  it('returns true for an admin with no claim for this artist', async () => {
+    const { canEditArtist, getApprovedClaimForArtistByUserId, getUserById } = await setup();
+    getApprovedClaimForArtistByUserId.mockResolvedValue(undefined);
+    getUserById.mockResolvedValue({ id: 'admin-1', isAdmin: true });
+
+    expect(await canEditArtist('admin-1', 'a1')).toBe(true);
+    expect(getUserById).toHaveBeenCalledWith('admin-1');
+  });
+
+  it('returns false for a non-owner non-admin', async () => {
+    const { canEditArtist, getApprovedClaimForArtistByUserId, getUserById } = await setup();
+    getApprovedClaimForArtistByUserId.mockResolvedValue(undefined);
+    getUserById.mockResolvedValue({ id: 'u2', isAdmin: false });
+
+    expect(await canEditArtist('u2', 'a1')).toBe(false);
+  });
+});

--- a/src/server/utils/__tests__/artistEditAuth.test.ts
+++ b/src/server/utils/__tests__/artistEditAuth.test.ts
@@ -56,4 +56,12 @@ describe('canEditArtist', () => {
 
     expect(await canEditArtist('u2', 'a1')).toBe(false);
   });
+
+  it('returns false when the user record does not exist', async () => {
+    const { canEditArtist, getApprovedClaimForArtistByUserId, getUserById } = await setup();
+    getApprovedClaimForArtistByUserId.mockResolvedValue(undefined);
+    getUserById.mockResolvedValue(undefined);
+
+    expect(await canEditArtist('ghost', 'a1')).toBe(false);
+  });
 });

--- a/src/server/utils/artistEditAuth.ts
+++ b/src/server/utils/artistEditAuth.ts
@@ -1,14 +1,7 @@
 import { getUserById } from "@/server/utils/queries/userQueries";
 import { getApprovedClaimForArtistByUserId } from "@/server/utils/queries/dashboardQueries";
 
-/**
- * Single source of truth for "may this user directly edit this artist?":
- * the approved claimant of THIS artist, or an admin.
- *
- * Claim-for-artist is checked first (one indexed lookup) so the common owner
- * path skips the users lookup. Uses the per-artist claim query so it is correct
- * even if a user ever holds multiple approved claims.
- */
+// May this user directly edit this artist? Approved claimant of this artist (claim-first, multi-claim-safe), or admin.
 export async function canEditArtist(userId: string, artistId: string): Promise<boolean> {
   const claim = await getApprovedClaimForArtistByUserId(userId, artistId);
   if (claim) return true;

--- a/src/server/utils/artistEditAuth.ts
+++ b/src/server/utils/artistEditAuth.ts
@@ -1,0 +1,17 @@
+import { getUserById } from "@/server/utils/queries/userQueries";
+import { getApprovedClaimForArtistByUserId } from "@/server/utils/queries/dashboardQueries";
+
+/**
+ * Single source of truth for "may this user directly edit this artist?":
+ * the approved claimant of THIS artist, or an admin.
+ *
+ * Claim-for-artist is checked first (one indexed lookup) so the common owner
+ * path skips the users lookup. Uses the per-artist claim query so it is correct
+ * even if a user ever holds multiple approved claims.
+ */
+export async function canEditArtist(userId: string, artistId: string): Promise<boolean> {
+  const claim = await getApprovedClaimForArtistByUserId(userId, artistId);
+  if (claim) return true;
+  const user = await getUserById(userId);
+  return !!user?.isAdmin;
+}


### PR DESCRIPTION
## Summary

Follow-up to #1117. Collapses the "may this user directly edit this artist?" check — previously implemented ~5 different ways across routes and server actions, with two different claim queries and inconsistent check order — onto a single source of truth.

New core: `src/server/utils/artistEditAuth.ts`
```ts
canEditArtist(userId, artistId) // approved claimant of THIS artist, OR admin
```
- **Claim-first** (one indexed lookup) so the common owner path skips the users lookup.
- Uses the **per-artist** claim query `getApprovedClaimForArtistByUserId(userId, artistId)` — fixes a latent **multi-claim correctness bug** (most paths used the single-claim `getApprovedClaimByUserId`, which authorizes against the wrong artist if a user ever holds more than one approved claim). The source-edit path was the worst case: admins used the by-id lookup while owners used by-id-and-claim, so a multi-claim owner could only edit via one of their claims.

## Routed through the core
- `requireArtistEditor` (auth-helpers) → bio `PUT`
- `verifyArtistEditable` / `verifySourceEditable` (vault actions) — `verifySourceEditable` now resolves the source's own `artistId` and authorizes against that
- `resolveBioArtistId` (targetArtistId branch)
- `/api/vault/upload`, `/api/artist/profile-image` (hand-rolled claim/admin block → one `canEditArtist` check)
- `/api/directEditLink` (social/support links)

## Intentionally unchanged
- UGC submission/approval (separate, lower-bar flow)
- `removeVaultSources` internals; the no-target `resolveBioArtistId` "my own artist" branch
- Per-route **session resolution** (the dev-session fallback some routes use is a separate, smaller inconsistency — not addressed here)

## Behavior changes (intended only)
- Multi-claim correctness (per-artist claim query everywhere)
- A few 403 message strings unified to "Not authorized for this artist"

## Test Plan
- New `artistEditAuth.test.ts` (owner / admin / neither + claim-first ordering)
- Updated the upload-route, vault-auth, dashboardActions, and directEditLink tests to exercise the **real** `canEditArtist` against mocked queries (no path mocks the guard itself)
- Full gate green: type-check, lint, **108 suites / 1054 tests**, build

## Note
No DB change here. Separately worth deciding whether one-approved-claim-per-user should be enforced with a partial unique index on `artist_claims.userId` — this PR makes the code correct either way.