### PR TITLE
fix: enforce 10k char cap on bio PUT save (consistent with Save-to-vault)

### DIFF
--- a/src/app/actions/dashboardActions.ts
+++ b/src/app/actions/dashboardActions.ts
@@ -28,6 +28,7 @@ import { updateVaultSourceContent } from "@/server/utils/queries/dashboardQuerie
 import { generateReferenceCode } from "@/lib/referenceCode";
 import { sendDiscordMessage } from "@/server/utils/queries/discord";
 import { canEditArtist } from "@/server/utils/artistEditAuth";
+import { MAX_BIO_LENGTH } from "@/lib/bioConstants";
 
 // Best-effort debounce for bio regen (same serverless caveat as rate limiting)
 const bioRegenTimestamps = new Map<string, number>();
@@ -273,8 +274,6 @@ export async function getArtistBioVersions(targetArtistId?: string): Promise<{ s
         return { success: false, error: "Failed to load bio versions" };
     }
 }
-
-const MAX_BIO_LENGTH = 10_000;
 
 export async function saveCurrentBio(bioText: string, targetArtistId?: string): Promise<{ success: boolean; error?: string }> {
     const session = await getServerAuthSession() ?? await getDevSession();

--- a/src/app/api/artistBio/[id]/__tests__/route.put.test.ts
+++ b/src/app/api/artistBio/[id]/__tests__/route.put.test.ts
@@ -41,6 +41,25 @@ describe('PUT /api/artistBio/[id]', () => {
     expect(aq.updateArtistBio).toHaveBeenCalledWith('artist-1', 'New bio', false);
   });
 
+  it('rejects a bio that exceeds the character cap with a 400', async () => {
+    const { requireArtistEditor } = await import('@/lib/auth-helpers');
+    const aq = await import('@/server/utils/queries/artistQueries');
+    const { MAX_BIO_LENGTH } = await import('@/lib/bioConstants');
+    (requireArtistEditor as jest.Mock).mockResolvedValue({ authenticated: true, session: {}, userId: 'u1' });
+
+    const tooLong = 'a'.repeat(MAX_BIO_LENGTH + 1);
+    const { PUT } = await import('../route');
+    const req = new Request('http://t/', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ bio: tooLong }),
+    });
+    const res = await PUT(req, { params: Promise.resolve({ id: 'artist-1' }) });
+
+    expect(res.status).toBe(400);
+    expect(aq.updateArtistBio).not.toHaveBeenCalled();
+  });
+
   it('returns the guard failure (403) when not an authorized editor', async () => {
     const { requireArtistEditor } = await import('@/lib/auth-helpers');
     (requireArtistEditor as jest.Mock).mockResolvedValue({

--- a/src/app/api/artistBio/[id]/__tests__/route.put.test.ts
+++ b/src/app/api/artistBio/[id]/__tests__/route.put.test.ts
@@ -57,6 +57,8 @@ describe('PUT /api/artistBio/[id]', () => {
     const res = await PUT(req, { params: Promise.resolve({ id: 'artist-1' }) });
 
     expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.message).toBe(`Bio must be ${MAX_BIO_LENGTH} characters or fewer`);
     expect(aq.updateArtistBio).not.toHaveBeenCalled();
   });
 

--- a/src/app/api/artistBio/[id]/route.ts
+++ b/src/app/api/artistBio/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getArtistById } from "@/server/utils/queries/artistQueries";
 import { generateArtistBio } from "@/server/utils/queries/artistBioQuery";
 import { requireArtistEditor } from "@/lib/auth-helpers";
+import { MAX_BIO_LENGTH } from "@/lib/bioConstants";
 
 // CORS configuration for this route
 const ALLOWED_ORIGIN = process.env.NEXT_PUBLIC_ALLOWED_ORIGIN || "*";
@@ -103,6 +104,14 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
     // For regeneration, bio can be empty
     if (!regenerate && (!bio || typeof bio !== "string" || bio.trim().length === 0)) {
       return NextResponse.json({ message: "Invalid bio" }, { status: 400, headers: CORS_HEADERS });
+    }
+
+    // Enforce the same character cap as saveCurrentBio so the Save and Save-to-vault paths agree.
+    if (!regenerate && bio.length > MAX_BIO_LENGTH) {
+      return NextResponse.json(
+        { message: `Bio must be ${MAX_BIO_LENGTH} characters or fewer` },
+        { status: 400, headers: CORS_HEADERS }
+      );
     }
 
     const { updateArtistBio } = await import("@/server/utils/queries/artistQueries");

--- a/src/app/api/artistBio/[id]/route.ts
+++ b/src/app/api/artistBio/[id]/route.ts
@@ -106,7 +106,6 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
       return NextResponse.json({ message: "Invalid bio" }, { status: 400, headers: CORS_HEADERS });
     }
 
-    // Enforce the same character cap as saveCurrentBio so the Save and Save-to-vault paths agree.
     if (!regenerate && bio.length > MAX_BIO_LENGTH) {
       return NextResponse.json(
         { message: `Bio must be ${MAX_BIO_LENGTH} characters or fewer` },

--- a/src/lib/bioConstants.ts
+++ b/src/lib/bioConstants.ts
@@ -1,0 +1,2 @@
+/** Max characters allowed in an artist bio (Save and Save-to-vault both enforce this). */
+export const MAX_BIO_LENGTH = 10_000;


### PR DESCRIPTION
## Summary

Closes a small but real inconsistency in the bio save paths:

| Path | Previous cap |
|---|---|
| `saveCurrentBio` action (the **"Save to vault"** button → versions) | **10,000 chars** (`MAX_BIO_LENGTH`) |
| `PUT /api/artistBio/[id]` (the **"Save"** button → `artists.bio`) | **no cap** (only a "not empty" check) |

A user could paste a 50,000-char bio into the editor, hit Save, and it would land in `artists.bio` — then they couldn't snapshot it as a version because that path enforces 10k. This PR makes the two paths agree.

## Changes
- New `src/lib/bioConstants.ts` exporting `MAX_BIO_LENGTH = 10_000` so both call sites share one number.
- `dashboardActions.ts` — imports the constant instead of declaring its own local copy.
- `PUT /api/artistBio/[id]` — adds a 400 `{ message: "Bio must be <N> characters or fewer" }` response when `bio.length > MAX_BIO_LENGTH` (only when not regenerating; regenerate path is unchanged).
- New test case in `route.put.test.ts`: a bio of `MAX_BIO_LENGTH + 1` chars → 400, and `updateArtistBio` is **not** called.

## Test Plan
Full gate green: type-check, lint, **1060 tests**, build.

## Notes
Pre-main polish. Independent of #1121.