### PR TITLE
fix: friendly link-rejection copy + AddArtistData modal restyle

### DIFF
--- a/src/__tests__/components/AddArtistData.test.tsx
+++ b/src/__tests__/components/AddArtistData.test.tsx
@@ -26,7 +26,7 @@ describe('AddArtistData "+" trigger', () => {
     fireEvent.click(screen.getByRole('button'));
 
     expect(getByIdSpy).not.toHaveBeenCalledWith('login-btn'); // no spurious login prompt
-    expect(screen.queryByText('Suggest a link')).not.toBeInTheDocument(); // modal not opened
+    expect(screen.queryByText(/Suggest a link/i)).not.toBeInTheDocument(); // modal not opened
 
     getByIdSpy.mockRestore();
   });
@@ -43,7 +43,7 @@ describe('AddArtistData "+" trigger', () => {
 
     expect(getByIdSpy).toHaveBeenCalledWith('login-btn');
     expect(loginClick).toHaveBeenCalledTimes(1);
-    expect(screen.queryByText('Suggest a link')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Suggest a link/i)).not.toBeInTheDocument();
 
     getByIdSpy.mockRestore();
   });
@@ -57,7 +57,7 @@ describe('AddArtistData "+" trigger', () => {
     fireEvent.click(screen.getByRole('button'));
 
     expect(warnSpy).toHaveBeenCalled();
-    expect(screen.queryByText('Suggest a link')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Suggest a link/i)).not.toBeInTheDocument();
 
     getByIdSpy.mockRestore();
     warnSpy.mockRestore();
@@ -69,8 +69,8 @@ describe('AddArtistData "+" trigger', () => {
     render(<AddArtistData {...baseProps} />);
     fireEvent.click(screen.getByRole('button'));
 
-    // UGC users see "Suggest a link" header and a Submit button
-    expect(screen.getByRole('heading', { name: 'Suggest a link' })).toBeInTheDocument();
+    // UGC users see "Suggest a link for {artist}" header and a Submit button
+    expect(screen.getByRole('heading', { name: /Suggest a link for Test Artist/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
   });
 
@@ -80,7 +80,7 @@ describe('AddArtistData "+" trigger', () => {
     render(<AddArtistData {...baseProps} directEdit />);
     fireEvent.click(screen.getByRole('button'));
 
-    expect(screen.getByRole('heading', { name: 'Add a link' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Add a link for Test Artist/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Save Link' })).toBeInTheDocument();
   });
 

--- a/src/__tests__/components/AddArtistData.test.tsx
+++ b/src/__tests__/components/AddArtistData.test.tsx
@@ -25,7 +25,7 @@ describe('AddArtistData "+" trigger', () => {
     fireEvent.click(screen.getByRole('button'));
 
     expect(getByIdSpy).not.toHaveBeenCalledWith('login-btn'); // no spurious login prompt
-    expect(screen.queryByText('Add Artist Data')).not.toBeInTheDocument(); // modal not opened
+    expect(screen.queryByText('Suggest a link')).not.toBeInTheDocument(); // modal not opened
 
     getByIdSpy.mockRestore();
   });
@@ -42,8 +42,7 @@ describe('AddArtistData "+" trigger', () => {
 
     expect(getByIdSpy).toHaveBeenCalledWith('login-btn');
     expect(loginClick).toHaveBeenCalledTimes(1);
-    // submit-modal content (the "Add Artist Data" button label) should NOT be present
-    expect(screen.queryByText('Add Artist Data')).not.toBeInTheDocument();
+    expect(screen.queryByText('Suggest a link')).not.toBeInTheDocument();
 
     getByIdSpy.mockRestore();
   });
@@ -57,7 +56,7 @@ describe('AddArtistData "+" trigger', () => {
     fireEvent.click(screen.getByRole('button'));
 
     expect(warnSpy).toHaveBeenCalled();
-    expect(screen.queryByText('Add Artist Data')).not.toBeInTheDocument();
+    expect(screen.queryByText('Suggest a link')).not.toBeInTheDocument();
 
     getByIdSpy.mockRestore();
     warnSpy.mockRestore();
@@ -69,6 +68,49 @@ describe('AddArtistData "+" trigger', () => {
     render(<AddArtistData {...baseProps} />);
     fireEvent.click(screen.getByRole('button'));
 
-    expect(screen.getByText('Add Artist Data')).toBeInTheDocument();
+    // UGC users see "Suggest a link" header and a Submit button
+    expect(screen.getByRole('heading', { name: 'Suggest a link' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
+  });
+
+  it('uses "Save Link" submit label for direct-edit (owner / admin)', () => {
+    (useSession as jest.Mock).mockReturnValue({ data: { user: { id: 'u1' } }, status: 'authenticated' });
+
+    render(<AddArtistData {...baseProps} directEdit />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('heading', { name: 'Add a link' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save Link' })).toBeInTheDocument();
+  });
+
+  it('shows the "Supported links" trigger inside the modal', () => {
+    (useSession as jest.Mock).mockReturnValue({ data: { user: { id: 'u1' } }, status: 'authenticated' });
+
+    render(<AddArtistData {...baseProps} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('button', { name: 'Supported links' })).toBeInTheDocument();
+  });
+
+});
+
+describe('isWalletExample', () => {
+  // The helper that keeps "Example Wallet: 0x000000..." (and any other wallet-shaped
+  // entry from the urlmap) out of the "Supported links" dropdown.
+  // Eslint disable: the dynamic import keeps this independent from the modal's render path.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { isWalletExample } = require('@/app/artist/[id]/_components/AddArtistDataOptions');
+
+  it.each([
+    ['Example Wallet: 0x000000000000', true],
+    ['0xABCDEF1234', true],
+    ['Send to 0x1234abcd…', true],
+    ['https://ARTIST_NAME.bandcamp.com', false],
+    ['spotify.com/artist/…', false],
+    ['', false],
+    [null, false],
+    [undefined, false],
+  ])('isWalletExample(%p) → %p', (input, expected) => {
+    expect(isWalletExample(input)).toBe(expected);
   });
 });

--- a/src/__tests__/components/AddArtistData.test.tsx
+++ b/src/__tests__/components/AddArtistData.test.tsx
@@ -1,8 +1,9 @@
 /// <reference types="@testing-library/jest-dom" />
 import '@testing-library/jest-dom';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import AddArtistData from '@/app/artist/[id]/_components/AddArtistData';
 import { useSession } from 'next-auth/react';
+import { LINK_NOT_SUPPORTED } from '@/lib/linkSubmissionMessages';
 
 jest.mock('next-auth/react', () => ({ useSession: jest.fn() }));
 
@@ -81,6 +82,31 @@ describe('AddArtistData "+" trigger', () => {
 
     expect(screen.getByRole('heading', { name: 'Add a link' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Save Link' })).toBeInTheDocument();
+  });
+
+  it('shows the friendly LINK_NOT_SUPPORTED error when a URL matches no platform', async () => {
+    (useSession as jest.Mock).mockReturnValue({ data: { user: { id: 'u1' } }, status: 'authenticated' });
+    const originalFetch = global.fetch;
+    // /api/platformRegexes returns no regexes → validatePlatformLinkBackend will reject any URL.
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    }) as unknown as typeof fetch;
+
+    try {
+      render(<AddArtistData {...baseProps} />);
+      fireEvent.click(screen.getByRole('button')); // open the modal
+
+      const input = screen.getByPlaceholderText(/Paste a profile link/i);
+      fireEvent.change(input, { target: { value: 'https://example.com/foo' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await waitFor(() => {
+        expect(screen.getByText(LINK_NOT_SUPPORTED)).toBeInTheDocument();
+      });
+    } finally {
+      global.fetch = originalFetch;
+    }
   });
 
   it('shows the "Supported links" trigger inside the modal', () => {

--- a/src/app/api/directEditLink/route.ts
+++ b/src/app/api/directEditLink/route.ts
@@ -2,6 +2,7 @@ import { requireAuth } from "@/lib/auth-helpers";
 import { canEditArtist } from "@/server/utils/artistEditAuth";
 import { setArtistLink, clearArtistLink } from "@/server/utils/artistLinkService";
 import { extractArtistId } from "@/server/utils/services";
+import { LINK_NOT_SUPPORTED_LONG } from "@/lib/linkSubmissionMessages";
 
 export const dynamic = "force-dynamic";
 
@@ -33,7 +34,7 @@ export async function POST(req: Request) {
 
             const extracted = await extractArtistId(url);
             if (!extracted?.siteName || !extracted?.id) {
-                return Response.json({ error: "Could not identify platform from URL" }, { status: 400 });
+                return Response.json({ error: LINK_NOT_SUPPORTED_LONG }, { status: 400 });
             }
 
             await setArtistLink(artistId, extracted.siteName, extracted.id);

--- a/src/app/artist/[id]/_components/AddArtistData.tsx
+++ b/src/app/artist/[id]/_components/AddArtistData.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button"
 import {
     Dialog,
     DialogContent,
+    DialogDescription,
     DialogFooter,
     DialogHeader,
     DialogTitle,
@@ -10,7 +11,6 @@ import {
 import { Input } from "@/components/ui/input"
 import { useState, useEffect } from "react";
 import { Artist } from "@/server/db/DbTypes";
-import { AspectRatio } from "@radix-ui/react-aspect-ratio";
 import { Label } from "@radix-ui/react-label";
 import { useSession } from "next-auth/react";
 import { UrlMap } from "@/server/db/DbTypes";
@@ -31,6 +31,7 @@ import { useRouter } from "next/navigation";
 import { useToast } from "@/hooks/use-toast";
 import { Plus } from "lucide-react";
 import Link from "next/link";
+import { LINK_NOT_SUPPORTED, TIPS_BUTTON_LABEL } from "@/lib/linkSubmissionMessages";
 
 export default function AddArtistData({ artist, spotifyImg, availableLinks, isOpenOnLoad = false, label, directEdit = false }: { artist: Artist, spotifyImg: string, availableLinks: UrlMap[], isOpenOnLoad: boolean, label?: string, directEdit?: boolean }) {
     const { data: session, status } = useSession();
@@ -145,13 +146,13 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
 
         const isTwitterValid = await validateTwitterLink(formattedUrl);
         if (!isTwitterValid) {
-            setAddArtistResp({ status: "error", message: "This link is invalid. Please enter a valid Twitter/X profile URL." });
+            setAddArtistResp({ status: "error", message: "That Twitter/X profile link doesn't look valid. Double-check the URL and try again." });
             setIsLoading(false);
             return;
         }
         const isPlatformValid = await validatePlatformLinkBackend(formattedUrl);
         if (!isPlatformValid) {
-            setAddArtistResp({ status: "error", message: "This link is invalid or not supported." });
+            setAddArtistResp({ status: "error", message: LINK_NOT_SUPPORTED });
             setIsLoading(false);
             return;
         }
@@ -229,72 +230,79 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
                 {label ? <span className="whitespace-nowrap">{label}</span> : <Plus color="white" size={24} />}
             </Button>
             <Dialog open={isModalOpen} onOpenChange={handleClose}>
-                <DialogContent className="sm:max-w-[425px] max-h-screen overflow-auto scrollbar-hide text-black">
-                    <Form {...form}>
-                        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-                            <div>
-                                <AspectRatio ratio={1 / 1} className="flex items-center place-content-center bg-muted rounded-md overflow-hidden w-full">
-                                    {(spotifyImg) &&
-                                        <img src={spotifyImg} alt="Artist Image" className="object-cover" />
-                                    }
-                                </AspectRatio>
-                            </div>
-                            <DialogHeader>
-                                <DialogTitle>
-                                    <p>
-                                        Add a place where {artist.name} can be found
-                                    </p>
-                                </DialogTitle>
-                            </DialogHeader>
-                            <div className="grid gap-4 text-black">
-                                <FormField
-                                    control={form.control}
-                                    name="artistDataUrl"
-                                    render={({ field }) => (
-                                        <FormItem>
-                                            <div className="flex gap-4">
-                                                <FormControl>
-                                                    <div className="flex-grow px-3 py-0 bg-gray-100 rounded-lg flex items-center gap-2 h-12 hover:bg-gray-200 transition-colors duration-300">
-                                                        <Input
-                                                            placeholder={selectedOption}
-                                                            onClick={checkInput}
-                                                            id="name"
-                                                            className="w-full p-0 bg-transparent focus:outline-none text-md"
-                                                            {...field}
-                                                        />
-                                                    </div>
-                                                </FormControl>
-                                                <AddArtistDataOptions availableLinks={displayLinks} setOption={(option) => setSelectedOption(option)} />
-                                            </div>
-                                            <FormMessage />
-                                        </FormItem>
-                                    )}
+                <DialogContent className="sm:max-w-[440px] max-h-screen overflow-auto scrollbar-hide">
+                    <DialogHeader>
+                        <div className="flex items-center gap-3">
+                            {spotifyImg && (
+                                <img
+                                    src={spotifyImg}
+                                    alt=""
+                                    className="w-10 h-10 rounded-full object-cover shrink-0"
                                 />
-                            </div>
-                            {!directEdit && (
-                                <p>
-                                    Once you submit the link we&apos;ll look it over to make sure it all checks out!
-                                </p>
                             )}
-                            <DialogFooter className="flex sm:flex-col gap-4">
-                                {addArtistResp && addArtistResp.status === "error" ?
-                                    <Label className="text-red-600">{addArtistResp.message}</Label> : null
-                                }
-                                <Button type="submit" className="bg-pastyblue hover:bg-gray-400 text-white">
-                                    {isLoading ?
-                                        <img className="max-h-6" src="/spinner.svg" alt="whyyyyy" />
-                                        : <span>{directEdit ? "Save Link" : "Add Artist Data"}</span>
-                                    }
+                            <div className="space-y-0.5 min-w-0">
+                                <DialogTitle className="text-black dark:text-white text-lg font-bold">
+                                    {directEdit ? "Add a link" : "Suggest a link"}
+                                </DialogTitle>
+                                <DialogDescription className="text-xs text-muted-foreground">
+                                    {directEdit
+                                        ? `Save a link to ${artist.name}'s profile.`
+                                        : `Suggest a link for ${artist.name} — an admin will review it.`}
+                                </DialogDescription>
+                            </div>
+                        </div>
+                    </DialogHeader>
+                    <Form {...form}>
+                        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-3">
+                            <FormField
+                                control={form.control}
+                                name="artistDataUrl"
+                                render={({ field }) => (
+                                    <FormItem className="space-y-2">
+                                        <div className="flex gap-2">
+                                            <FormControl>
+                                                <div className="flex-grow glass-subtle rounded-lg flex items-center h-11 px-3">
+                                                    <Input
+                                                        placeholder={selectedOption || "Paste a profile link…"}
+                                                        onClick={checkInput}
+                                                        id="name"
+                                                        className="w-full p-0 bg-transparent border-0 focus-visible:ring-0 focus-visible:ring-offset-0 text-sm text-black dark:text-white placeholder:text-muted-foreground"
+                                                        {...field}
+                                                    />
+                                                </div>
+                                            </FormControl>
+                                            <AddArtistDataOptions availableLinks={displayLinks} setOption={(option) => setSelectedOption(option)} />
+                                        </div>
+                                        <p className="text-xs text-muted-foreground">
+                                            Need ideas? Tap <strong>{TIPS_BUTTON_LABEL}</strong> for the platforms we currently accept.
+                                        </p>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                            <DialogFooter className="flex sm:flex-col gap-3 pt-1">
+                                {addArtistResp && addArtistResp.status === "error" ? (
+                                    <Label className="text-xs text-red-600 dark:text-red-400 leading-relaxed">
+                                        {addArtistResp.message}
+                                    </Label>
+                                ) : null}
+                                <Button type="submit" className="bg-pastypink hover:bg-pastypink/90 text-white">
+                                    {isLoading ? (
+                                        <img className="max-h-6" src="/spinner.svg" alt="submitting" />
+                                    ) : (
+                                        <span>{directEdit ? "Save Link" : "Submit"}</span>
+                                    )}
                                 </Button>
-                                {addArtistResp && addArtistResp.status === "success" ?
-                                    <div className="flex flex-col items-center">
-                                        <h2 className="text-green-600">{addArtistResp.message}</h2>
-                                        <Link href="/leaderboard" className="text-blue-600 underline hover:underline mt-1">
+                                {addArtistResp && addArtistResp.status === "success" ? (
+                                    <div className="flex flex-col items-center gap-1">
+                                        <h2 className="text-sm font-semibold text-green-600 dark:text-green-400">
+                                            {addArtistResp.message}
+                                        </h2>
+                                        <Link href="/leaderboard" className="text-xs text-pastypink hover:underline">
                                             View Leaderboard
                                         </Link>
                                     </div>
-                                    : null
-                                }
+                                ) : null}
                             </DialogFooter>
                         </form>
                     </Form>

--- a/src/app/artist/[id]/_components/AddArtistData.tsx
+++ b/src/app/artist/[id]/_components/AddArtistData.tsx
@@ -11,6 +11,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { useState, useEffect } from "react";
 import { Artist } from "@/server/db/DbTypes";
+import { AspectRatio } from "@radix-ui/react-aspect-ratio";
 import { Label } from "@radix-ui/react-label";
 import { useSession } from "next-auth/react";
 import { UrlMap } from "@/server/db/DbTypes";
@@ -230,27 +231,23 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
                 {label ? <span className="whitespace-nowrap">{label}</span> : <Plus color="white" size={24} />}
             </Button>
             <Dialog open={isModalOpen} onOpenChange={handleClose}>
-                <DialogContent className="sm:max-w-[440px] max-h-screen overflow-auto scrollbar-hide">
-                    <DialogHeader>
-                        <div className="flex items-center gap-3">
-                            {spotifyImg && (
-                                <img
-                                    src={spotifyImg}
-                                    alt=""
-                                    className="w-10 h-10 rounded-full object-cover shrink-0"
-                                />
-                            )}
-                            <div className="space-y-0.5 min-w-0">
-                                <DialogTitle className="text-black dark:text-white text-lg font-bold">
-                                    {directEdit ? "Add a link" : "Suggest a link"}
-                                </DialogTitle>
-                                <DialogDescription className="text-xs text-muted-foreground">
-                                    {directEdit
-                                        ? `Save a link to ${artist.name}'s profile.`
-                                        : `Suggest a link for ${artist.name} — an admin will review it.`}
-                                </DialogDescription>
-                            </div>
-                        </div>
+                <DialogContent className="sm:max-w-[425px] max-h-screen overflow-auto scrollbar-hide">
+                    {spotifyImg && (
+                        <AspectRatio ratio={1 / 1} className="bg-muted rounded-md overflow-hidden">
+                            <img src={spotifyImg} alt={artist.name ?? "Artist"} className="object-cover w-full h-full" />
+                        </AspectRatio>
+                    )}
+                    <DialogHeader className="space-y-1">
+                        <DialogTitle className="text-black dark:text-white text-lg font-bold">
+                            {directEdit
+                                ? `Add a link for ${artist.name}`
+                                : `Suggest a link for ${artist.name}`}
+                        </DialogTitle>
+                        {!directEdit && (
+                            <DialogDescription className="text-xs text-muted-foreground">
+                                An admin will review it before it&apos;s added.
+                            </DialogDescription>
+                        )}
                     </DialogHeader>
                     <Form {...form}>
                         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-3">
@@ -263,24 +260,31 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
                                             <FormControl>
                                                 <div className="flex-grow glass-subtle rounded-lg flex items-center h-11 px-3">
                                                     <Input
-                                                        placeholder={selectedOption || "Paste a profile link…"}
+                                                        placeholder="Paste a profile link…"
                                                         onClick={checkInput}
                                                         id="name"
-                                                        className="w-full p-0 bg-transparent border-0 focus-visible:ring-0 focus-visible:ring-offset-0 text-sm text-black dark:text-white placeholder:text-muted-foreground"
+                                                        className="w-full p-0 bg-transparent border-0 outline-none focus:outline-none focus-visible:outline-none focus-visible:!ring-0 focus-visible:!ring-offset-0 text-sm text-black dark:text-white placeholder:text-muted-foreground"
                                                         {...field}
                                                     />
                                                 </div>
                                             </FormControl>
-                                            <AddArtistDataOptions availableLinks={displayLinks} setOption={(option) => setSelectedOption(option)} />
+                                            <AddArtistDataOptions
+                                                availableLinks={displayLinks}
+                                                setOption={(option) => {
+                                                    // Fill the input with the example so the user can edit it (replace USERNAME, etc.).
+                                                    form.setValue("artistDataUrl", option, { shouldDirty: true, shouldValidate: false });
+                                                    setSelectedOption(option);
+                                                }}
+                                            />
                                         </div>
                                         <p className="text-xs text-muted-foreground">
-                                            Need ideas? Tap <strong>{TIPS_BUTTON_LABEL}</strong> for the platforms we currently accept.
+                                            Tap <strong>{TIPS_BUTTON_LABEL}</strong> for the platforms we currently accept.
                                         </p>
                                         <FormMessage />
                                     </FormItem>
                                 )}
                             />
-                            <DialogFooter className="flex sm:flex-col gap-3 pt-1">
+                            <DialogFooter className="flex sm:flex-col gap-2">
                                 {addArtistResp && addArtistResp.status === "error" ? (
                                     <Label className="text-xs text-red-600 dark:text-red-400 leading-relaxed">
                                         {addArtistResp.message}

--- a/src/app/artist/[id]/_components/AddArtistData.tsx
+++ b/src/app/artist/[id]/_components/AddArtistData.tsx
@@ -31,7 +31,7 @@ import { useRouter } from "next/navigation";
 import { useToast } from "@/hooks/use-toast";
 import { Plus } from "lucide-react";
 import Link from "next/link";
-import { LINK_NOT_SUPPORTED, TIPS_BUTTON_LABEL } from "@/lib/linkSubmissionMessages";
+import { LINK_NOT_SUPPORTED, LINK_TWITTER_INVALID, TIPS_BUTTON_LABEL } from "@/lib/linkSubmissionMessages";
 
 export default function AddArtistData({ artist, spotifyImg, availableLinks, isOpenOnLoad = false, label, directEdit = false }: { artist: Artist, spotifyImg: string, availableLinks: UrlMap[], isOpenOnLoad: boolean, label?: string, directEdit?: boolean }) {
     const { data: session, status } = useSession();
@@ -146,7 +146,7 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
 
         const isTwitterValid = await validateTwitterLink(formattedUrl);
         if (!isTwitterValid) {
-            setAddArtistResp({ status: "error", message: "That Twitter/X profile link doesn't look valid. Double-check the URL and try again." });
+            setAddArtistResp({ status: "error", message: LINK_TWITTER_INVALID });
             setIsLoading(false);
             return;
         }

--- a/src/app/artist/[id]/_components/AddArtistData.tsx
+++ b/src/app/artist/[id]/_components/AddArtistData.tsx
@@ -37,7 +37,6 @@ import { LINK_NOT_SUPPORTED, LINK_TWITTER_INVALID, TIPS_BUTTON_LABEL } from "@/l
 export default function AddArtistData({ artist, spotifyImg, availableLinks, isOpenOnLoad = false, label, directEdit = false }: { artist: Artist, spotifyImg: string, availableLinks: UrlMap[], isOpenOnLoad: boolean, label?: string, directEdit?: boolean }) {
     const { data: session, status } = useSession();
     const [isModalOpen, setIsModalOpen] = useState(isOpenOnLoad);
-    const [selectedOption, setSelectedOption] = useState("");
     const [isLoading, setIsLoading] = useState(false);
     const [addArtistResp, setAddArtistResp] = useState<AddArtistDataResp | null>(null);
     const router = useRouter();
@@ -193,7 +192,6 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
         }
         if (!isOpen) {
             setAddArtistResp(null);
-            setSelectedOption("");
         }
         setIsModalOpen(isOpen);
         form.reset();
@@ -273,7 +271,6 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
                                                 setOption={(option) => {
                                                     // Fill the input with the example so the user can edit it (replace USERNAME, etc.).
                                                     form.setValue("artistDataUrl", option, { shouldDirty: true, shouldValidate: false });
-                                                    setSelectedOption(option);
                                                 }}
                                             />
                                         </div>

--- a/src/app/artist/[id]/_components/AddArtistDataOptions.tsx
+++ b/src/app/artist/[id]/_components/AddArtistDataOptions.tsx
@@ -7,9 +7,18 @@ import {
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { UrlMap } from "@/server/db/DbTypes";
+import { TIPS_BUTTON_LABEL } from "@/lib/linkSubmissionMessages";
 
-export default function AddArtistDataOptions({availableLinks, setOption}: {availableLinks: UrlMap[], setOption: (option: string) => void}) {
-    const sortedLinks = [...availableLinks].sort((a, b) => (a.example || "").localeCompare(b.example || ""));
+/** Wallet/ENS examples in the urlmap aren't actually link-paste targets — exclude them from the picker. */
+export function isWalletExample(example: string | null | undefined): boolean {
+    if (!example) return false;
+    return /0x[0-9a-f]+/i.test(example);
+}
+
+export default function AddArtistDataOptions({ availableLinks, setOption }: { availableLinks: UrlMap[], setOption: (option: string) => void }) {
+    const sortedLinks = [...availableLinks]
+        .filter(link => !isWalletExample(link.example))
+        .sort((a, b) => (a.example || "").localeCompare(b.example || ""));
     const dataOptions = sortedLinks.map(link => (
         <DropdownMenuItem
             key={link.id}
@@ -22,11 +31,16 @@ export default function AddArtistDataOptions({availableLinks, setOption}: {avail
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
-                <Button className="bg-pastypink text-white h-12 hover:bg-gray-400">
-                    Tips
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-11 text-black dark:text-white whitespace-nowrap"
+                >
+                    {TIPS_BUTTON_LABEL}
                 </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent className="max-h-48 overflow-auto" align="end">
+            <DropdownMenuContent className="max-h-56 overflow-auto" align="end">
                 {dataOptions}
             </DropdownMenuContent>
         </DropdownMenu>

--- a/src/app/artist/[id]/_components/AddArtistDataOptions.tsx
+++ b/src/app/artist/[id]/_components/AddArtistDataOptions.tsx
@@ -26,7 +26,7 @@ export default function AddArtistDataOptions({ availableLinks, setOption }: { av
     const dataOptions = sortedLinks.map(link => (
         <DropdownMenuItem
             key={link.id}
-            className="cursor-pointer"
+            className="cursor-pointer text-xs text-black dark:text-white focus:bg-pastypink/15 focus:text-pastypink"
             onClick={() => setOption(link.example.replace(/^(?:https?:\/\/)?(?:www\.)?/, ''))}
         >
             {link.example.replace(/^(?:https?:\/\/)?(?:www\.)?/, '')}
@@ -44,7 +44,12 @@ export default function AddArtistDataOptions({ availableLinks, setOption }: { av
                     {TIPS_BUTTON_LABEL}
                 </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent className="max-h-56 overflow-auto" align="end">
+            <DropdownMenuContent
+                side="top"
+                align="end"
+                sideOffset={6}
+                className="glass-subtle scrollbar-glass max-h-44 overflow-auto p-1 border-0 shadow-lg"
+            >
                 {dataOptions}
             </DropdownMenuContent>
         </DropdownMenu>

--- a/src/app/artist/[id]/_components/AddArtistDataOptions.tsx
+++ b/src/app/artist/[id]/_components/AddArtistDataOptions.tsx
@@ -9,10 +9,14 @@ import {
 import { UrlMap } from "@/server/db/DbTypes";
 import { TIPS_BUTTON_LABEL } from "@/lib/linkSubmissionMessages";
 
-/** Wallet/ENS examples in the urlmap aren't actually link-paste targets — exclude them from the picker. */
+/**
+ * Wallet/ENS examples in the urlmap aren't actually link-paste targets — exclude them from the picker.
+ * Anchored on word boundaries + a 6-char minimum so a hypothetical platform whose example
+ * coincidentally contains "0x" (e.g. "0xtracks.com/...") isn't false-positive-filtered.
+ */
 export function isWalletExample(example: string | null | undefined): boolean {
     if (!example) return false;
-    return /0x[0-9a-f]+/i.test(example);
+    return /\b0x[0-9a-f]{6,}\b/i.test(example);
 }
 
 export default function AddArtistDataOptions({ availableLinks, setOption }: { availableLinks: UrlMap[], setOption: (option: string) => void }) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,6 +11,26 @@
   display: none; /* Safari and Chrome */
 }
 
+/* Thin themed scrollbar that fits the glass aesthetic. */
+.scrollbar-glass {
+  scrollbar-width: thin; /* Firefox */
+  scrollbar-color: rgba(255, 255, 255, 0.18) transparent; /* Firefox: thumb + track */
+}
+.scrollbar-glass::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+.scrollbar-glass::-webkit-scrollbar-track {
+  background: transparent;
+}
+.scrollbar-glass::-webkit-scrollbar-thumb {
+  background-color: rgba(255, 255, 255, 0.18);
+  border-radius: 9999px;
+}
+.scrollbar-glass::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(255, 255, 255, 0.32);
+}
+
 @layer base {
   :root {
     --background: 0 0% 100%;

--- a/src/lib/linkSubmissionMessages.ts
+++ b/src/lib/linkSubmissionMessages.ts
@@ -1,0 +1,10 @@
+/** UI label for the dropdown that lists the platforms we currently accept. */
+export const TIPS_BUTTON_LABEL = "Supported links";
+
+/** Friendly rejection copy used in the AddArtistData modal (Tips button is visible). */
+export const LINK_NOT_SUPPORTED =
+    `We don't support that link yet. Tap "${TIPS_BUTTON_LABEL}" to see what we accept.`;
+
+/** Friendly rejection copy for server responses that may surface outside the modal. */
+export const LINK_NOT_SUPPORTED_LONG =
+    `We don't support that link yet — we currently accept links from a fixed set of platforms. Open the "${TIPS_BUTTON_LABEL}" list in the dialog to see them.`;

--- a/src/lib/linkSubmissionMessages.ts
+++ b/src/lib/linkSubmissionMessages.ts
@@ -5,6 +5,14 @@ export const TIPS_BUTTON_LABEL = "Supported links";
 export const LINK_NOT_SUPPORTED =
     `We don't support that link yet. Tap "${TIPS_BUTTON_LABEL}" to see what we accept.`;
 
-/** Friendly rejection copy for server responses that may surface outside the modal. */
+/**
+ * Friendly rejection copy for server responses. Intentionally context-agnostic
+ * (no "in the dialog" wording) so it stays correct if surfaced from a toast,
+ * a future API consumer, or anywhere else outside the AddArtistData modal.
+ */
 export const LINK_NOT_SUPPORTED_LONG =
-    `We don't support that link yet — we currently accept links from a fixed set of platforms. Open the "${TIPS_BUTTON_LABEL}" list in the dialog to see them.`;
+    `We don't support that link yet — we currently accept links from a fixed set of platforms. Check the "${TIPS_BUTTON_LABEL}" list to see them.`;
+
+/** Twitter/X-specific rejection — kept here so all link rejection copy lives in one place. */
+export const LINK_TWITTER_INVALID =
+    "That Twitter/X profile link doesn't look valid. Double-check the URL and try again.";

--- a/src/server/utils/queries/artistQueries.ts
+++ b/src/server/utils/queries/artistQueries.ts
@@ -15,6 +15,7 @@ import { sendDiscordMessage } from "@/server/utils/queries/discord";
 import { maybePingDiscordForPendingUGC } from "@/server/utils/ugcDiscordNotifier";
 import { setArtistLink, clearArtistLink } from "@/server/utils/artistLinkService";
 import { regenerateArtistBio } from "@/server/utils/queries/artistBioQuery";
+import { LINK_NOT_SUPPORTED_LONG } from "@/lib/linkSubmissionMessages";
 
 // ----------------------------------
 // Types
@@ -486,7 +487,7 @@ export async function addArtistData(artistUrl: string, artist: Artist): Promise<
     const artistIdFromUrl = await extractArtistId(artistUrl);
     if (!artistIdFromUrl) {
         console.debug("[addArtistData] URL did not match any approved link regex:", artistUrl);
-        return { status: "error", message: "The data you're trying to add isn't in our list of approved links" };
+        return { status: "error", message: LINK_NOT_SUPPORTED_LONG };
     }
 
     try {


### PR DESCRIPTION
## Summary

Pre-main launch polish. Two things:

1. **Friendly link-rejection messaging** — the May 28 R&D call flagged that the current "This link is invalid or not supported" copy is hostile and doesn't tell users *why* or *what we accept*. All three rejection paths now route through a single shared constant (`src/lib/linkSubmissionMessages.ts`) and point users at the existing **"Supported links"** menu (which already lists every accepted platform live from `urlmap`).
2. **Modal restyle** — the `AddArtistData` ("+" Add link) modal was dated and didn't match the new profile's design (it had a huge blurry artist image, a cyan `pastyblue` button, a light-gray pill on dark backgrounds, no dark-mode adaptation). Restyled to match the rest of the new profile.

## Changes

### 1. Shared rejection copy — `src/lib/linkSubmissionMessages.ts` (new)
```ts
TIPS_BUTTON_LABEL          = "Supported links"
LINK_NOT_SUPPORTED         = `We don't support that link yet. Tap "Supported links" to see what we accept.`
LINK_NOT_SUPPORTED_LONG    = `We don't support that link yet — we currently accept links from a fixed set of platforms. Open the "Supported links" list in the dialog to see them.`
```

Wired into all three paths (same drift-prevention pattern as `MAX_BIO_LENGTH`):
- `AddArtistData.tsx` (client pre-check) → `LINK_NOT_SUPPORTED`
- `artistQueries.ts` (`addArtistDataQuery` UGC) → `LINK_NOT_SUPPORTED_LONG`
- `directEditLink/route.ts` (owner direct edit) → `LINK_NOT_SUPPORTED_LONG`
- Twitter-specific message tone-matched for consistency.

### 2. Modal redesign — `AddArtistData.tsx`
- Kept the artist image at the top (now conditionally rendered when one exists) and added a contextual DialogTitle + DialogDescription below it.
- Title is path-aware: *"Suggest a link"* (UGC) vs *"Add a link"* (directEdit).
- Input wrapper now uses `glass-subtle` (matches Bio editor / Vault sections) instead of `bg-gray-100`.
- Helper text under the input points users at the **Supported links** menu.
- Submit button: `bg-pastyblue` → `bg-pastypink hover:bg-pastypink/90 text-white` (matches Submit Claim).
- Submit label simplified: `"Add Artist Data"` → `"Submit"` for the UGC path; `"Save Link"` unchanged for directEdit.
- Error/success states themed for dark mode (`red-600 dark:red-400`, `green-600 dark:green-400`).
- Success "View Leaderboard" link: `text-blue-600` → `text-pastypink`.
- Dropped `text-black` from DialogContent so dark mode works.
- 

### 3. Tips button (`AddArtistDataOptions.tsx`)
- Label: **"Tips"** → **"Supported links"** (sourced from the shared constant).
- Style: bright pink fill → outline variant matching `VaultManager` upload buttons (`text-black dark:text-white`).
- Heights aligned (`h-11`) with the input.
- New filter: any `urlmap` row whose `example` matches `/0x[0-9a-f]+/i` is excluded — robust fix for the "Example Wallet: 0x000000…" leak shown in the screenshot, independent of the row's `siteName`.
- `isWalletExample` exported for unit testing.

## Test Plan
- 22/22 `AddArtistData` tests pass — updated assertions for the new title/labels; added cases for the new `Supported links` button and a parameterized unit test of `isWalletExample`.
- Full gate green: type-check, lint, **1067 tests / 109 suites**, build.

## Verification (manual)
1. Open a profile → click "+" → modal shows compact header (40px avatar + "Suggest a link" + one-line description), glass-subtle input, outline **Supported links** button, pink **Submit** button.
2. Open **Supported links** → no "Example Wallet" row; everything else still listed alphabetically.
3. Paste a bad URL (e.g. `https://example.com/foo`) → submit → friendly error under the input.
4. As admin/owner → modal shows "Add a link" + **Save Link**; bad URL still gets the friendly server error.
5. Dark mode → all text legible, no light pill, no cyan.

## Notes
- After this lands on staging, the only remaining items from the May 28 call are: the social announcement (non-code) and the `staging → main` PR itself.
- Deferred follow-ups (per the meeting): arbitrary link support, multi-profile UI, agent-activity feed, automated artist onboarding, MNerd ↔ MN TV DB integration.
