### PR TITLE
fix: full artist bio (no Read More) + vault purpose descriptor

### DIFF
--- a/src/__tests__/components/BlurbSection.test.tsx
+++ b/src/__tests__/components/BlurbSection.test.tsx
@@ -90,9 +90,9 @@ describe('BlurbSection', () => {
 
             await waitFor(() => {
                 expect(screen.getByText(longContent)).toBeInTheDocument();
+                expect(screen.queryByText('Read more')).not.toBeInTheDocument();
+                expect(screen.queryByText('Show less')).not.toBeInTheDocument();
             });
-            expect(screen.queryByText('Read more')).not.toBeInTheDocument();
-            expect(screen.queryByText('Show less')).not.toBeInTheDocument();
         });
     });
 

--- a/src/__tests__/components/BlurbSection.test.tsx
+++ b/src/__tests__/components/BlurbSection.test.tsx
@@ -77,59 +77,8 @@ describe('BlurbSection', () => {
         });
     });
 
-    describe('Read more Functionality', () => {
-        it('shows Read more button for long content', async () => {
-            mockUseArtistBio.mockReturnValue({
-                bio: longContent,
-                loading: false,
-                error: null,
-                refetch: jest.fn()
-            });
-
-            render(<BlurbSection {...defaultProps} />);
-            
-            await waitFor(() => {
-                expect(screen.getByText('Read more')).toBeInTheDocument();
-            });
-        });
-
-        it('does not show Read more button for short content', async () => {
-            mockUseArtistBio.mockReturnValue({
-                bio: 'Short content',
-                loading: false,
-                error: null,
-                refetch: jest.fn()
-            });
-
-            render(<BlurbSection {...defaultProps} />);
-            
-            await waitFor(() => {
-                expect(screen.queryByText('Read more')).not.toBeInTheDocument();
-            });
-        });
-
-        it('expands when Read more is clicked', async () => {
-            mockUseArtistBio.mockReturnValue({
-                bio: longContent,
-                loading: false,
-                error: null,
-                refetch: jest.fn()
-            });
-
-            render(<BlurbSection {...defaultProps} />);
-            
-            await waitFor(() => {
-                expect(screen.getByText('Read more')).toBeInTheDocument();
-            });
-
-            fireEvent.click(screen.getByText('Read more'));
-
-            await waitFor(() => {
-                expect(screen.getByText('Show less')).toBeInTheDocument();
-            });
-        });
-
-        it('collapses when Show less is clicked', async () => {
+    describe('Full bio (no truncation)', () => {
+        it('renders the full bio with no Read more / Show less control', async () => {
             mockUseArtistBio.mockReturnValue({
                 bio: longContent,
                 loading: false,
@@ -140,20 +89,10 @@ describe('BlurbSection', () => {
             render(<BlurbSection {...defaultProps} />);
 
             await waitFor(() => {
-                expect(screen.getByText('Read more')).toBeInTheDocument();
+                expect(screen.getByText(longContent)).toBeInTheDocument();
             });
-
-            fireEvent.click(screen.getByText('Read more'));
-
-            await waitFor(() => {
-                expect(screen.getByText('Show less')).toBeInTheDocument();
-            });
-
-            fireEvent.click(screen.getByText('Show less'));
-
-            await waitFor(() => {
-                expect(screen.getByText('Read more')).toBeInTheDocument();
-            });
+            expect(screen.queryByText('Read more')).not.toBeInTheDocument();
+            expect(screen.queryByText('Show less')).not.toBeInTheDocument();
         });
     });
 

--- a/src/app/artist/[id]/_components/BlurbSection.tsx
+++ b/src/app/artist/[id]/_components/BlurbSection.tsx
@@ -5,7 +5,7 @@ import { EditModeContext } from "@/app/_components/EditModeContext";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { useArtistBio } from "@/hooks/useArtistBio";
-import { ChevronDown, Check } from "lucide-react";
+import { Check } from "lucide-react";
 import { saveCurrentBio } from "@/app/actions/dashboardActions";
 import BioVersionHistory from "./BioVersionHistory";
 
@@ -22,17 +22,10 @@ function renderMarkdown(text: string): string {
     .replace(/\*(.+?)\*/g, "<em>$1</em>");
 }
 
-/** Height (px) of the collapsed bio box */
-const COLLAPSED_HEIGHT = 112;
-
 export default function BlurbSection({ artistName, artistId, initialBio }: BlurbSectionProps) {
   const { isEditing, canEdit } = useContext(EditModeContext);
   const { toast } = useToast();
   const { bio: aiBlurb, loading: loadingAi, refetch } = useArtistBio(artistId, initialBio);
-
-  const [expanded, setExpanded] = useState(false);
-  const [needsTruncation, setNeedsTruncation] = useState(false);
-  const contentRef = useRef<HTMLDivElement>(null);
 
   const [editText, setEditText] = useState<string>("");
   const [isSaving, setIsSaving] = useState(false);
@@ -57,16 +50,6 @@ export default function BlurbSection({ artistName, artistId, initialBio }: Blurb
       setOriginalBio(aiBlurb ?? "");
     }
   }, [isEditing, aiBlurb]);
-
-  // Measure content to decide if truncation is needed
-  useEffect(() => {
-    if (contentRef.current && contentRef.current.scrollHeight > 0) {
-      setNeedsTruncation(contentRef.current.scrollHeight > COLLAPSED_HEIGHT);
-    } else if (aiBlurb && aiBlurb.length > 200) {
-      // Fallback for environments without layout (e.g. JSDOM)
-      setNeedsTruncation(true);
-    }
-  }, [aiBlurb]);
 
   // Cleanup timer on unmount
   useEffect(() => {
@@ -167,7 +150,7 @@ export default function BlurbSection({ artistName, artistId, initialBio }: Blurb
 
   if (loadingAi) {
     return (
-      <div className="glass-subtle p-3" style={{ height: COLLAPSED_HEIGHT }}>
+      <div className="glass-subtle p-3 min-h-[80px]">
         <p className="text-gray-500 dark:text-gray-400 italic">Loading summary...</p>
       </div>
     );
@@ -235,46 +218,16 @@ export default function BlurbSection({ artistName, artistId, initialBio }: Blurb
     );
   }
 
-  // Non-editing view — smooth expand/collapse
+  // Non-editing view — show the full bio (no truncation)
   return (
-    <div className="space-y-1.5">
-      <div className="glass-subtle p-3 relative">
-        {/* Expandable content wrapper */}
-        <div
-          ref={contentRef}
-          className="overflow-hidden transition-[max-height] duration-300 ease-in-out"
-          style={{ maxHeight: expanded ? contentRef.current?.scrollHeight ?? "none" : COLLAPSED_HEIGHT }}
-        >
-          {aiBlurb ? (
-            <p
-              className="text-black dark:text-white text-sm leading-relaxed"
-              dangerouslySetInnerHTML={{ __html: renderMarkdown(aiBlurb) }}
-            />
-          ) : (
-            <p className="text-gray-500 dark:text-gray-400 italic">No summary is available</p>
-          )}
-        </div>
-
-        {/* Fade gradient when collapsed */}
-        {needsTruncation && !expanded && (
-          <div className="absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-white/80 dark:from-[#1a1a1a]/80 to-transparent rounded-b-xl pointer-events-none" />
-        )}
-      </div>
-
-      {/* Expand toggle — edit controls live in edit mode only */}
-      {needsTruncation && (
-        <div className="flex items-center justify-end px-1">
-          <button
-            onClick={() => setExpanded(!expanded)}
-            className="flex items-center gap-0.5 text-xs text-muted-foreground hover:text-pastypink transition-colors"
-          >
-            {expanded ? "Show less" : "Read more"}
-            <ChevronDown
-              size={13}
-              className={`transition-transform duration-300 ${expanded ? "rotate-180" : ""}`}
-            />
-          </button>
-        </div>
+    <div className="glass-subtle p-3">
+      {aiBlurb ? (
+        <p
+          className="text-black dark:text-white text-sm leading-relaxed"
+          dangerouslySetInnerHTML={{ __html: renderMarkdown(aiBlurb) }}
+        />
+      ) : (
+        <p className="text-gray-500 dark:text-gray-400 italic">No summary is available</p>
       )}
     </div>
   );

--- a/src/app/artist/[id]/_components/VaultManager.tsx
+++ b/src/app/artist/[id]/_components/VaultManager.tsx
@@ -212,6 +212,11 @@ export default function VaultManager({ artistId, pendingSources, approvedSources
 
   return (
     <div className="space-y-4">
+      {/* What the vault is for */}
+      <p className="text-xs text-muted-foreground leading-relaxed">
+        Your vault powers your profile. Approved sources — articles, interviews, reviews, uploaded files — become context for your AI-generated <strong>Artist Summary</strong> and the <strong>Ask About</strong> answers. The more quality sources you add, the better and more accurate that content gets.
+      </p>
+
       {/* Add a source by URL */}
       <div className="flex gap-2">
         <Input


### PR DESCRIPTION
## Summary

Two pre-main UX fixes on the artist profile:

1. **Remove "Read More" from the bio.** `BlurbSection`'s read view no longer truncates — the Artist Summary paragraph renders in full. Removed the collapse/expand machinery (`COLLAPSED_HEIGHT`, `needsTruncation`/`expanded` state, the measurement effect, the fade gradient, and the Read more / Show less toggle).
2. **Add a vault purpose descriptor.** `VaultManager` (shown to a claimed owner/admin while editing the vault) now leads with a short explainer: that approved sources power the AI-generated **Artist Summary** and **Ask About** answers, so more quality sources = better content. It only appears in edit mode (inside the existing `if (!isEditing) return null` guard).

## Test Plan
- Replaced the four "Read more" tests with one asserting the full bio renders and no Read more / Show less control exists.
- `VaultManager` tests unchanged and passing (descriptor is additive).
- Full gate green: type-check, lint, 1056 tests, build.

## Notes
- Edit-mode bio controls (Regenerate / Save / Save-to-vault / version history) are unchanged.
- DB migration for the earlier work is already applied to prod (per maintainer).