### PR TITLE
fix: suppress no-op artist link notifications

### DIFF
--- a/src/app/api/directEditLink/__tests__/route.test.ts
+++ b/src/app/api/directEditLink/__tests__/route.test.ts
@@ -132,6 +132,19 @@ describe("POST /api/directEditLink", () => {
         );
     });
 
+    it("does not notify Discord when the link value is unchanged", async () => {
+        const { POST, requireAuth, getUserById, sendDiscordMessage, extractArtistId, setArtistLink } = await setup();
+        requireAuth.mockResolvedValue({ authenticated: true, session: {}, userId: "u1" });
+        getUserById.mockResolvedValue({ id: "u1", username: "admin-user", isAdmin: true });
+        extractArtistId.mockResolvedValue({ siteName: "x", id: "testuser", cardPlatformName: "X" });
+        setArtistLink.mockResolvedValue({ oldValue: "testuser", artistName: "Test Artist" });
+
+        const res = await POST(makeRequest({ artistId: "a1", action: "set", url: "https://x.com/testuser" }));
+
+        expect(res.status).toBe(200);
+        expect(sendDiscordMessage).not.toHaveBeenCalled();
+    });
+
     it("clears a link successfully", async () => {
         const { POST, requireAuth, getUserById, sendDiscordMessage, clearArtistLink } = await setup();
         requireAuth.mockResolvedValue({ authenticated: true, session: {}, userId: "u1" });

--- a/src/app/api/directEditLink/route.ts
+++ b/src/app/api/directEditLink/route.ts
@@ -40,14 +40,16 @@ export async function POST(req: Request) {
             }
 
             const user = await getUserById(authResult.userId);
-            const { artistName } = await setArtistLink(artistId, extracted.siteName, extracted.id);
-            await notifyDiscordOfArtistLinkAdded({
-                user: user ?? {},
-                artistName: artistName ?? artistId,
-                platformName: extracted.cardPlatformName ?? extracted.siteName,
-                platformId: extracted.id,
-                submittedUrl: url,
-            });
+            const { oldValue, artistName } = await setArtistLink(artistId, extracted.siteName, extracted.id);
+            if (oldValue !== extracted.id) {
+                await notifyDiscordOfArtistLinkAdded({
+                    user: user ?? {},
+                    artistName: artistName ?? artistId,
+                    platformName: extracted.cardPlatformName ?? extracted.siteName,
+                    platformId: extracted.id,
+                    submittedUrl: url,
+                });
+            }
             return Response.json({ success: true, siteName: extracted.siteName, platformName: extracted.cardPlatformName });
         }
 

--- a/src/server/utils/__tests__/artistLinkService.test.ts
+++ b/src/server/utils/__tests__/artistLinkService.test.ts
@@ -151,7 +151,23 @@ describe("artistLinkService", () => {
     expect(result).toEqual({ oldValue: "old-user", artistName: "Test Artist" });
   });
 
-  // 19. clearArtistLink returns old value when column has existing data
+  // 19. setArtistLink reads the aliased facebookID property
+  it("setArtistLink returns the old value for facebookID", async () => {
+    const { db, setArtistLink } = await setup();
+    (db as any).query.artists.findFirst.mockResolvedValue({ id: "artist-123", name: "Test Artist", facebookId: "old-facebook-id" });
+    const result = await setArtistLink("artist-123", "facebookID", "old-facebook-id");
+    expect(result).toEqual({ oldValue: "old-facebook-id", artistName: "Test Artist" });
+  });
+
+  // 20. setArtistLink reads the aliased tiktokID property
+  it("setArtistLink returns the old value for tiktokID", async () => {
+    const { db, setArtistLink } = await setup();
+    (db as any).query.artists.findFirst.mockResolvedValue({ id: "artist-123", name: "Test Artist", tiktokId: "old-tiktok-id" });
+    const result = await setArtistLink("artist-123", "tiktokID", "old-tiktok-id");
+    expect(result).toEqual({ oldValue: "old-tiktok-id", artistName: "Test Artist" });
+  });
+
+  // 21. clearArtistLink returns old value when column has existing data
   it("clearArtistLink returns old value when clearing", async () => {
     const { db, clearArtistLink } = await setup();
     (db as any).query.artists.findFirst.mockResolvedValue({ id: "artist-123", x: "old-handle" });

--- a/src/server/utils/artistLinkService.ts
+++ b/src/server/utils/artistLinkService.ts
@@ -23,6 +23,12 @@ const WRITABLE_LINK_COLUMNS = new Set([
   "supercollector", "ens",
 ]);
 
+// Drizzle row properties can differ from the physical column names used in SQL.
+const ARTIST_ROW_PROPERTY_BY_COLUMN: Record<string, string> = {
+  facebookID: "facebookId",
+  tiktokID: "tiktokId",
+};
+
 export function sanitizeColumnName(siteName: string): string {
   return siteName.replace(/[^a-zA-Z0-9_]/g, "");
 }
@@ -37,6 +43,11 @@ function assertWritable(columnName: string): void {
   if (!WRITABLE_LINK_COLUMNS.has(columnName)) {
     throw new Error(`Column not in writable whitelist: ${columnName}`);
   }
+}
+
+function getArtistLinkValue(artist: object, columnName: string): string | null {
+  const propertyName = ARTIST_ROW_PROPERTY_BY_COLUMN[columnName] ?? columnName;
+  return ((artist as Record<string, unknown>)[propertyName] as string | null | undefined) ?? null;
 }
 
 export async function setArtistLink(
@@ -60,7 +71,7 @@ export async function setArtistLink(
   }
 
   // Safe: assertWritable() above guarantees columnName is a known text column from the whitelist
-  const oldValue = (artist as Record<string, unknown>)[columnName] as string | null ?? null;
+  const oldValue = getArtistLinkValue(artist, columnName);
 
   // For bio-relevant columns, set value and null bio in a single statement
   if (BIO_RELEVANT_COLUMNS.includes(columnName)) {
@@ -89,7 +100,7 @@ export async function clearArtistLink(
   }
 
   // Safe: assertWritable() above guarantees columnName is a known text column from the whitelist
-  const oldValue = (artist as Record<string, unknown>)[columnName] as string | null ?? null;
+  const oldValue = getArtistLinkValue(artist, columnName);
 
   if (BIO_RELEVANT_COLUMNS.includes(columnName)) {
     await db.execute(sql`UPDATE artists SET ${sql.identifier(columnName)} = NULL, bio = NULL WHERE id = ${artistId}`);


### PR DESCRIPTION
## Summary

- suppress Discord notifications when a direct artist-link save does not change the stored value
- preserve the successful API response for no-op saves
- add regression coverage for the no-op path

Addresses the Codex P2 finding on #1130: https://github.com/xdjs/MusicNerdWeb/pull/1130#discussion_r3555364910

## Verification

- 109 Jest suites passed
- 1,080 tests passed, 6 skipped
- TypeScript type check passed
- ESLint passed with existing warnings only
- Next.js production build passed
