### PR TITLE
chore: post-merge review polish from #1126 + #1127 second reviews

### DIFF
--- a/src/app/actions/dashboardActions.ts
+++ b/src/app/actions/dashboardActions.ts
@@ -31,6 +31,13 @@ import { MAX_BIO_LENGTH } from "@/lib/bioConstants";
 // Best-effort debounce for bio regen (same serverless caveat as rate limiting).
 // Map is module-level — on long-lived workers (e.g. self-hosted Node) it would
 // grow unbounded without the prune below. Soft-cap + TTL drop keeps it bounded.
+//
+// Prune fires only on the WRITE path (right before set()), not on read. On a quiet
+// worker that always hits the debounce for the same small set of artists, the map
+// is small and prune is unnecessary. On a busy worker, every new artist write goes
+// through this prune, so growth is naturally rate-limited. A separate timer/sweeper
+// would just burn cycles on idle workers and add coordination overhead — write-time
+// prune is the right shape for best-effort serverless state.
 const bioRegenTimestamps = new Map<string, number>();
 const BIO_REGEN_DEBOUNCE_MS = 30_000;
 const BIO_REGEN_MAP_SOFT_CAP = 5_000;

--- a/src/app/api/artist/profile-image/route.ts
+++ b/src/app/api/artist/profile-image/route.ts
@@ -13,6 +13,14 @@ export const dynamic = "force-dynamic";
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 const ALLOWED_TYPES = ["image/png", "image/jpeg", "image/webp"];
 
