### PR TITLE
fix: notify Discord for direct artist link edits

### DIFF
--- a/src/app/api/directEditLink/__tests__/route.test.ts
+++ b/src/app/api/directEditLink/__tests__/route.test.ts
@@ -8,9 +8,6 @@ jest.mock("@/server/utils/queries/userQueries", () => ({
     getUserDisplayName: jest.requireActual("@/server/utils/queries/userQueries").getUserDisplayName,
     getUserById: jest.fn(),
 }));
-jest.mock("@/server/utils/queries/artistQueries", () => ({
-    getArtistById: jest.fn(),
-}));
 jest.mock("@/server/utils/queries/discord", () => ({
     sendDiscordMessage: jest.fn(),
 }));
@@ -41,7 +38,6 @@ describe("POST /api/directEditLink", () => {
     async function setup() {
         const { requireAuth } = await import("@/lib/auth-helpers");
         const { getUserById } = await import("@/server/utils/queries/userQueries");
-        const { getArtistById } = await import("@/server/utils/queries/artistQueries");
         const { sendDiscordMessage } = await import("@/server/utils/queries/discord");
         const { getApprovedClaimForArtistByUserId } = await import("@/server/utils/queries/dashboardQueries");
         const { setArtistLink, clearArtistLink } = await import("@/server/utils/artistLinkService");
@@ -51,7 +47,6 @@ describe("POST /api/directEditLink", () => {
             POST,
             requireAuth: requireAuth as jest.Mock,
             getUserById: getUserById as jest.Mock,
-            getArtistById: getArtistById as jest.Mock,
             sendDiscordMessage: sendDiscordMessage as jest.Mock,
             getApprovedClaimForArtistByUserId: getApprovedClaimForArtistByUserId as jest.Mock,
             setArtistLink: setArtistLink as jest.Mock,
@@ -100,12 +95,11 @@ describe("POST /api/directEditLink", () => {
     });
 
     it("allows admin to edit any artist and notifies Discord", async () => {
-        const { POST, requireAuth, getUserById, getArtistById, sendDiscordMessage, extractArtistId, setArtistLink } = await setup();
+        const { POST, requireAuth, getUserById, sendDiscordMessage, extractArtistId, setArtistLink } = await setup();
         requireAuth.mockResolvedValue({ authenticated: true, session: {}, userId: "u1" });
         getUserById.mockResolvedValue({ id: "u1", username: "admin-user", isAdmin: true });
-        getArtistById.mockResolvedValue({ id: "a1", name: "Test Artist" });
         extractArtistId.mockResolvedValue({ siteName: "x", id: "testuser", cardPlatformName: "X" });
-        setArtistLink.mockResolvedValue(undefined);
+        setArtistLink.mockResolvedValue({ oldValue: null, artistName: "Test Artist" });
 
         const res = await POST(makeRequest({ artistId: "a1", action: "set", url: "https://x.com/testuser" }));
         const data = await res.json();
@@ -120,13 +114,12 @@ describe("POST /api/directEditLink", () => {
     });
 
     it("allows claimed artist to edit own profile", async () => {
-        const { POST, requireAuth, getUserById, getArtistById, sendDiscordMessage, getApprovedClaimForArtistByUserId, extractArtistId, setArtistLink } = await setup();
+        const { POST, requireAuth, getUserById, sendDiscordMessage, getApprovedClaimForArtistByUserId, extractArtistId, setArtistLink } = await setup();
         requireAuth.mockResolvedValue({ authenticated: true, session: {}, userId: "u1" });
         getUserById.mockResolvedValue({ id: "u1", username: "claimed-artist", isAdmin: false });
-        getArtistById.mockResolvedValue({ id: "a1", name: "Claimed Artist" });
         getApprovedClaimForArtistByUserId.mockResolvedValue({ id: "c1", artistId: "a1", userId: "u1" });
         extractArtistId.mockResolvedValue({ siteName: "instagram", id: "artist", cardPlatformName: "Instagram" });
-        setArtistLink.mockResolvedValue(undefined);
+        setArtistLink.mockResolvedValue({ oldValue: null, artistName: "Claimed Artist" });
 
         const res = await POST(makeRequest({ artistId: "a1", action: "set", url: "https://instagram.com/artist" }));
         const data = await res.json();
@@ -154,10 +147,9 @@ describe("POST /api/directEditLink", () => {
     });
 
     it("does not notify Discord when setting the link fails", async () => {
-        const { POST, requireAuth, getUserById, getArtistById, sendDiscordMessage, extractArtistId, setArtistLink } = await setup();
+        const { POST, requireAuth, getUserById, sendDiscordMessage, extractArtistId, setArtistLink } = await setup();
         requireAuth.mockResolvedValue({ authenticated: true, session: {}, userId: "u1" });
         getUserById.mockResolvedValue({ id: "u1", username: "admin-user", isAdmin: true });
-        getArtistById.mockResolvedValue({ id: "a1", name: "Test Artist" });
         extractArtistId.mockResolvedValue({ siteName: "x", id: "testuser", cardPlatformName: "X" });
         setArtistLink.mockRejectedValue(new Error("Database write failed"));
 

--- a/src/app/api/directEditLink/__tests__/route.test.ts
+++ b/src/app/api/directEditLink/__tests__/route.test.ts
@@ -5,7 +5,14 @@ jest.mock("@/lib/auth-helpers", () => ({
     requireAuth: jest.fn(),
 }));
 jest.mock("@/server/utils/queries/userQueries", () => ({
+    getUserDisplayName: jest.requireActual("@/server/utils/queries/userQueries").getUserDisplayName,
     getUserById: jest.fn(),
+}));
+jest.mock("@/server/utils/queries/artistQueries", () => ({
+    getArtistById: jest.fn(),
+}));
+jest.mock("@/server/utils/queries/discord", () => ({
+    sendDiscordMessage: jest.fn(),
 }));
 jest.mock("@/server/utils/queries/dashboardQueries", () => ({
     getApprovedClaimForArtistByUserId: jest.fn(),
@@ -34,6 +41,8 @@ describe("POST /api/directEditLink", () => {
     async function setup() {
         const { requireAuth } = await import("@/lib/auth-helpers");
         const { getUserById } = await import("@/server/utils/queries/userQueries");
+        const { getArtistById } = await import("@/server/utils/queries/artistQueries");
+        const { sendDiscordMessage } = await import("@/server/utils/queries/discord");
         const { getApprovedClaimForArtistByUserId } = await import("@/server/utils/queries/dashboardQueries");
         const { setArtistLink, clearArtistLink } = await import("@/server/utils/artistLinkService");
         const { extractArtistId } = await import("@/server/utils/services");
@@ -42,6 +51,8 @@ describe("POST /api/directEditLink", () => {
             POST,
             requireAuth: requireAuth as jest.Mock,
             getUserById: getUserById as jest.Mock,
+            getArtistById: getArtistById as jest.Mock,
+            sendDiscordMessage: sendDiscordMessage as jest.Mock,
             getApprovedClaimForArtistByUserId: getApprovedClaimForArtistByUserId as jest.Mock,
             setArtistLink: setArtistLink as jest.Mock,
             clearArtistLink: clearArtistLink as jest.Mock,
@@ -88,10 +99,11 @@ describe("POST /api/directEditLink", () => {
         expect(res.status).toBe(403);
     });
 
-    it("allows admin to edit any artist", async () => {
-        const { POST, requireAuth, getUserById, extractArtistId, setArtistLink } = await setup();
+    it("allows admin to edit any artist and notifies Discord", async () => {
+        const { POST, requireAuth, getUserById, getArtistById, sendDiscordMessage, extractArtistId, setArtistLink } = await setup();
         requireAuth.mockResolvedValue({ authenticated: true, session: {}, userId: "u1" });
-        getUserById.mockResolvedValue({ id: "u1", isAdmin: true });
+        getUserById.mockResolvedValue({ id: "u1", username: "admin-user", isAdmin: true });
+        getArtistById.mockResolvedValue({ id: "a1", name: "Test Artist" });
         extractArtistId.mockResolvedValue({ siteName: "x", id: "testuser", cardPlatformName: "X" });
         setArtistLink.mockResolvedValue(undefined);
 
@@ -100,12 +112,18 @@ describe("POST /api/directEditLink", () => {
         expect(res.status).toBe(200);
         expect(data.success).toBe(true);
         expect(setArtistLink).toHaveBeenCalledWith("a1", "x", "testuser");
+        expect(sendDiscordMessage).toHaveBeenCalledWith(
+            expect.stringMatching(
+                /^admin-user added Test Artist's X: testuser \(Submitted URL: https:\/\/x\.com\/testuser\) \d{4}-\d{2}-\d{2}T/
+            )
+        );
     });
 
     it("allows claimed artist to edit own profile", async () => {
-        const { POST, requireAuth, getUserById, getApprovedClaimForArtistByUserId, extractArtistId, setArtistLink } = await setup();
+        const { POST, requireAuth, getUserById, getArtistById, sendDiscordMessage, getApprovedClaimForArtistByUserId, extractArtistId, setArtistLink } = await setup();
         requireAuth.mockResolvedValue({ authenticated: true, session: {}, userId: "u1" });
-        getUserById.mockResolvedValue({ id: "u1", isAdmin: false });
+        getUserById.mockResolvedValue({ id: "u1", username: "claimed-artist", isAdmin: false });
+        getArtistById.mockResolvedValue({ id: "a1", name: "Claimed Artist" });
         getApprovedClaimForArtistByUserId.mockResolvedValue({ id: "c1", artistId: "a1", userId: "u1" });
         extractArtistId.mockResolvedValue({ siteName: "instagram", id: "artist", cardPlatformName: "Instagram" });
         setArtistLink.mockResolvedValue(undefined);
@@ -114,10 +132,15 @@ describe("POST /api/directEditLink", () => {
         const data = await res.json();
         expect(res.status).toBe(200);
         expect(data.success).toBe(true);
+        expect(sendDiscordMessage).toHaveBeenCalledWith(
+            expect.stringMatching(
+                /^claimed-artist added Claimed Artist's Instagram: artist \(Submitted URL: https:\/\/instagram\.com\/artist\) \d{4}-\d{2}-\d{2}T/
+            )
+        );
     });
 
     it("clears a link successfully", async () => {
-        const { POST, requireAuth, getUserById, clearArtistLink } = await setup();
+        const { POST, requireAuth, getUserById, sendDiscordMessage, clearArtistLink } = await setup();
         requireAuth.mockResolvedValue({ authenticated: true, session: {}, userId: "u1" });
         getUserById.mockResolvedValue({ id: "u1", isAdmin: true });
         clearArtistLink.mockResolvedValue(undefined);
@@ -127,6 +150,21 @@ describe("POST /api/directEditLink", () => {
         expect(res.status).toBe(200);
         expect(data.success).toBe(true);
         expect(clearArtistLink).toHaveBeenCalledWith("a1", "instagram");
+        expect(sendDiscordMessage).not.toHaveBeenCalled();
+    });
+
+    it("does not notify Discord when setting the link fails", async () => {
+        const { POST, requireAuth, getUserById, getArtistById, sendDiscordMessage, extractArtistId, setArtistLink } = await setup();
+        requireAuth.mockResolvedValue({ authenticated: true, session: {}, userId: "u1" });
+        getUserById.mockResolvedValue({ id: "u1", username: "admin-user", isAdmin: true });
+        getArtistById.mockResolvedValue({ id: "a1", name: "Test Artist" });
+        extractArtistId.mockResolvedValue({ siteName: "x", id: "testuser", cardPlatformName: "X" });
+        setArtistLink.mockRejectedValue(new Error("Database write failed"));
+
+        const res = await POST(makeRequest({ artistId: "a1", action: "set", url: "https://x.com/testuser" }));
+
+        expect(res.status).toBe(500);
+        expect(sendDiscordMessage).not.toHaveBeenCalled();
     });
 
     it("returns 400 when url missing for set action", async () => {

--- a/src/app/api/directEditLink/route.ts
+++ b/src/app/api/directEditLink/route.ts
@@ -2,7 +2,6 @@ import { requireAuth } from "@/lib/auth-helpers";
 import { canEditArtist } from "@/server/utils/artistEditAuth";
 import { notifyDiscordOfArtistLinkAdded } from "@/server/utils/artistLinkDiscordNotifier";
 import { setArtistLink, clearArtistLink } from "@/server/utils/artistLinkService";
-import { getArtistById } from "@/server/utils/queries/artistQueries";
 import { getUserById } from "@/server/utils/queries/userQueries";
 import { extractArtistId } from "@/server/utils/services";
 import { LINK_NOT_SUPPORTED_LONG } from "@/lib/linkSubmissionMessages";
@@ -40,14 +39,11 @@ export async function POST(req: Request) {
                 return Response.json({ error: LINK_NOT_SUPPORTED_LONG }, { status: 400 });
             }
 
-            const [user, artist] = await Promise.all([
-                getUserById(authResult.userId),
-                getArtistById(artistId),
-            ]);
-            await setArtistLink(artistId, extracted.siteName, extracted.id);
+            const user = await getUserById(authResult.userId);
+            const { artistName } = await setArtistLink(artistId, extracted.siteName, extracted.id);
             await notifyDiscordOfArtistLinkAdded({
                 user: user ?? {},
-                artistName: artist?.name ?? artistId,
+                artistName: artistName ?? artistId,
                 platformName: extracted.cardPlatformName ?? extracted.siteName,
                 platformId: extracted.id,
                 submittedUrl: url,

--- a/src/app/api/directEditLink/route.ts
+++ b/src/app/api/directEditLink/route.ts
@@ -1,6 +1,9 @@
 import { requireAuth } from "@/lib/auth-helpers";
 import { canEditArtist } from "@/server/utils/artistEditAuth";
+import { notifyDiscordOfArtistLinkAdded } from "@/server/utils/artistLinkDiscordNotifier";
 import { setArtistLink, clearArtistLink } from "@/server/utils/artistLinkService";
+import { getArtistById } from "@/server/utils/queries/artistQueries";
+import { getUserById } from "@/server/utils/queries/userQueries";
 import { extractArtistId } from "@/server/utils/services";
 import { LINK_NOT_SUPPORTED_LONG } from "@/lib/linkSubmissionMessages";
 
@@ -37,7 +40,18 @@ export async function POST(req: Request) {
                 return Response.json({ error: LINK_NOT_SUPPORTED_LONG }, { status: 400 });
             }
 
+            const [user, artist] = await Promise.all([
+                getUserById(authResult.userId),
+                getArtistById(artistId),
+            ]);
             await setArtistLink(artistId, extracted.siteName, extracted.id);
+            await notifyDiscordOfArtistLinkAdded({
+                user: user ?? {},
+                artistName: artist?.name ?? artistId,
+                platformName: extracted.cardPlatformName ?? extracted.siteName,
+                platformId: extracted.id,
+                submittedUrl: url,
+            });
             return Response.json({ success: true, siteName: extracted.siteName, platformName: extracted.cardPlatformName });
         }
 

--- a/src/server/utils/__tests__/artistLinkService.test.ts
+++ b/src/server/utils/__tests__/artistLinkService.test.ts
@@ -15,7 +15,7 @@ describe("artistLinkService", () => {
     const { db } = await import("@/server/db/drizzle");
     db.execute = jest.fn().mockResolvedValue([]);
     // Mock artist existence check - return a found artist by default
-    (db as any).query.artists.findFirst = jest.fn().mockResolvedValue({ id: "artist-123" });
+    (db as any).query.artists.findFirst = jest.fn().mockResolvedValue({ id: "artist-123", name: "Test Artist" });
     const { regenerateArtistBio } = await import("@/server/utils/queries/artistBioQuery");
     const { setArtistLink, clearArtistLink, sanitizeColumnName, BIO_RELEVANT_COLUMNS } = await import("../artistLinkService");
     return { db, setArtistLink, clearArtistLink, sanitizeColumnName, BIO_RELEVANT_COLUMNS, regenerateArtistBio };
@@ -34,12 +34,12 @@ describe("artistLinkService", () => {
     expect(sanitizeColumnName("youtube_channel")).toBe("youtube_channel");
   });
 
-  // 3. setArtistLink sets a generic text column and returns oldValue
+  // 3. setArtistLink sets a generic text column and returns artist context
   it("setArtistLink sets a generic text column via sql.identifier", async () => {
     const { db, setArtistLink } = await setup();
     const result = await setArtistLink("artist-123", "instagram", "testuser");
     expect(db.execute).toHaveBeenCalled();
-    expect(result).toEqual({ oldValue: null });
+    expect(result).toEqual({ oldValue: null, artistName: "Test Artist" });
   });
 
   // 4. setArtistLink sets ens directly
@@ -48,7 +48,7 @@ describe("artistLinkService", () => {
     const result = await setArtistLink("artist-123", "ens", "vitalik.eth");
     expect(db.execute).toHaveBeenCalledTimes(1);
     expect(regenerateArtistBio).not.toHaveBeenCalled();
-    expect(result).toEqual({ oldValue: null });
+    expect(result).toEqual({ oldValue: null, artistName: "Test Artist" });
   });
 
   // 5. setArtistLink triggers bio regen for prompt-relevant column
@@ -146,9 +146,9 @@ describe("artistLinkService", () => {
   // 18. setArtistLink returns old value when column has existing data
   it("setArtistLink returns old value when overwriting", async () => {
     const { db, setArtistLink } = await setup();
-    (db as any).query.artists.findFirst.mockResolvedValue({ id: "artist-123", instagram: "old-user" });
+    (db as any).query.artists.findFirst.mockResolvedValue({ id: "artist-123", name: "Test Artist", instagram: "old-user" });
     const result = await setArtistLink("artist-123", "instagram", "new-user");
-    expect(result).toEqual({ oldValue: "old-user" });
+    expect(result).toEqual({ oldValue: "old-user", artistName: "Test Artist" });
   });
 
   // 19. clearArtistLink returns old value when column has existing data

--- a/src/server/utils/artistLinkDiscordNotifier.ts
+++ b/src/server/utils/artistLinkDiscordNotifier.ts
@@ -1,0 +1,26 @@
+import { sendDiscordMessage } from "@/server/utils/queries/discord";
+import { getUserDisplayName } from "@/server/utils/queries/userQueries";
+
+type DiscordUser = Parameters<typeof getUserDisplayName>[0];
+
+type ArtistLinkAddedNotification = {
+    user: DiscordUser;
+    artistName: string;
+    platformName: string;
+    platformId: string;
+    submittedUrl: string;
+    createdAt?: string;
+};
+
+export async function notifyDiscordOfArtistLinkAdded({
+    user,
+    artistName,
+    platformName,
+    platformId,
+    submittedUrl,
+    createdAt = new Date().toISOString(),
+}: ArtistLinkAddedNotification) {
+    await sendDiscordMessage(
+        `${getUserDisplayName(user)} added ${artistName}'s ${platformName}: ${platformId} (Submitted URL: ${submittedUrl}) ${createdAt}`
+    );
+}

--- a/src/server/utils/artistLinkService.ts
+++ b/src/server/utils/artistLinkService.ts
@@ -43,7 +43,7 @@ export async function setArtistLink(
   artistId: string,
   siteName: string,
   value: string
-): Promise<{ oldValue: string | null }> {
+): Promise<{ oldValue: string | null; artistName: string | null }> {
   const columnName = sanitizeColumnName(siteName);
   assertWritable(columnName);
 
@@ -70,7 +70,7 @@ export async function setArtistLink(
     await db.execute(sql`UPDATE artists SET ${sql.identifier(columnName)} = ${value} WHERE id = ${artistId}`);
   }
 
-  return { oldValue };
+  return { oldValue, artistName: artist.name ?? null };
 }
 
 export async function clearArtistLink(

--- a/src/server/utils/queries/artistQueries.ts
+++ b/src/server/utils/queries/artistQueries.ts
@@ -13,6 +13,7 @@ import { headers } from "next/headers";
 import { getUserById, getUserDisplayName } from "@/server/utils/queries/userQueries";
 import { sendDiscordMessage } from "@/server/utils/queries/discord";
 import { maybePingDiscordForPendingUGC } from "@/server/utils/ugcDiscordNotifier";
+import { notifyDiscordOfArtistLinkAdded } from "@/server/utils/artistLinkDiscordNotifier";
 import { setArtistLink, clearArtistLink } from "@/server/utils/artistLinkService";
 import { regenerateArtistBio } from "@/server/utils/queries/artistBioQuery";
 import { LINK_NOT_SUPPORTED_LONG } from "@/lib/linkSubmissionMessages";
@@ -537,9 +538,14 @@ export async function addArtistData(artistUrl: string, artist: Artist): Promise<
         }
 
         if (user) {
-            await sendDiscordMessage(
-                `${getUserDisplayName(user)} added ${artist.name}'s ${artistIdFromUrl.cardPlatformName}: ${artistIdFromUrl.id} (Submitted URL: ${artistUrl}) ${newUGC.createdAt}`
-            );
+            await notifyDiscordOfArtistLinkAdded({
+                user,
+                artistName: artist.name ?? artist.id,
+                platformName: artistIdFromUrl.cardPlatformName ?? artistIdFromUrl.siteName,
+                platformId: artistIdFromUrl.id,
+                submittedUrl: artistUrl,
+                createdAt: newUGC.createdAt ?? undefined,
+            });
         }
 
         return {


### PR DESCRIPTION
## Summary

- Centralizes artist social-link Discord message formatting in a shared server notifier.
- Sends the same notification for successful direct edits made by admins and approved claimed artists.
- Keeps link removals and failed writes silent.
- Adds regression coverage for both authorized roles and negative paths.

## Test Coverage

Test Coverage Audit: 10 of 11 changed paths covered (91%). One regression test was added to the existing route suite.

Tests: 152 test files before, 152 after (+0 files, +1 test case).

## Pre-Landing Review

No issues found.

## Design Review

No frontend files changed. Design review skipped.

## Eval Results

No prompt-related files changed. Evals skipped.

## Scope Drift

Scope Check: CLEAN

## Plan Completion

No plan file detected.

## Verification Results

- 109 Jest suites passed
- 1,079 tests passed, 6 skipped
- TypeScript type check passed
- ESLint passed with existing warnings only
- Next.js production build passed

## Test plan

- [x] Admin direct link additions notify Discord
- [x] Approved claimed-artist direct link additions notify Discord
- [x] Failed writes do not notify Discord
- [x] Link removals do not emit addition notifications
- [x] Existing regular UGC notification behavior remains covered

Generated with OpenAI Codex.