+// Stale profile-image purge: don't delete anything younger than this. The exact-filename
+// guard (`f.name === filename` below) is the primary safety net — it makes the new
+// upload unkillable regardless of clock skew. This window catches OTHER same-artist
+// concurrent uploads (e.g. two browser tabs racing), where the second upload's
+// list() would otherwise find the first upload's storage object and nuke it before
+// the first one's DB update lands.
+const STALE_PROFILE_IMAGE_GRACE_MS = 30_000;
+
 export async function POST(req: Request) {
     const session = await getServerAuthSession() ?? await getDevSession();
     if (!session) {
@@ -102,11 +110,9 @@ export async function POST(req: Request) {
                 .from(VAULT_BUCKET)
                 .list("profile-images", { limit: 1000, offset: 0, search: `${artistId}_` });
             // Defense in depth: `search` is substring match — re-anchor with startsWith.
-            // Exclude the file we just uploaded AND anything uploaded in the last 30s,
-            // so two concurrent uploads from the same owner can't have one nuke the
-            // other's just-uploaded storage object before its DB update lands.
-            const concurrentGraceMs = 30_000;
-            const ageCutoff = Date.now() - concurrentGraceMs;
+            // Exclude the file we just uploaded AND anything within the grace window
+            // (see STALE_PROFILE_IMAGE_GRACE_MS docs above).
+            const ageCutoff = Date.now() - STALE_PROFILE_IMAGE_GRACE_MS;
             const stale = (files ?? [])
                 .filter(f => {
                     if (!f.name.startsWith(`${artistId}_`)) return false;

--- a/src/app/api/vault/upload/__tests__/route.admin.test.ts
+++ b/src/app/api/vault/upload/__tests__/route.admin.test.ts
@@ -118,7 +118,7 @@ describe('POST /api/vault/upload admin path', () => {
     expect(body.success).toBe(true);
   });
 
-  it('persists filePath as the storage key, NOT the public URL (regression: #1126 forward-only change)', async () => {
+  it('persists filePath as the storage key, not the public URL', async () => {
     const auth = await import('@/server/auth');
     const users = await import('@/server/utils/queries/userQueries');
     const claims = await import('@/server/utils/queries/dashboardQueries');

--- a/src/app/api/vault/upload/__tests__/route.admin.test.ts
+++ b/src/app/api/vault/upload/__tests__/route.admin.test.ts
@@ -118,6 +118,38 @@ describe('POST /api/vault/upload admin path', () => {
     expect(body.success).toBe(true);
   });
 
+  it('persists filePath as the storage key, NOT the public URL (regression: #1126 forward-only change)', async () => {
+    const auth = await import('@/server/auth');
+    const users = await import('@/server/utils/queries/userQueries');
+    const claims = await import('@/server/utils/queries/dashboardQueries');
+    (auth.getServerAuthSession as jest.Mock).mockResolvedValue({ user: { id: 'admin-1' } });
+    (users.getUserById as jest.Mock).mockResolvedValue({ isAdmin: true });
+    (claims.getApprovedClaimForArtistByUserId as jest.Mock).mockResolvedValue(undefined);
+    (claims.insertVaultSource as jest.Mock).mockResolvedValue({ id: 'src-1' });
+
+    const { POST } = await import('../route');
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const mockFile = {
+      name: 'press-photo.png',
+      type: 'image/png',
+      size: pngBytes.byteLength,
+      arrayBuffer: async () => pngBytes.buffer,
+    };
+    const fd = new Map([['file', mockFile], ['artistId', 'artist-x']]);
+    const req = { formData: async () => ({ get: (k) => fd.get(k) }) } as unknown as Request;
+    await POST(req);
+
+    expect(claims.insertVaultSource).toHaveBeenCalledTimes(1);
+    const callArg = (claims.insertVaultSource as jest.Mock).mock.calls[0][0];
+    // url stays as the publicly-served URL (used by browsers to render the asset)
+    expect(callArg.url).toBe('http://x/file.png');
+    // filePath holds the Supabase storage KEY — `${artistId}/${timestamp}_${safeName}${ext}` —
+    // so per-file deletion can call .remove([filePath]) without URL-parsing.
+    expect(callArg.filePath).not.toBe(callArg.url);
+    expect(callArg.filePath).not.toMatch(/^https?:\/\//);
+    expect(callArg.filePath).toMatch(/^artist-x\/\d+_press-photo\.png$/);
+  });
+
   it('rejects a non-admin WITH a claim for a different artist', async () => {
     const auth = await import('@/server/auth');
     const users = await import('@/server/utils/queries/userQueries');


### PR DESCRIPTION
Tiny follow-up addressing the **second** claude-reviews on #1126 and #1127 (the ones posted after each PR's nit-commit). Both reviews explicitly approved the PRs; these items were classified as "consider" / "minor nit" / "test gap" — polish, not bugs.

## What's in this PR

### From #1126 second review
- **New test: `filePath = storagePath` regression guard.** Asserts that for new vault uploads, `insertVaultSource` is called with `filePath` set to the Supabase storage key (e.g. `artist-x/1735000000_press-photo.png`) — never the public URL. Locks in the forward-only change so a future regression to `filePath: publicUrl` is caught.

### From #1127 second review
- **Hoisted `concurrentGraceMs` → `STALE_PROFILE_IMAGE_GRACE_MS`** at module scope, with a docstring explaining the safety model: the exact-filename guard (`f.name === filename`) is the **primary** safety net (makes the just-uploaded file unkillable regardless of clock skew); the grace window only protects against OTHER concurrent uploads (e.g. two browser tabs racing).
- **Clarified the grace-check inline comment** to reference the named constant.
- **Documented `pruneBioRegenTimestamps` prune-on-write rationale** — write-path prune naturally rate-limits to busy workers; a separate sweeper would burn cycles on idle ones. The reviewer noted the "only fires on write" choice and asked for an explanation.

## Intentionally NOT in this PR

- **`getVaultSourcesByIds` batch helper.** Reviewer's note was contingent ("if larger payloads"). Current UI bulk deletes are typically 1-5 sources — premature optimization. YAGNI.

## Why this is a chore PR, not a fix

Both #1126 and #1127 were already approved + merged when these reviews landed. Nothing in either review was a bug or a regression; the items are comments, a test for already-shipped behavior, and a refactor of a constant's placement. Clean polish before the production cutover.

## Tests + CI

- Local CI: type-check ✅ · lint ✅ · 1078 tests pass ✅ (was 1077; +1 for the new filePath assertion) · build ✅

## After merge

I'll update #1125's body — adding a one-line note that this polish is in, no checklist changes needed (no new migrations or behavior changes).