### PR TITLE
docs: DESIGN.md source of truth + design-sync preview bundle

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,475 @@
+# MusicNerdWeb — Design System (DESIGN.md)
+
+## Purpose & how to use this doc
+
+This file is the **north star** for MusicNerdWeb's visual and interaction design. It is the single source of truth for color, typography, layout, components, and motion.
+
+Two rules for using it:
+
+1. **It documents what EXISTS today**, grounded in the actual code — not an aspirational redesign. Where a value is a stock shadcn/Tailwind default that was never rebranded, this doc **flags it as stock** so it can be changed *on purpose* rather than by accident.
+2. **When proposing any UI change, state it against this system.** Say which token/utility/component you are touching, whether you are following an existing convention or introducing a new one, and — if you are diverging — why. Prefer editing tokens over adding one-off hex literals.
+
+A companion section, [Known inconsistencies to reconcile](#known-inconsistencies-to-reconcile), catalogs where the current implementation contradicts itself. Treat that table as the backlog of design-debt decisions: each row is a place where a human should pick one source of truth.
+
+> **The single most important fact about this codebase:** the brand identity (candy-neon pink/blue/green over frosted glass) is applied *on top of* an **unmodified shadcn "slate" token layer**, almost entirely through hardcoded hex literals and a ~330-line wall of `!important` dark-mode overrides — not through the semantic token system. `--primary` is navy slate; the brand's pink lives outside the tokens as three different hex values. Nearly every inconsistency below traces back to this.
+
+---
+
+## Design philosophy
+
+MusicNerd is a **playful, indie, candy-neon music directory dressed in Apple-style frosted glass.** The personality lives in a handful of electric accent colors — a hot orchid pink, a bright cyan, and a jelly mint-green — set against a light-forward, rounded, glassmorphic surface language, with a lowercase-casual voice ("music nerd", "Made in Seattle by @cxy @clt and friends"). Underneath, the structural chrome (buttons, cards, inputs, semantic tokens) is stock shadcn slate — brand character is layered on top as ad-hoc hex accents and glass utilities.
+
+**Signature visual moves:**
+
+- **The neon accent trio** — `pastyblue #2ad4fc`, `pastypink #ef95ff`, `jellygreen #19ffb8`. The whimsical names ("pasty", "jelly") are themselves a voice cue. `maroon #422b46` is the deep-aubergine "ink" for footer/body text.
+- **The glowing hot-pink wordmark** — the homepage renders only a giant lowercase `music nerd` in `#ff9ce3` with a pink `textShadow` glow, fluid-sized `clamp(32px → 84px)` with tight negative letter-spacing.
+- **Apple-style glassmorphism panels** — `.glass` (translucent white + `backdrop-filter: blur(20px) saturate(180%)`) is the primary surface across 13+ artist-page components and admin. Even the scrollbar is themed to match.
+- **Ambient, calm motion** — logo spins on hover, a pulsing "Live" ping dot, staggered 30ms feed fade-ins, framer-motion scroll parallax on the artist hero. Slow (3–20s), eased, never frantic.
+- **Round everything** — circular avatars, pill indicators, `rounded-lg`/`rounded-2xl` surfaces, a pink placeholder avatar.
+- **The light→dark accent swap** — dark mode deliberately shifts the accent from **pink → cyan/green** (checked checkboxes `#ff9ce3` → `#2ad4fc`; feed live dot emerald → jellygreen). The pink wordmark is the one element forced to stay pink in both modes.
+
+**Design principles (inferred from the actual UI):**
+
+1. **Neon accents, quiet chrome.** Deploy pastypink/pastyblue/jellygreen as punctuation on top of neutral slate surfaces — never as full backgrounds or large fills.
+2. **Glass is the surface language.** Prefer `.glass` / `.glass-subtle` for panels; keep radii generous (0.75–2rem) and edges soft.
+3. **Round everything.** Circular avatars, pill indicators, rounded cards/buttons; avoid hard corners.
+4. **Motion should feel alive but calm.** Spinning logo, live ping, staggered fades, scroll parallax — slow, eased, ambient.
+5. **Pink is the identity in light; cyan/green take over in dark.** Honor the light→dark accent swap already coded into checkboxes and the live feed.
+6. **Lowercase, friendly, personal voice.** Short, casual, a little self-aware; credit real humans ("Made in Seattle by @cxy @clt and friends"); no corporate polish. Dev humor leaks through (a loading spinner's alt text is literally `alt="whyyyyy"`).
+7. **Big, fluid, tightly-tracked display type.** Use `clamp()` fluid sizing with negative letter-spacing for hero headlines — the `music nerd` wordmark is the template.
+
+**What to avoid (to stay on-brand):**
+
+- Don't introduce a **fourth pink or a new blue.** Three pinks already exist; consolidate toward named tokens instead of inventing more hex.
+- Don't make accent colors **load-bearing backgrounds** or large fills — neon-on-neon breaks the "quiet chrome" balance.
+- Don't ship **opaque, hard-edged, flat cards** where a glass panel is expected.
+- Don't rely on the **KoHo** class names expecting that typeface — KoHo never loads in the app; those classes render as system sans-serif.
+- Don't add more **`!important` dark-mode patch overrides** — the override wall is already brittle. Prefer theming via CSS-variable tokens.
+- Don't force **serious/corporate copy, ALL-CAPS shouting, or sharp geometric/brutalist styling** — it contradicts the lowercase, playful, glassy, indie personality.
+
+---
+
+## Color
+
+MusicNerdWeb's color system is **three disconnected layers that never reconcile**: a 4-color brand palette in `tailwind.config.ts`, a stock untouched shadcn "slate" semantic-token layer in `globals.css`, and a dead SCSS file (`_colors.scss`) that redefines the brand under different names and is imported nowhere. The visual identity is applied almost entirely through hardcoded hex literals (200+ occurrences) and `!important` dark-mode overrides — **not** through tokens. The brand pink alone exists as **three different hex values**.
+
+### 1. Brand palette — `tailwind.config.ts` (lines 26–29)
+
+Plain Tailwind color extensions. **Not** wired into the semantic `--primary`/`--accent` tokens.
+
+| Token (Tailwind class) | Value | Direct uses in `src/` | Notes |
+|---|---|---|---|
+| `maroon` | `#422b46` | 1 | Footer text (`.text-maroon`), forced white in dark mode |
+| `pastyblue` | `#2ad4fc` | 1 | Also hardcoded for dark checkbox + moon icon |
+| `pastypink` | `#ef95ff` | 93 | Most-used brand token; also the hero gradient pink |
+| `jellygreen` | `#19ffb8` | (via raw hex) | Appears mainly as raw hex in ActivityFeed |
+
+### 2. Semantic HSL tokens — `globals.css` `:root` / `.dark` (lines 35–90)
+
+**These are verbatim stock shadcn/ui "slate" defaults** (navy `222.2 47.4% 11.2%` primary, `210 40% 96.1%` secondary, `0 84.2% 60.2%` destructive). **None carry the brand's pink/blue/green** — the semantic layer was scaffolded from shadcn and never rebranded. Consumed as `hsl(var(--token))` via `tailwind.config.ts` (lines 30–62).
+
+| Token | Light (`:root`) | Dark (`.dark`) |
+|---|---|---|
+| `--background` | `0 0% 100%` | `222.2 84% 4.9%` |
+| `--foreground` | `222.2 84% 4.9%` | `210 40% 98%` |
+| `--card` | `0 0% 100%` | `222.2 84% 4.9%` |
+| `--card-foreground` | `222.2 84% 4.9%` | `210 40% 98%` |
+| `--popover` | `0 0% 100%` | `222.2 84% 4.9%` |
+| `--popover-foreground` | `222.2 84% 4.9%` | `210 40% 98%` |
+| `--primary` | `222.2 47.4% 11.2%` | `210 40% 98%` |
+| `--primary-foreground` | `210 40% 98%` | `222.2 47.4% 11.2%` |
+| `--secondary` | `210 40% 96.1%` | `217.2 32.6% 17.5%` |
+| `--secondary-foreground` | `222.2 47.4% 11.2%` | `210 40% 98%` |
+| `--muted` | `210 40% 96.1%` | `217.2 32.6% 17.5%` |
+| `--muted-foreground` | `215.4 16.3% 46.9%` | `215 20.2% 65.1%` |
+| `--accent` | `210 40% 96.1%` | `217.2 32.6% 17.5%` |
+| `--accent-foreground` | `222.2 47.4% 11.2%` | `210 40% 98%` |
+| `--destructive` | `0 84.2% 60.2%` | `0 62.8% 30.6%` |
+| `--destructive-foreground` | `210 40% 98%` | `210 40% 98%` |
+| `--border` | `214.3 31.8% 91.4%` | `217.2 32.6% 17.5%` |
+| `--input` | `214.3 31.8% 91.4%` | `217.2 32.6% 17.5%` |
+| `--ring` | `222.2 84% 4.9%` | `212.7 26.8% 83.9%` |
+| `--radius` | `0.5rem` | (same) |
+
+**Chart colors** (`--chart-1..5`) are **also stock shadcn defaults**:
+
+| | Light | Dark |
+|---|---|---|
+| `--chart-1` | `12 76% 61%` | `220 70% 50%` |
+| `--chart-2` | `173 58% 39%` | `160 60% 45%` |
+| `--chart-3` | `197 37% 24%` | `30 80% 55%` |
+| `--chart-4` | `43 74% 66%` | `280 65% 60%` |
+| `--chart-5` | `27 87% 67%` | `340 75% 55%` |
+
+**Custom token** — `--subtitle-color` (line 61 / 89):
+
+| | Light | Dark |
+|---|---|---|
+| `--subtitle-color` | `rgb(89, 48, 97, 0.6)` | `rgb(198, 191, 199)` |
+
+Note: the light value uses the malformed legacy 4-arg `rgb(r,g,b,a)` syntax (should be `rgba()`); the dark value drops alpha entirely.
+
+### 3. SCSS layer — `src/app/_colors.scss` (DEAD / unimported)
+
+`grep` confirms this file is **imported nowhere**. It redefines the brand under a *second* naming scheme and defines `.text-color-primary { color: $primary }` (`#2ad4fc`), which collides by name with a live definition in `globals.css`.
+
+| SCSS var | Value | Duplicates |
+|---|---|---|
+| `$primary` | `#2ad4fc` | `pastyblue` |
+| `$secondary` | `#ef95ff` | `pastypink` |
+| `$tertiary` | `#19ffb8` | `jellygreen` |
+| `$grey` | `rgb(184, 182, 182)` | — |
+| `$purple` | `rgb(25, 0, 50)` | — |
+| `$lightpurple` | `rgb(100, 0, 200)` | — |
+
+### 4. The "real" brand pink is fragmented into 3 hex values
+
+The pink actually seen on screen (splash title, highlighted leaderboard rows, checked checkboxes in light mode, focus rings) is **`#ff9ce3`** — 57 occurrences — **defined nowhere in the palette**, and different from `pastypink` `#ef95ff`. A third pink `#EDADF8` powers `.text-color-primary` and `.pink-btn`.
+
+| Pink | Where | Source |
+|---|---|---|
+| `#ef95ff` | `pastypink` / `$secondary` / HeroSection gradient | `tailwind.config.ts:28`, `_colors.scss:2` |
+| `#ff9ce3` | "Music Nerd" title, highlight borders/glows, light checked checkbox, focus rings, ActivityFeed `--feed-artist` | 57 hardcoded uses; `globals.css:168–277`, `485–488` |
+| `#EDADF8` | `.text-color-primary`, `.pink-btn` background | `globals.css:516`, `585` |
+
+### Gradients
+
+| Gradient | Definition | File |
+|---|---|---|
+| Hero brand wash | `bg-gradient-to-br from-[#ef95ff]/20 via-transparent to-[#7c3aed]/15` | `artist/[id]/_components/HeroSection.tsx:79` |
+| Hero dark overlay | `bg-gradient-to-b from-black/20 to-black/50` | `HeroSection.tsx:82` |
+| Press thumb fallback | `bg-gradient-to-br from-pastypink/10 via-purple-900/20 to-transparent` | `PressAndFeatures.tsx:68` |
+
+Note the hero uses raw hex (`#7c3aed` violet-600, `#ef95ff`) while the press thumb uses the `pastypink` token + Tailwind `purple-900` — two vocabularies for the same "pink→purple" wash.
+
+### Glass / glassmorphism — `globals.css`
+
+The "Apple-style glass" look is built from **white-alpha layers, not tokens**:
+
+| Utility | Light | Dark |
+|---|---|---|
+| `.glass` | `bg rgba(255,255,255,0.55)`; `blur(20px) saturate(180%)`; border `1px rgba(255,255,255,0.3)`; radius `1rem` | `bg rgba(30,30,30,0.55)`; border `1px rgba(255,255,255,0.08)` |
+| `.glass-subtle` | `bg rgba(255,255,255,0.35)`; `blur(12px) saturate(150%)`; border `1px rgba(255,255,255,0.25)`; radius `0.75rem` | `bg rgba(40,40,40,0.4)`; border `1px rgba(255,255,255,0.06)` |
+| `.scrollbar-glass` | thumb `rgba(255,255,255,0.18)`, hover `0.32`, track transparent, 6px | (same) |
+
+### Ad-hoc palettes hidden in overrides (not tokenized)
+
+- **Dead duplicate `:root` block (create-next-app leftover)** — `globals.css:519–528` defines a *second* `:root` with `--foreground-rgb: 0,0,0`, `--background-start-rgb: 214,219,220`, `--background-end-rgb: 255,255,255`, plus a bare `body { color: rgb(var(--foreground-rgb)); background: white }` and `.dark body { background: #1a1a1a }`. This hardcoded body background **overrides** the token-driven `@apply bg-background text-foreground` set earlier — an unmentioned dead/duplicate token layer and a direct token-vs-hardcode inconsistency.
+- **Dark-mode neutral ramp** — Tailwind slate values hardcoded as hex rather than driven by `--background`/`--muted` (lines 112–532): `#1a1a1a` (dark body), `#2d3748` (panels/search), `#4a5568` (hover/border), `#f7fafc` (near-white text), `#a0aec0` (muted text), `#374151` (borders).
+- **Leaderboard / UGC "mauve" family** — a purple-grey micro-palette used only through `!important` overrides (lines 132–304): `#9b83a0`, `#c6bfc7`, `#6f4b75`, `#b8b1b9`, `#a08ba8`, `rgb(89,48,97,0.6)`, `rgb(198,191,199)`, `rgb(111,75,117,0.8)`. `rgb(89,48,97,0.6)` is the same value as light `--subtitle-color` but re-typed as a literal everywhere.
+- **ActivityFeed** (`ActivityFeed.tsx:69–115`) defines its **own parallel token system** via injected `--feed-*` custom properties with light/dark variants — reusing brand hex (`#ff9ce3`, `#19ffb8`, `#2ad4fc`) plus one-offs `#5a4d5e`, `#3d2f42`, `#9b8a9f`, `#059669` (emerald), `#0891b2` (cyan-600), `#c44a8c`, `#e0d8e2`. This is the best-structured light/dark token set in the app and is a good candidate for promotion into the shared layer.
+
+### Interactive accents
+
+- **Checkbox checked:** light `#ff9ce3`, dark `#2ad4fc`; checkmark forced `white`.
+- **Theme-toggle moon icon (dark):** `#2ad4fc`.
+- **Notification dot:** `bg-red-600` with a forced 2px white border in dark. (The 6 `#FF0000` hits in the tree are test-fixture `colorHex` mock values in `src/__tests__/components/ArtistLinks.test.tsx`, not UI colors — there are zero `#ff0000` literals in shipping app code.)
+- **Highlight glow:** `box-shadow 0 0 20px rgba(255,156,227,0.3)` (`#ff9ce3` at 0.3), forced via `!important`.
+
+### Theme mechanism
+
+Dark mode is **class-based** (`darkMode: 'class'`) driven by a **custom `ThemeProvider`** (`_components/ThemeProvider.tsx`) — **not `next-themes`**, despite next-themes being the documented convention. It toggles `.light`/`.dark` on `<html>`, persists to `localStorage` key `musicnerd-theme`, and falls back to `prefers-color-scheme`. Because most of dark mode is expressed as `!important` overrides of hardcoded light values rather than swapped token values, the `.dark` block runs ~330 lines.
+
+---
+
+## Typography
+
+### The headline finding: the brand typeface never loads in the app
+
+The intended brand font is **KoHo** (Google font), but **it is not loaded anywhere in the Next.js app.** There is no `next/font` import in `src/`, no `<link>` font tag in `layout.tsx`, no `@font-face`/`@import` in `globals.css`, no font package in `package.json`, and no `fontFamily` key in `tailwind.config.ts`.
+
+`globals.css` *declares* `font-family: "KoHo", sans-serif` in three places — `.koho-extralight` (weight 200), `.koho-light` (weight 300), and `.pink-btn` — but because KoHo never loads, **each silently falls back to `sans-serif`**. `.pink-btn` is a shipping class (the "Log In" button), so the login button renders in system sans-serif, not KoHo.
+
+**Net effect:** the entire app renders in Tailwind's default `font-sans` stack (`ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, …`). No `font-family` is set on `body`. Stock Tailwind behavior, no customization — an unintended gap between design intent (KoHo) and reality (system font). **Assume the app font is the default sans stack.**
+
+KoHo *does* load correctly, but only in two standalone static files outside the React app — `public/tmprivacy.html` and `public/mnidprivacy.html` (Google Fonts `<link>`, weights 200–700, their own inline `koho` Tailwind family). The declared brand stack is therefore **`"KoHo", sans-serif`** with weights **200, 300, 400, 500, 600, 700** — but it only manifests on the legal pages.
+
+### Type scale — stock Tailwind defaults, no custom scale
+
+There is **no custom `fontSize` scale**; every `text-*` resolves to Tailwind built-ins. Actual usage across `src/`:
+
+| Tailwind class | Size / line-height | Uses | Role |
+|---|---|---|---|
+| `text-xs` | 12px / 16px | 108 | Badges, captions, metadata, timestamps |
+| `text-sm` | 14px / 20px | 138 | **De-facto body/UI size** — table body, card descriptions, buttons |
+| `text-base` | 16px / 24px | 22 | `Input` default |
+| `text-lg` | 18px / 28px | 40 | Sub-headings |
+| `text-xl` | 20px / 28px | 22 | Section headings |
+| `text-2xl` | 24px / 32px | 14 | `CardTitle`, artist name |
+| `text-3xl` | 30px / 36px | 5 | Page H1s ("Admin Dashboard", "User Profile") |
+| `text-4xl` | 36px / 40px | 1 | `.artist-name` utility only (`globals.css:696`, `text-4xl text-purple-500`) |
+
+No `text-5xl`+ anywhere. Root size is browser default 16px (never overridden).
+
+### Weights
+
+Four Tailwind weight utilities appear; the app maps to a narrow band:
+
+| Class | Uses | Role |
+|---|---|---|
+| `font-semibold` (600) | 62 | Dominant emphasis/heading weight (card titles, badges, table headers) |
+| `font-medium` (500) | 41 | Buttons (`text-sm font-medium`), labels |
+| `font-bold` (700) | 33 | Page H1s (`text-3xl font-bold`) |
+| `font-normal` (400) | 8 | Occasional body reset |
+
+The two light weights the brand cares about — **200 (`.koho-extralight`) and 300 (`.koho-light`)** — are defined but never render (KoHo isn't loaded; the classes aren't applied by any component).
+
+### Letter-spacing & line-height
+
+Sparse, mostly on the shadcn `CardTitle` and a few headings: `leading-none` ×11, `leading-tight` ×9, `leading-relaxed` ×6, `leading-snug` ×2; `tracking-tight` ×3, `tracking-wide` ×2, `tracking-wider` ×1, `tracking-widest` ×1. Canonical pattern (stock shadcn): `CardTitle = text-2xl font-semibold leading-none tracking-tight`.
+
+### The real display type — two hand-rolled fluid clamp headings
+
+The only genuinely designed (non-default) type on the site is two fluid headings, both interpolated across a **360px → 1440px** viewport window:
+
+1. **Homepage "music nerd" title** — `HomePageSplash.tsx`, inline-styled (the largest type on the site):
+   - `font-size: clamp(32px, calc(32px + (84 - 32) * ((100vw - 360px) / (1440 - 360))), 84px)`
+   - `letter-spacing: clamp(-1px, …, -4px)` (tightens as it grows), `line-height: 1`, `lowercase font-bold`
+   - color `#ff9ce3` with `textShadow: 0 0 40px rgba(255,156,227,0.25)` — a **pink glow, not a gradient.**
+2. **`.home-text-h2`** — `globals.css:616`: `font-size: clamp(28px, …, 70px)`, `letter-spacing: clamp(-1px, …, -3px)`, `line-height: clamp(36px, …, 70px)`; colored `#9b83a0` (light) / `#a08ba8` (dark) as subtitle, or `#ff9ce3` as a title variant. **Legacy/dead** — referenced only inside `globals.css`, never applied by any `.tsx`.
+
+### Special text treatments
+
+- **Pink glow, not gradient text.** There is **no gradient-clipped text** anywhere (`bg-clip-text` / `text-transparent` = 0 hits). All `bg-gradient-*` usages are background gradients on `<div>` overlays, not type. The only text effect is the `#ff9ce3` glow on the homepage title, defended aggressively against dark-mode overrides via ~15 `!important` selectors (`globals.css:168–277`).
+- **Animated-text components exist but are unused (dead code):** `TypeWriter.tsx` (char-by-char, `startDelay=1000ms`, `typingDelay=80ms`) and `SlidingText.tsx` (vertical word-carousel, `interval=1000ms`, the only consumer of `.home-text-height`). **Neither is imported anywhere.**
+- **Marquee/spin keyframes** available to text/logo rows: `scroll-left`/`scroll-right` (`20s linear infinite`) and `slow-spin` (`10s`) — all currently unused.
+- **`.pink-btn`** (login button): declared KoHo (falls back to sans-serif), `18px` desktop / `16px` <768px, `color #422B46` on `#EDADF8`, `border-radius: 5px`.
+
+---
+
+## Layout & spacing
+
+MusicNerdWeb has **no shared page-container primitive**. The root layout is a flex column; each page defines its own centered column with an ad-hoc `max-w-* mx-auto` and its own padding. Tailwind's stock `container` config is present but **dead** — the `.container` class appears nowhere in `src/`. Breakpoints and the radius scale are unmodified defaults; the only bespoke layout logic is fluid `clamp()` typography and one hand-written SCSS media query.
+
+### Root shell (`src/app/layout.tsx`)
+
+```
+<body className="min-h-screen flex flex-col">
+  <Nav />
+  <main className="flex-grow flex flex-col min-h-0 w-full"> {children} </main>
+  <Toaster />
+  <Footer />   // mt-auto pins footer to bottom
+```
+
+A sticky-footer flex column. `<main>` imposes **no** max-width or padding — every page owns its own gutters.
+
+### Page container rules (the real convention)
+
+The dominant pattern is a **centered column** (`max-w-* mx-auto`) with padding that steps up at `sm:`, and vertical section stacking via `space-y-6`.
+
+| Page | Container className | Max width | H-pad | V-pad |
+|---|---|---|---|---|
+| Nav (`NavContent.tsx:11`) | `w-full px-3 py-3 sm:p-6 … max-w-[1000px] mx-auto` | `1000px` | `px-3 → sm:6` | `py-3 → sm:6` |
+| Home (`HomePageSplash.tsx:7`) | `px-6 sm:px-8 pt-0 pb-4 … w-full` + inner `max-w-2xl` | `2xl` (42rem) | `px-6 → sm:8` | `pt-0 pb-4` |
+| Artist (`artist/[id]/page.tsx:107`) | `w-full max-w-[800px] mx-auto px-4 py-5 space-y-6` | `800px` | `px-4` | `py-5` |
+| Admin (`admin/page.tsx:50`) | `admin-page px-4 sm:px-10 py-5 space-y-6` | none (full-bleed) | `px-4 → sm:10` | `py-5` |
+| Leaderboard/Profile (`leaderboard/ClientWrapper.tsx`) | `px-5 sm:px-10 py-10` | none | `px-5 → sm:10` | `py-10` |
+| Add-artist (`AddArtistContent.tsx`) | `min-h-screen flex items-center justify-center` + card `p-8 max-w-2xl w-full mx-4` | `2xl` | `mx-4` / card `p-8` | centered |
+| Footer (`Footer.tsx:3`) | `px-5 py-5 w-full text-center mt-auto` | none | `px-5` | `py-5` |
+
+Horizontal gutters cluster on **`px-4`/`px-5` → `sm:px-8`/`sm:px-10`**; vertical page padding is **`py-5`** (content pages) or **`py-10`** (leaderboard). Named max-widths are inconsistent — `800px` (artist), `2xl` (home, add-artist), `1000px` (nav) — with no shared token. The dead container config would have capped at **1400px**.
+
+### Section / card shell (artist page)
+
+The repeated content-section shell is a glass panel: **`glass p-4 sm:p-5 space-y-3`** (used 5× on the artist page). Page sections are separated by the parent's `space-y-6`; content inside each panel stacks on `space-y-3`.
+
+The shadcn `Card` primitive is **stock**: `rounded-lg border bg-card shadow-sm`, with `CardHeader`/`Content`/`Footer` all on **`p-6`**. The codebase mostly uses the custom `.glass p-4/p-5` panels rather than `Card` for primary layout — so **two padding conventions coexist** for card-like surfaces.
+
+### Breakpoints
+
+**No custom breakpoints** — `theme.screens` is never set, so all defaults apply.
+
+| Token | Value | Source |
+|---|---|---|
+| sm | 640px | Tailwind default |
+| md | 768px | Tailwind default |
+| lg | 1024px | Tailwind default |
+| xl | 1280px | Tailwind default |
+| 2xl | 1536px | Tailwind default |
+| container `2xl` | **1400px** | `tailwind.config.ts:20` (overrides container max only; **unused**) |
+
+Effective usage is a near-two-breakpoint system: `sm:` **157×**, `md:` **41×**, `lg:` **7×**, `xl:`/`2xl:` **0×**. One hand-written SCSS breakpoint at **`max-width: 768px`** (`globals.css:631`) governs `.nav-bar`, `.nav-grid`, `.home-text`, `.pink-btn` — duplicating Tailwind's `md` boundary in raw CSS. Fluid title sizing uses `clamp()` over **360px → 1440px**, independent of the breakpoint tokens.
+
+### Spacing & gutter conventions
+
+Drawn from Tailwind's 4px scale, with clear favorites:
+
+- **Flex/grid gap:** `gap-2` (0.5rem) dominant (**65×**), then `gap-4` (27×), `gap-1` (21×), `gap-3` (17×), `gap-1.5` (12×). `gap-2` is the default inline-cluster gutter.
+- **Vertical stacking:** `space-y-4` dominant (**24×**), `space-y-2` (17×), `space-y-3` (14×); page-level sections use `space-y-6`.
+- **Component padding (stock shadcn):** Button `default h-10 px-4 py-2`, `sm h-9 px-3`, `lg h-12 px-8`, `icon h-10 w-10`; Input/SelectTrigger `h-10 px-3 py-2`; Badge `px-2.5 py-0.5`; `Dialog p-6`.
+- **Custom off-scale utility:** `.pink-btn` uses `5px` vertical / `30px` horizontal padding (`4px` on mobile).
+
+### Border-radius scale
+
+Base token **`--radius: 0.5rem` (8px)**, not overridden in `.dark`. Tailwind derivations use the stock shadcn formula:
+
+| Class | Formula | Computed |
+|---|---|---|
+| `rounded-lg` | `var(--radius)` | 8px |
+| `rounded-md` | `calc(var(--radius) - 2px)` | 6px |
+| `rounded-sm` | `calc(var(--radius) - 4px)` | 4px |
+| `rounded-xl` | Tailwind default | 12px |
+| `rounded-2xl` | Tailwind default | 16px |
+| `rounded-full` | 9999px | pill |
+
+Usage: `rounded-full` **65×** (icons, avatars, badges, genre pills), `rounded-md` **53×** (buttons, inputs, selects), `rounded-lg` **28×**, `rounded` **14×**, `rounded-sm` **9×**, `rounded-xl` **7×**. **Off-scale hardcoded radii** live in `globals.css` and do not derive from `--radius`: `.glass` = **16px**, `.glass-subtle` = **12px**, `.search-bar` & `.pink-btn` = **5px**, glass scrollbar thumb = `9999px`.
+
+---
+
+## Components
+
+The UI is built on a **shadcn/ui + Radix** primitive layer in `src/components/ui/` (21 files), wrapped and extended by custom feature components in `src/app/_components/`. Most primitives are **stock shadcn defaults** (unmodified generated code); a handful were hand-edited, and **those edits are the load-bearing design facts.** Only **four** primitives use `cva` for variants — Button, Badge, Toast, Label — everything else is a fixed-className Radix wrapper.
+
+> **Record for future contributors:** brand identity is carried by the **custom components + global utilities**, not the primitives. Style at the custom-component layer; don't fork primitives.
+
+### Core primitives — variants & sizes (`cva`)
+
+| Component | File | Variants | Sizes | Default | Notes |
+|---|---|---|---|---|---|
+| **Button** | `button.tsx` | `default`, `destructive`, `outline`, `secondary`, `ghost`, `link` | `default` (h-10 px-4 py-2), `sm` (h-9 px-3), `lg` (h-12 px-8), `icon` (h-10 w-10) | `default`/`default` | `rounded-md text-sm font-medium transition-colors`, focus-visible ring-2. **Deviation:** the `default` variant is only `bg-primary text-primary-foreground` — stock `hover:bg-primary/90` was removed, so the primary button has **no hover feedback** |
+| **Badge** | `badge.tsx` | `default`, `secondary`, `destructive`, `outline` | — | `default` | `rounded-full border px-2.5 py-0.5 text-xs font-semibold`. Stock |
+| **Toast** | `toast.tsx` | `default`, `destructive` | — | `default` | `rounded-md border p-6 pr-8 shadow-lg`, swipe anims. Stock (Radix Toast) |
+| **Label** | `label.tsx` | none (cva with base string only) | — | — | `text-sm font-medium leading-none`. Stock |
+
+### Non-cva primitives (fixed styling, Radix-wrapped or plain)
+
+| Component | File | Notable styling | Stock or modified |
+|---|---|---|---|
+| **Card** (+ Header/Title/Description/Content/Footer) | `card.tsx` | `rounded-lg border bg-card text-card-foreground shadow-sm`; header `p-6 space-y-1.5`; title `text-2xl font-semibold tracking-tight`; content `p-6 pt-0` | Stock |
+| **Input** | `input.tsx` | `flex w-full rounded-md bg-background px-3 py-2 text-base … placeholder:text-muted-foreground disabled:opacity-50` | **Heavily stripped:** no `h-10`, **no `border border-input`**, **no `focus-visible:ring`**, uses `text-base` (stock uses `text-sm`). Renders borderless & height-less — forms must re-style via `className` |
+| **Textarea** | `textarea.tsx` | `min-h-[50px] w-full rounded-md border border-input bg-background text-base md:text-sm` | Modified: `min-h-[50px]` (stock 80px), and **`focus-visible:ring-2` is missing** (has `ring-ring`/`ring-offset-2` but no ring width) so the focus ring won't render |
+| **Select** (Radix) | `select.tsx` | `SelectTrigger h-10 border border-input focus:ring-2`; popper slide/zoom anims | Stock |
+| **Tabs** (Radix) | `tabs.tsx` | `TabsList h-10 rounded-md bg-muted`; `TabsTrigger data-[state=active]:bg-background data-[state=active]:shadow-sm` | Stock |
+| **Dialog** (Radix) | `dialog.tsx` | `DialogContent max-w-lg gap-4 border bg-background p-6 shadow-lg sm:rounded-lg`, overlay `bg-black/80` | **Modified:** className prefixed with `dark:bg-gray-900 text-foreground` (hardcoded dark surface instead of `bg-background`) |
+| **Table** (+ Header/Body/Footer/Row/Head/Cell/Caption) | `table.tsx` | `TableRow hover:bg-muted/50`; `TableHead h-10 px-2 text-muted-foreground` | **Modified:** `TableCell` adds `whitespace-nowrap overflow-hidden text-ellipsis` (truncating cells); padding `px-2`/`p-2` (stock `p-4`) |
+| **Tooltip** (Radix) | `tooltip.tsx` | `rounded-md border bg-popover px-3 py-1.5 text-sm shadow-md`, `sideOffset=4` | Stock |
+| **Checkbox** (Radix) | `checkbox.tsx` | `h-4 w-4 rounded-sm border border-primary data-[state=checked]:bg-primary` | Stock |
+| **DropdownMenu** (Radix, full set) | `dropdown-menu.tsx` | `bg-popover p-1 rounded-md shadow-md`, `inset` prop, Check/Circle/ChevronRight icons | Stock |
+
+Additional stock primitives present but not individually styled: `aspect-ratio`, `calendar`, `carousel`, `drawer`, `form`, `popover`, `toaster`.
+
+### Signature custom components (`src/app/_components/`)
+
+- **HomePageSplash** — homepage hero. Lowercase `music nerd` `<h1>` with fluid `clamp()` font-size (32px → 84px), negative letter-spacing, **hardcoded** `color: #ff9ce3` + pink `textShadow` glow, then mounts `ActivityFeed`. Uses raw hex, not the `pastypink` token.
+- **ArtistLinks** — async server component. Platform links as **list rows** (`StaticPlatformLink` / `EditablePlatformLink` when `canEdit`) using `.link-item-grid` + `.corners-rounded` globals; splits monetized "support" links from general links, injects Spotify/Deezer.
+- **ArtistLinksGrid** — the newer **grid-based** link renderer that coexists with `ArtistLinks`. Circular glassmorphism tiles: `w-12 h-12 rounded-full backdrop-blur-sm bg-white/70 dark:bg-white/10 border-white/40`, with `group-hover:scale-110` and a colored glow (pink `shadow-[0_0_15px_rgba(239,149,255,0.45)]`, blue for Deezer/listen).
+- **EditableLinkIcon** — editable glass tile; adds a red `-top-1 -right-1` delete `X` gated on `EditModeContext.isEditing`, posting to `/api/directEditLink`.
+- **ThemeToggle** — a **fully custom animated pill switch** (not Radix Switch). Mobile `w-12 h-12` circle and desktop `w-28 h-8` pill with sliding knob + "Dark Mode"/"Light Mode" labels; Moon/Sun icons. Colors hardcoded inline (`#2d3748`/`#f3f4f6` track, `#2ad4fc` moon = `pastyblue` value).
+- **EditModeToggle** — wraps shadcn `<Button variant="outline" size="sm">`, restyled with brand `pastypink` (`border-pastypink/50 text-pastypink hover:bg-pastypink hover:text-white`); Pencil/Check icons.
+- **BookmarkButton** — wraps shadcn `<Button variant="outline" size="sm">`, `localStorage`-backed toggle, fixed `w-[120px]`, `pastypink` fill/border states.
+- **SlidingText** — vertical text carousel cycling `ReactNode[]` via `translateY`. Uses `.home-text-height`. **Dead code (imported nowhere).**
+- **TypeWriter** — char-by-char typewriter (`startDelay=1000ms`, `typingDelay=80ms`). **Dead code (imported nowhere).**
+- **LoginBtn** (`buttons/LoginBtn/index.tsx`) — **legacy pre-shadcn button**: raw `<button className="pink-btn">` (`background #EDADF8`, maroon `#422B46` text, KoHo font, `5px` radius, 18px). Evidence of an older button system still in the tree.
+- **nav/** — top nav: spinning logo (`hover:animate-[spin_3s_linear_infinite]`), `SearchBar`, `AddArtist`, `Login`. `Login.tsx` branches to `NoWalletLogin` (admin gear) or `PrivyLogin` (email-first auth); also `LegacyAccountModal`.
+
+### Design facts to record
+
+- The shadcn primitives are **~70% stock generated code.** Meaningful hand-edits: Button (removed default hover), Input (stripped border/height/ring), Textarea (`min-h-[50px]`, missing ring width), Dialog (`dark:bg-gray-900`), Table (truncating cells, tighter padding).
+- **Three parallel button systems** coexist: the cva `Button`, the legacy `.pink-btn` global class, and the fully-custom `ThemeToggle` `<button>`.
+- **Two artist-link renderers** coexist: `ArtistLinks` (list rows) and `ArtistLinksGrid` (glass icon grid).
+- Brand color is applied **two ways**: via Tailwind tokens (`pastypink`, `pastyblue`) in `EditModeToggle`/`BookmarkButton`, and via hardcoded hex (`#ff9ce3`, `#2d3748`, `#EDADF8`) in `HomePageSplash`, `ThemeToggle`, `.pink-btn`.
+- **A dead pre-shadcn utility-class layer survives** in `globals.css:679–738`: `@apply`-based legacy classes `.navbar`, `.logo`, `.login-button` (`bg-purple-600`), `.support-button`/`.sound-button`/`.world-button` (`bg-green-500`), `.play-button` (`bg-pink-500`), `.support-input`, `.scroll-text`, and a duplicate `.search-bar { @apply p-2 border rounded }` that conflicts with the earlier `.search-bar { border-radius: 5px }`. Evidence of an older styling system predating shadcn, still in the tree.
+
+---
+
+## Motion & interaction
+
+The motion system is a **three-layer stack**: (1) `tailwindcss-animate` powering stock shadcn/Radix enter/exit transitions, (2) hand-written CSS `@keyframes` in `globals.css`, and (3) `framer-motion` (v12.36.0) used in exactly three artist-page components for scroll-driven and scroll-reveal effects. The signature gesture is a **pink-glow lift** on hover (scale + colored box-shadow). There is **no `prefers-reduced-motion` handling anywhere**, and several defined animations are dead code.
+
+### Animation tokens
+
+| Name | Duration | Easing | Definition | Status |
+|---|---|---|---|---|
+| `fadeSlideIn` | `0.3s` | `ease-out both` | opacity `0→1`, `translateY(-8px→0)` | **Live** — `ActivityFeed.tsx:230` |
+| `accordion-down` | `0.2s` | `ease-out` | height `0 → var(--radix-accordion-content-height)` | **Dead** — no Accordion exists |
+| `accordion-up` | `0.2s` | `ease-out` | height `var(...) → 0` | **Dead** — no Accordion exists |
+| `scroll-left` | `20s` | `linear infinite` | `translateX(0 → -50%)` (marquee) | **Dead** — zero usages |
+| `scroll-right` | `20s` | `linear infinite` | `translateX(0 → 50%)` | **Dead** — zero usages |
+| `slow-spin` | `10s` | `linear infinite` | `rotate(0 → 360deg)` | **Dead** — zero usages |
+
+`tailwindcss-animate` supplies the `animate-in`/`animate-out`/`fade-in-0`/`zoom-in-95`/`slide-in-from-*` utilities used by the shadcn primitives — **stock strings, unmodified.** Dialog content overrides the default to `duration-200`; everything else inherits the tailwindcss-animate default (~150ms).
+
+**Tailwind utility durations actually used (`.tsx`):** `duration-300` ×22 (de-facto standard), `duration-200` ×3, `duration-500` ×2, `duration-150` ×1, `duration-1000` ×1. **Only easing utility used:** `ease-in-out` ×6. There is **no tokenized duration/easing scale** — 300ms is convention by repetition, not definition.
+
+**Framer-motion transitions** (inline per-component, not tokenized):
+
+- `RevealSection.tsx` — `transition={{ duration: 0.5, ease: "easeOut", delay }}`, `initial={{opacity:0, y:30}} → whileInView={{opacity:1, y:0}}`, `viewport={{ once: true, margin: "-50px" }}`.
+- `HeroSection.tsx` — scroll-linked via `useScroll` + `useTransform`: parallax `bgY 0%→50%`, `bgOpacity 1→0`, `photoScale 1→0.65`, `photoOpacity 1→0`, `stickyOpacity 0→1`.
+
+### Interaction principles (as observed)
+
+- **Hover — the signature "pink-glow lift."** `transition-all duration-300` + `group-hover:scale-110` + a colored glow box-shadow, on circular link icons (`ArtistLinksGrid.tsx`, `EditableLinkIcon.tsx`): `group-hover:scale-110 group-hover:shadow-[0_0_15px_rgba(239,149,255,0.45)] group-hover:bg-white/90`. Cards echo it larger — `PressAndFeatures.tsx:65` `hover:shadow-[0_0_30px_rgba(239,149,255,0.35)]`; hero photo `hover:shadow-[0_0_25px_rgba(239,149,255,0.5)]`. The "listen"-platform variant swaps the glow to **blue** `rgba(0,199,242,0.45)`. ActivityFeed rows use a subtler `hover:bg-[var(--feed-hover-bg)]` + `group-hover:h-5` accent-bar growth.
+- **Hover — shadcn primitives.** Stock `transition-colors` tint-shifts (`hover:bg-secondary/80`, `hover:bg-accent`). **Deviation:** the `default` button variant has **no hover state** (stock ships `hover:bg-primary/90`).
+- **Focus.** Stock focus rings on button, tabs, checkbox (`focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`) and badge/dialog-close/toast (`focus:ring-2`). **Deviation:** `input.tsx` has **no border and no `focus-visible` ring** — text inputs have no default focus affordance.
+- **Active/press.** No `active:` classes anywhere — there is **no press-scale or tactile down-state feedback.**
+- **Theme toggle** is the most deliberately animated control: pill + sliding knob use `transition-all duration-300 ease-in-out`; labels cross-fade via `transition-opacity duration-300`.
+- **Loading/ambient.** `animate-spin` bordered rings (AgentWorkSection, ArtistDataSection, UserEntriesTable, UserSearch), `Loader2` (VaultManager); `animate-pulse` on the login placeholder and the "Ask" logo; `animate-ping` on the "Live" dot (`ActivityFeed.tsx:202`).
+- **Scrollbars.** `.scrollbar-glass` — bespoke 6px thin scrollbar, `rgba(255,255,255,0.18)` thumb → `0.32` on `:hover` (the only scrollbar hover transition, instantaneous). `.scrollbar-hide` fully hides.
+
+### Signature motion
+
+1. **Fade-slide-in feed (live).** The only bespoke keyframe wired up. `ActivityFeed` applies `animate-fadeSlideIn` with **staggered `animationDelay: i*30ms`** on first load and a **depth opacity decay** (`Math.max(0.45, 1 - i*0.035)`), plus the `animate-ping` "Live" pulse.
+2. **Scroll-driven hero (framer-motion).** `HeroSection` + `StickyHeroBar` layer a parallax: blurred bg drifts at half-speed and fades, the centered photo scales `1→0.65` and fades, a frosted sticky bar fades in — all pure `MotionValue`s ("no React state" per the code comment), so it's jank-free.
+3. **Reveal-on-scroll (framer-motion).** `RevealSection` — reusable `whileInView` fade-up (`opacity 0→1`, `y 30→0`, `0.5s easeOut`, fires `once`).
+4. **Orphaned signature motion (dead code).** `TypeWriter.tsx` and `SlidingText.tsx` are fully built but imported nowhere. `SlidingText.tsx:33` also uses `transition-max-height` — **not a valid Tailwind utility**, so the intended collapse/expand is un-animated (latent bug, dormant).
+
+---
+
+## Known inconsistencies to reconcile
+
+Each row is a design-debt decision: pick one source of truth and migrate. Ordered roughly by blast radius.
+
+| # | What diverges | Where | Suggested single source of truth |
+|---|---|---|---|
+| 1 | **Brand pink = 3 values.** `#ef95ff` (pastypink token / `$secondary` / hero gradient), `#ff9ce3` (wordmark + highlights + light checkbox + focus rings, 57 hardcoded uses, in no palette), `#EDADF8` (`.pink-btn` / `.text-color-primary`). | `tailwind.config.ts:28`, `globals.css:485/516/585`, `HomePageSplash.tsx:16` | One canonical `brand.pink` token in `tailwind.config.ts`; migrate the 57 `#ff9ce3` literals and `#EDADF8`. The palette pink (`#ef95ff`) isn't even the pink users see. |
+| 2 | **Brand palette never reaches the semantic layer.** `--primary`/`--secondary`/`--accent`/`--ring`/`--chart-*` are 100% stock shadcn slate in both `:root` and `.dark`; brand is applied only as one-off hex on top. | `globals.css:34–91`, `tailwind.config.ts:26–29` | Decide on purpose: either keep the semantic layer intentionally neutral, or map `--primary`/`--accent`/`--ring` onto the brand palette so components inherit brand color. |
+| 3 | **"Primary" means two opposite colors.** SCSS `$primary` = cyan `#2ad4fc`; shadcn `--primary` = navy slate `222.2 47.4% 11.2%`. Code reading "primary" gets different intent per system. | `_colors.scss:1`, `globals.css:42` | Rename SCSS `$primary/$secondary/$tertiary` → `$brand-*`, or feed the brand palette into the shadcn tokens so the two agree. |
+| 4 | **`_colors.scss` is dead code.** Imported nowhere; duplicates the brand under a second naming scheme; its `.text-color-primary` (`$primary` = `#2ad4fc`) conflicts with the live `globals.css:516` definition (`#EDADF8`). | `_colors.scss` | Delete it, or wire it in and remove the shadowing. Do not keep a second brand naming scheme. |
+| 5 | **Dark mode = ~330 lines of `!important` overrides**, not token swaps. Neutral ramp hardcoded as slate hex (`#1a1a1a`, `#2d3748`, `#4a5568`, `#f7fafc`, `#a0aec0`) bypassing `--background`/`--card`/`--muted`. | `globals.css:102–532` | Migrate to token swaps in the `.dark` block so new components inherit dark styling. Long-term this is the highest-leverage cleanup. |
+| 6 | **`--subtitle-color` re-typed as a literal.** `rgb(89,48,97,0.6)` is both the light token and a raw literal in ~8 leaderboard/FunFacts overrides. Also the token uses malformed 4-arg `rgb()` (light) and drops alpha (dark). | `globals.css:61/89/138/281–303` | Reference the token instead of re-typing; fix `rgb(...)` → `rgba(...)`. |
+| 7 | **KoHo never loads in the app.** No `next/font`, `<link>`, `@font-face`, or font package. `.koho-*` and `.pink-btn` fall back to system sans; KoHo only loads in `public/*privacy.html`. | `layout.tsx`, `globals.css:572/578/587`, `package.json` | Decide if KoHo is the brand font. If yes, load once via `next/font/google` in `layout.tsx` and set as Tailwind `font-sans`. If no, delete the dead `.koho-*` classes. |
+| 8 | **Three parallel button systems.** cva `Button`, legacy `.pink-btn` (`LoginBtn`), hand-rolled `ThemeToggle` `<button>`. | `button.tsx`, `globals.css:584`, `ThemeToggle.tsx` | Standardize on shadcn `Button`; retire `.pink-btn`/`LoginBtn`. Keep `ThemeToggle` bespoke (documented exception). |
+| 9 | **Default Button has no hover state.** Stock `hover:bg-primary/90` was removed; every other variant has a hover. | `button.tsx:12` | Restore `hover:bg-primary/90` (or document the removal as intentional). |
+| 10 | **Input primitive stripped bare.** No border, no fixed height, no focus-visible ring; `text-base` instead of `text-sm`. Every form must re-add chrome. Inconsistent with fully-styled Textarea/Select. | `input.tsx:13` | Restore stock border/`h-10`/focus ring, or document Input as intentionally bare. |
+| 11 | **Textarea focus ring won't render.** Has `ring-ring` + `ring-offset-2` but is missing `focus-visible:ring-2` (no ring width). | `textarea.tsx:12` | Add `focus-visible:ring-2` to match Select/Button (accessibility). |
+| 12 | **Dialog hardcodes `dark:bg-gray-900`** instead of `bg-background`/`bg-card`, diverging from token-driven theming. | `dialog.tsx:41` | Use the surface token. |
+| 13 | **Two artist-link renderers.** `ArtistLinks` (list rows) vs `ArtistLinksGrid` (glass icon grid) — different visual languages for the same data. | `ArtistLinks.tsx`, `ArtistLinksGrid.tsx` | Pick one canonical renderer; retire or clearly scope the other. |
+| 14 | **No shared page-container primitive.** Max-widths diverge with no token: `800px` (artist), `2xl` (home/add-artist), `1000px` (nav). | per-page wrappers | Extract a `<PageContainer>` (e.g. `max-w-[800px] mx-auto px-4 sm:px-8 py-5`); reconcile the max-widths. |
+| 15 | **Dead container config.** `tailwind.config.ts` defines center/padding-2rem/2xl-1400px, but `.container` is used nowhere; real content width is 800–1000px. | `tailwind.config.ts:20` | Adopt the container class, or delete the config. |
+| 16 | **Inconsistent horizontal gutters.** `px-3` (nav), `px-4` (artist/admin), `px-5` (leaderboard/footer), `px-6` (home), stepping to `sm:px-8`/`sm:px-10`/`sm:p-6`. | multiple pages | Pick one step (e.g. `px-4 → sm:px-8`) and apply uniformly. |
+| 17 | **768px breakpoint expressed twice.** Raw SCSS `@media (max-width:768px)` in `globals.css` **and** Tailwind `md:` utilities. | `globals.css:631` | Fold the SCSS rules into `md:` utilities, or document why nav needs hand-written CSS. |
+| 18 | **Off-scale radii.** `.glass` 16px, `.glass-subtle` 12px, `.search-bar`/`.pink-btn` 5px — none derive from `--radius` (4/6/8px). | `globals.css:28/546/560/569/588` | Bring onto the `--radius` scale, or record as intentional brand exceptions. |
+| 19 | **Two card padding conventions.** Custom `.glass p-4/p-5` (primary panels) vs shadcn `Card p-6`. | `globals.css`, `card.tsx` | Pick one primary panel and align padding. |
+| 20 | **No motion token scale.** `duration-300` (22×) is de-facto standard, but SlidingText 500/1000ms, ThemeToggle 300ms, shadcn 150/200ms, framer 0.5s — all ad hoc. | codebase-wide | Define `--motion-fast 150ms` / `--motion-base 300ms` / `--motion-slow 500ms` + a standard easing; reference them. |
+| 21 | **No `prefers-reduced-motion` guard.** Infinite spins, `animate-ping`, scroll parallax, staggered feed all run unconditionally. | codebase-wide | Add a global strategy; use framer's `useReducedMotion` for scroll effects. |
+| 22 | **Two pink-glow hexes.** Hover glows use `rgba(239,149,255,x)` (`#ef95ff`); title shadow + highlight box-shadow use `rgba(255,156,227,x)` (`#ff9ce3`). | `ArtistLinksGrid.tsx`, `HomePageSplash.tsx`, `globals.css:414` | One `brand-glow` token. |
+| 23 | **Two vocabularies for the pink→purple gradient.** HeroSection raw hex `from-[#ef95ff] to-[#7c3aed]`; PressAndFeatures tokens `from-pastypink via-purple-900`. | `HeroSection.tsx:79`, `PressAndFeatures.tsx:68` | One expression (prefer tokens). |
+| 24 | **Dead typography.** `.home-text-h2`, `.home-text-height`, ~15 `!important` `#ff9ce3` overrides, `SlidingText.tsx`, `TypeWriter.tsx` — all legacy/unapplied. | `globals.css`, `_components/` | Delete, or wire back in. If keeping SlidingText, fix the invalid `transition-max-height`. |
+| 25 | **Dead animation code.** `accordion-down`/`up` (no Accordion), `.animate-scroll-left`/`-right`, `.animate-slow-spin` — zero usages. | `tailwind.config.ts`, `globals.css` | Delete or wire up. |
+| 26 | **Two fluid-heading definitions.** HomePageSplash h1 (32–84px inline) vs `.home-text-h2` (28–70px CSS) both re-implement the 360–1440px clamp by hand. | `HomePageSplash.tsx:13`, `globals.css:617` | Extract the clamp into a shared utility/token. |
+| 27 | **No custom type scale or font tokens.** Every `text-*` is a stock Tailwind default; no single source of truth for the type system. | codebase-wide | Document a minimal named scale (which `text-*` + weight = H1/H2/body/caption). |
+| 28 | **Cyan under two names.** `pastyblue` (Tailwind) and `$primary` (SCSS) both = `#2ad4fc`; pink has token + untracked literals. | `tailwind.config.ts`, `_colors.scss` | Consolidate naming across the two color systems. |
+| 29 | **Theme uses custom `ThemeProvider`, not `next-themes`** (the documented convention). | `_components/ThemeProvider.tsx` | Document this so contributors don't assume next-themes APIs. |
+| 30 | **ActivityFeed `--feed-*` is a parallel token system** — a well-structured light/dark set duplicating brand hex the rest of the app hardcodes. | `ActivityFeed.tsx:69–115` | Consider promoting into the shared token layer. |
+
+---
+
+## Proposing design changes
+
+This system evolves by editing tokens, not by scattering more literals. When you propose a change:
+
+1. **Change the token first, in the right place.** Color lives in three places today — keep them in sync deliberately:
+   - **Brand palette** → `tailwind.config.ts` `theme.extend.colors` (`pastypink`/`pastyblue`/`jellygreen`/`maroon`).
+   - **Semantic tokens** → `globals.css` `:root` / `.dark` (`--background`, `--primary`, `--radius`, etc.). Remember these are still stock slate — rebranding them is a deliberate, high-leverage act, not a casual edit.
+   - **SCSS** (`_colors.scss`) is currently **dead** — don't add to it unless you're intentionally reviving it.
+   Radius → `--radius`. Motion → introduce the `--motion-*` scale (see #20) rather than another `duration-*` literal.
+
+2. **State the change against this doc.** Name the token/utility/component you're touching, whether you're following a convention (e.g. `.glass p-4 sm:p-5` panels, `gap-2` clusters, the pink-glow-lift hover) or introducing a new one, and — if diverging — why.
+
+3. **Don't add a new hex, pink, blue, breakpoint, or button system.** Three pinks, two cyan names, three button systems, and two link renderers already exist. Migrate toward the named tokens; consolidate rather than extend. If you must add a one-off, add a row to [Known inconsistencies](#known-inconsistencies-to-reconcile) so it's tracked, not lost.
+
+4. **Prefer token swaps over `!important` dark overrides.** The `.dark` override wall is the most brittle part of the system. New components should inherit dark styling from tokens; adding another `!important` patch is a regression, not a fix.
+
+5. **Style at the custom-component layer, not the primitives.** Brand identity lives in `src/app/_components/` and the global utilities. The shadcn primitives are mostly stock — fork them only to fix a documented deviation (Input focus ring, default Button hover), not to inject brand color.
+
+6. **Honor the personality.** Neon accents on quiet chrome; glass surfaces; round everything; calm ambient motion; lowercase friendly voice; pink identity in light, cyan/green in dark. When in doubt, the `music nerd` wordmark and the `.glass` panel are the templates.

--- a/design-system/colors/brand-palette.html
+++ b/design-system/colors/brand-palette.html
@@ -1,0 +1,365 @@
+<!-- @dsCard group="Colors" name="Brand palette" subtitle="maroon · pastyblue · pastypink · jellygreen + the 3 pinks" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Brand palette — MusicNerdWeb</title>
+<style>
+  :root {
+    --canvas: #ffffff;
+    --ink: #422b46;          /* maroon — the brand "ink" */
+    --hairline: #ece7ee;
+    --muted: #8a7f90;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--canvas);
+    color: var(--ink);
+    font-family: var(--sans);
+    line-height: 1.45;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 32px 28px 40px;
+  }
+
+  header { margin-bottom: 28px; }
+
+  h1 {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin: 0 0 6px;
+  }
+
+  .lede {
+    font-size: 13.5px;
+    color: var(--muted);
+    margin: 0;
+    max-width: 62ch;
+  }
+
+  .lede code {
+    font-family: var(--mono);
+    font-size: 12px;
+    background: #f5f1f6;
+    padding: 1px 5px;
+    border-radius: 4px;
+    color: #6f4b75;
+  }
+
+  .section-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
+    color: var(--muted);
+    margin: 30px 0 14px;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+  .section-label .count {
+    font-weight: 400;
+    text-transform: none;
+    letter-spacing: 0;
+    color: #b3a8ba;
+  }
+
+  /* ---- Brand swatch grid ---- */
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+  }
+
+  .swatch {
+    border-radius: 8px;                 /* --radius 0.5rem = 8px */
+    overflow: hidden;
+    border: 1px solid var(--hairline);
+    background: #fff;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .chip {
+    height: 118px;
+    display: flex;
+    align-items: flex-end;
+    padding: 12px;
+  }
+  .chip .role {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    padding: 3px 8px;
+    border-radius: 999px;
+    background: rgba(255,255,255,0.35);
+    backdrop-filter: blur(2px);
+  }
+
+  .meta {
+    padding: 12px 13px 14px;
+  }
+  .meta .name {
+    font-size: 15px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin: 0 0 2px;
+  }
+  .meta .cls {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    color: #6f4b75;
+    margin: 0 0 8px;
+  }
+  .meta .hex {
+    font-family: var(--mono);
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    margin: 0 0 3px;
+  }
+  .meta .use {
+    font-size: 11.5px;
+    color: var(--muted);
+    margin: 0;
+    line-height: 1.35;
+  }
+
+  /* ---- Pink fragmentation row ---- */
+  .pink-panel {
+    border: 1px solid var(--hairline);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .pink-head {
+    padding: 13px 16px;
+    background: #fbf7fc;
+    border-bottom: 1px solid var(--hairline);
+  }
+  .pink-head .title {
+    font-size: 14px;
+    font-weight: 700;
+    margin: 0 0 3px;
+  }
+  .pink-head .sub {
+    font-size: 12px;
+    color: var(--muted);
+    margin: 0;
+  }
+  .pink-row {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .pink-cell {
+    padding: 0;
+    border-right: 1px solid var(--hairline);
+    display: flex;
+    flex-direction: column;
+  }
+  .pink-cell:last-child { border-right: 0; }
+  .pink-bar {
+    height: 76px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .pink-bar .hexlabel {
+    font-family: var(--mono);
+    font-size: 13px;
+    font-weight: 700;
+    color: #422b46;
+    background: rgba(255,255,255,0.55);
+    padding: 3px 9px;
+    border-radius: 999px;
+  }
+  .pink-info {
+    padding: 11px 13px 14px;
+  }
+  .pink-info .tok {
+    font-size: 12.5px;
+    font-weight: 700;
+    margin: 0 0 3px;
+  }
+  .pink-info .where {
+    font-size: 11.5px;
+    color: var(--muted);
+    margin: 0 0 6px;
+    line-height: 1.35;
+  }
+  .pink-info .src {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    color: #9b83a0;
+    margin: 0;
+  }
+  .badge {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 600;
+    padding: 1px 6px;
+    border-radius: 4px;
+    margin-top: 6px;
+  }
+  .badge.palette { background: #e6f9f2; color: #0a8a63; }
+  .badge.orphan  { background: #ffeef8; color: #b23a86; }
+
+  footer {
+    margin-top: 26px;
+    padding-top: 16px;
+    border-top: 1px solid var(--hairline);
+    font-size: 11.5px;
+    color: var(--muted);
+    line-height: 1.5;
+  }
+  footer code {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: #6f4b75;
+  }
+
+  @media (max-width: 520px) {
+    .pink-row { grid-template-columns: 1fr; }
+    .pink-cell { border-right: 0; border-bottom: 1px solid var(--hairline); }
+    .pink-cell:last-child { border-bottom: 0; }
+  }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <h1>Brand palette</h1>
+      <p class="lede">
+        The four Tailwind brand colors from <code>tailwind.config.ts</code> (lines 26–29). These are
+        plain color extensions — <strong>not</strong> wired into the shadcn semantic
+        <code>--primary</code>/<code>--accent</code> tokens, which stay stock navy "slate."
+        Brand character is layered on top as ad-hoc hex.
+      </p>
+    </header>
+
+    <div class="section-label">The neon accent trio + the ink</div>
+
+    <div class="grid">
+      <!-- maroon -->
+      <div class="swatch">
+        <div class="chip" style="background:#422b46;">
+          <span class="role" style="color:#f3e9f4;">ink / body text</span>
+        </div>
+        <div class="meta">
+          <p class="name">maroon</p>
+          <p class="cls">text-maroon</p>
+          <p class="hex">#422b46</p>
+          <p class="use">Deep aubergine for footer + body text. Forced to white in dark mode.</p>
+        </div>
+      </div>
+
+      <!-- pastyblue -->
+      <div class="swatch">
+        <div class="chip" style="background:#2ad4fc;">
+          <span class="role" style="color:#0b3a45;">accent · cyan</span>
+        </div>
+        <div class="meta">
+          <p class="name">pastyblue</p>
+          <p class="cls">bg-pastyblue</p>
+          <p class="hex">#2ad4fc</p>
+          <p class="use">Takes over as the accent in dark mode (checkbox, moon icon).</p>
+        </div>
+      </div>
+
+      <!-- pastypink -->
+      <div class="swatch">
+        <div class="chip" style="background:#ef95ff;">
+          <span class="role" style="color:#5a2b66;">accent · pink</span>
+        </div>
+        <div class="meta">
+          <p class="name">pastypink</p>
+          <p class="cls">text-pastypink</p>
+          <p class="hex">#ef95ff</p>
+          <p class="use">Most-used brand token (~93 uses). The hero gradient pink.</p>
+        </div>
+      </div>
+
+      <!-- jellygreen -->
+      <div class="swatch">
+        <div class="chip" style="background:#19ffb8;">
+          <span class="role" style="color:#0a5c42;">accent · mint</span>
+        </div>
+        <div class="meta">
+          <p class="name">jellygreen</p>
+          <p class="cls">bg-jellygreen</p>
+          <p class="hex">#19ffb8</p>
+          <p class="use">Jelly mint-green. Appears mostly as raw hex in the activity feed.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="section-label">
+      Brand pink is fragmented into 3 values
+      <span class="count">— an honest signature of the current system</span>
+    </div>
+
+    <div class="pink-panel">
+      <div class="pink-head">
+        <p class="title">One pink, three hexes that never reconcile</p>
+        <p class="sub">The pink you actually see on screen (<code style="font-family:var(--mono);font-size:11px;">#ff9ce3</code>) is not the palette token — it lives outside <code style="font-family:var(--mono);font-size:11px;">tailwind.config.ts</code> as 57 hardcoded uses.</p>
+      </div>
+      <div class="pink-row">
+        <!-- #ef95ff -->
+        <div class="pink-cell">
+          <div class="pink-bar" style="background:#ef95ff;">
+            <span class="hexlabel">#ef95ff</span>
+          </div>
+          <div class="pink-info">
+            <p class="tok">pastypink token</p>
+            <p class="where">HeroSection gradient, general accent. The one that lives in the palette.</p>
+            <p class="src">tailwind.config.ts:28 · _colors.scss:2 ($secondary)</p>
+            <span class="badge palette">IN PALETTE</span>
+          </div>
+        </div>
+
+        <!-- #ff9ce3 -->
+        <div class="pink-cell">
+          <div class="pink-bar" style="background:#ff9ce3;">
+            <span class="hexlabel">#ff9ce3</span>
+          </div>
+          <div class="pink-info">
+            <p class="tok">on-screen pink · 57 uses</p>
+            <p class="where">"music nerd" title glow, highlight borders, light checked checkbox, focus rings, feed.</p>
+            <p class="src">globals.css:168–277, 485–488 · hardcoded</p>
+            <span class="badge orphan">NOT IN PALETTE</span>
+          </div>
+        </div>
+
+        <!-- #edadf8 -->
+        <div class="pink-cell">
+          <div class="pink-bar" style="background:#edadf8;">
+            <span class="hexlabel">#edadf8</span>
+          </div>
+          <div class="pink-info">
+            <p class="tok">.pink-btn pink</p>
+            <p class="where">Login button background + <code style="font-family:var(--mono);font-size:10.5px;">.text-color-primary</code>. A third distinct value.</p>
+            <p class="src">globals.css:516, 585</p>
+            <span class="badge orphan">NOT IN PALETTE</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <footer>
+      Values verified against <code>tailwind.config.ts</code>, <code>src/app/_colors.scss</code>, and DESIGN.md §Color.
+      Radius base <code>--radius: 0.5rem</code> (8px). Type renders in the system sans stack
+      (<code>-apple-system, …</code>) — the intended brand font <strong>KoHo</strong> is declared but never loads in the app.
+    </footer>
+  </div>
+</body>
+</html>

--- a/design-system/colors/semantic-tokens.html
+++ b/design-system/colors/semantic-tokens.html
@@ -1,0 +1,200 @@
+<!-- @dsCard group="Colors" name="Semantic tokens" subtitle="stock shadcn slate · light + dark" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  :root {
+    --radius: 0.5rem;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: var(--sans);
+    background: #ffffff;
+    color: hsl(222.2 84% 4.9%);
+    -webkit-font-smoothing: antialiased;
+    padding: 28px;
+  }
+  .wrap { max-width: 860px; margin: 0 auto; }
+
+  header { margin-bottom: 20px; }
+  h1 {
+    font-size: 19px;
+    font-weight: 650;
+    letter-spacing: -0.01em;
+    margin: 0 0 4px;
+  }
+  .sub {
+    font-size: 13px;
+    color: hsl(215.4 16.3% 46.9%);
+    margin: 0;
+  }
+  .sub code {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: hsl(222.2 47.4% 11.2%);
+    background: hsl(210 40% 96.1%);
+    padding: 1px 5px;
+    border-radius: 4px;
+  }
+
+  .cols {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+  @media (max-width: 620px) { .cols { grid-template-columns: 1fr; } }
+
+  .panel {
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid rgba(0,0,0,0.08);
+  }
+  .panel-light {
+    background: hsl(0 0% 100%);
+    color: hsl(222.2 84% 4.9%);
+  }
+  .panel-dark {
+    background: hsl(222.2 84% 4.9%);
+    color: hsl(210 40% 98%);
+    border-color: rgba(255,255,255,0.10);
+  }
+
+  .panel-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 11px 14px;
+    font-size: 11px;
+    font-weight: 650;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    border-bottom: 1px solid rgba(0,0,0,0.06);
+  }
+  .panel-dark .panel-head { border-bottom-color: rgba(255,255,255,0.08); }
+  .mode-dot {
+    width: 13px; height: 13px; border-radius: 50%;
+    box-shadow: inset 0 0 0 1px rgba(128,128,128,0.35);
+  }
+  .panel-light .mode-dot { background: #ffffff; }
+  .panel-dark  .mode-dot { background: hsl(222.2 84% 4.9%); box-shadow: inset 0 0 0 1px rgba(255,255,255,0.35); }
+
+  .row {
+    display: grid;
+    grid-template-columns: 30px 1fr auto;
+    align-items: center;
+    gap: 11px;
+    padding: 8px 14px;
+  }
+  .row + .row { border-top: 1px solid rgba(128,128,128,0.10); }
+
+  .swatch {
+    width: 30px; height: 30px;
+    border-radius: 6px;
+    /* hairline ring so pure-white / near-black swatches stay visible on either canvas */
+    box-shadow: inset 0 0 0 1px rgba(128,128,128,0.28);
+  }
+
+  .name {
+    font-family: var(--mono);
+    font-size: 12.5px;
+    font-weight: 500;
+  }
+  .val {
+    font-family: var(--mono);
+    font-size: 11px;
+    text-align: right;
+    opacity: 0.62;
+    white-space: nowrap;
+  }
+
+  .caption {
+    margin-top: 18px;
+    padding: 13px 15px;
+    border: 1px solid rgba(0,0,0,0.08);
+    border-radius: var(--radius);
+    background: hsl(210 40% 96.1%);
+    font-size: 12.5px;
+    line-height: 1.55;
+    color: hsl(222.2 47.4% 11.2%);
+  }
+  .caption strong { font-weight: 650; }
+  .caption .chip {
+    display: inline-block;
+    width: 10px; height: 10px;
+    border-radius: 3px;
+    vertical-align: -1px;
+    margin: 0 1px;
+    box-shadow: inset 0 0 0 1px rgba(0,0,0,0.12);
+  }
+  .caption code {
+    font-family: var(--mono);
+    font-size: 11.5px;
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>Semantic tokens</h1>
+    <p class="sub">Unmodified stock shadcn <code>slate</code> — <code>globals.css</code> <code>:root</code> / <code>.dark</code>, resolved from real HSL</p>
+  </header>
+
+  <div class="cols">
+    <!-- LIGHT -->
+    <div class="panel panel-light">
+      <div class="panel-head"><span class="mode-dot"></span>Light · :root</div>
+
+      <div class="row"><div class="swatch" style="background:hsl(0 0% 100%)"></div><div class="name">background</div><div class="val">0 0% 100%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(222.2 84% 4.9%)"></div><div class="name">foreground</div><div class="val">222.2 84% 4.9%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(0 0% 100%)"></div><div class="name">card</div><div class="val">0 0% 100%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(0 0% 100%)"></div><div class="name">popover</div><div class="val">0 0% 100%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(222.2 47.4% 11.2%)"></div><div class="name">primary</div><div class="val">222.2 47.4% 11.2%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(210 40% 96.1%)"></div><div class="name">secondary</div><div class="val">210 40% 96.1%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(210 40% 96.1%)"></div><div class="name">muted</div><div class="val">210 40% 96.1%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(210 40% 96.1%)"></div><div class="name">accent</div><div class="val">210 40% 96.1%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(0 84.2% 60.2%)"></div><div class="name">destructive</div><div class="val">0 84.2% 60.2%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(214.3 31.8% 91.4%)"></div><div class="name">border</div><div class="val">214.3 31.8% 91.4%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(214.3 31.8% 91.4%)"></div><div class="name">input</div><div class="val">214.3 31.8% 91.4%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(222.2 84% 4.9%)"></div><div class="name">ring</div><div class="val">222.2 84% 4.9%</div></div>
+    </div>
+
+    <!-- DARK -->
+    <div class="panel panel-dark">
+      <div class="panel-head"><span class="mode-dot"></span>Dark · .dark</div>
+
+      <div class="row"><div class="swatch" style="background:hsl(222.2 84% 4.9%)"></div><div class="name">background</div><div class="val">222.2 84% 4.9%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(210 40% 98%)"></div><div class="name">foreground</div><div class="val">210 40% 98%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(222.2 84% 4.9%)"></div><div class="name">card</div><div class="val">222.2 84% 4.9%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(222.2 84% 4.9%)"></div><div class="name">popover</div><div class="val">222.2 84% 4.9%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(210 40% 98%)"></div><div class="name">primary</div><div class="val">210 40% 98%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(217.2 32.6% 17.5%)"></div><div class="name">secondary</div><div class="val">217.2 32.6% 17.5%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(217.2 32.6% 17.5%)"></div><div class="name">muted</div><div class="val">217.2 32.6% 17.5%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(217.2 32.6% 17.5%)"></div><div class="name">accent</div><div class="val">217.2 32.6% 17.5%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(0 62.8% 30.6%)"></div><div class="name">destructive</div><div class="val">0 62.8% 30.6%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(217.2 32.6% 17.5%)"></div><div class="name">border</div><div class="val">217.2 32.6% 17.5%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(217.2 32.6% 17.5%)"></div><div class="name">input</div><div class="val">217.2 32.6% 17.5%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(212.7 26.8% 83.9%)"></div><div class="name">ring</div><div class="val">212.7 26.8% 83.9%</div></div>
+    </div>
+  </div>
+
+  <p class="caption">
+    These twelve tokens are <strong>unmodified stock shadcn/ui &ldquo;slate&rdquo;</strong> — navy
+    <code>primary 222.2&nbsp;47.4%&nbsp;11.2%</code>, cool-grey <code>secondary/muted/accent 210&nbsp;40%&nbsp;96.1%</code>,
+    red <code>destructive 0&nbsp;84.2%&nbsp;60.2%</code>. The semantic layer was scaffolded from shadcn and
+    <strong>never rebranded</strong>: none of them carry MusicNerd&rsquo;s identity. The brand palette lives
+    <strong>outside</strong> these tokens as hardcoded hex — pink
+    <span class="chip" style="background:#ff9ce3"></span><code>#ff9ce3</code> /
+    <span class="chip" style="background:#ef95ff"></span><code>#ef95ff</code> /
+    <span class="chip" style="background:#edadf8"></span><code>#edadf8</code>, blue
+    <span class="chip" style="background:#2ad4fc"></span><code>#2ad4fc</code>, green
+    <span class="chip" style="background:#19ffb8"></span><code>#19ffb8</code>, maroon
+    <span class="chip" style="background:#422b46"></span><code>#422b46</code> — applied via 200+ literal uses and
+    <code>!important</code> dark overrides, not through <code>hsl(var(--token))</code>.
+  </p>
+</div>
+</body>
+</html>

--- a/design-system/components/badge.html
+++ b/design-system/components/badge.html
@@ -1,0 +1,278 @@
+<!-- @dsCard group="Components" name="Badge" subtitle="all cva variants" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  :root {
+    /* shadcn "slate" light tokens, verbatim from globals.css :root */
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --radius: 0.5rem;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    /* Reality: KoHo is declared but never loads in the app -> system sans */
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: hsl(var(--background));       /* --background 0 0% 100% */
+    color: hsl(var(--foreground));            /* --foreground 222.2 84% 4.9% */
+    padding: 40px 44px 48px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap { max-width: 760px; margin: 0 auto; }
+
+  h1 {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin: 0 0 4px;
+  }
+
+  .lede {
+    font-size: 13.5px;
+    color: hsl(var(--muted-foreground));      /* --muted-foreground 215.4 16.3% 46.9% */
+    margin: 0 0 6px;
+    max-width: 620px;
+  }
+
+  .mono {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
+
+  /* ---- the actual Badge base recipe, resolved from cva ---- */
+  /* "inline-flex items-center rounded-full border px-2.5 py-0.5
+      text-xs font-semibold transition-colors" */
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 9999px;               /* rounded-full */
+    border: 1px solid transparent;        /* border */
+    padding: 2px 10px;                    /* py-0.5 px-2.5 */
+    font-size: 12px;                      /* text-xs */
+    line-height: 16px;
+    font-weight: 600;                     /* font-semibold */
+    white-space: nowrap;
+    transition: background-color .15s, color .15s, border-color .15s;
+  }
+
+  /* variant: default -> bg-primary / text-primary-foreground / border-transparent */
+  .badge--default {
+    background: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    border-color: transparent;
+  }
+  /* variant: secondary -> bg-secondary / text-secondary-foreground / border-transparent */
+  .badge--secondary {
+    background: hsl(var(--secondary));
+    color: hsl(var(--secondary-foreground));
+    border-color: transparent;
+  }
+  /* variant: destructive -> bg-destructive / text-destructive-foreground / border-transparent */
+  .badge--destructive {
+    background: hsl(var(--destructive));
+    color: hsl(var(--destructive-foreground));
+    border-color: transparent;
+  }
+  /* variant: outline -> text-foreground only (transparent bg, default --border ring) */
+  .badge--outline {
+    background: transparent;
+    color: hsl(var(--foreground));
+    border-color: hsl(var(--border));    /* inherits base `border` -> --border */
+  }
+
+  /* ---- specimen rows ---- */
+  .rows {
+    margin-top: 26px;
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);         /* 0.5rem = 8px */
+    overflow: hidden;
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: 170px 1fr;
+    gap: 20px;
+    align-items: center;
+    padding: 20px 22px;
+    border-top: 1px solid hsl(var(--border));
+  }
+  .row:first-child { border-top: none; }
+
+  .specimen {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .vname {
+    font-size: 13px;
+    font-weight: 600;
+  }
+  .vsub {
+    display: block;
+    margin-top: 3px;
+    font-size: 11px;
+    color: hsl(var(--muted-foreground));
+  }
+
+  .tokens {
+    font-size: 11.5px;
+    color: hsl(var(--muted-foreground));
+    line-height: 1.7;
+  }
+  .tokens .k { color: hsl(var(--foreground)); }
+  .sw {
+    display: inline-block;
+    width: 9px; height: 9px;
+    border-radius: 2px;
+    vertical-align: middle;
+    margin-right: 5px;
+    border: 1px solid rgba(0,0,0,.12);
+  }
+
+  .base {
+    margin-top: 22px;
+    font-size: 11.5px;
+    color: hsl(var(--muted-foreground));
+    background: hsl(var(--secondary));
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    padding: 12px 14px;
+    line-height: 1.75;
+  }
+  .base b { color: hsl(var(--foreground)); font-weight: 600; }
+
+  .note {
+    margin-top: 16px;
+    font-size: 11.5px;
+    color: hsl(var(--muted-foreground));
+    border-left: 3px solid hsl(var(--destructive));
+    padding: 4px 0 4px 12px;
+  }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Badge</h1>
+    <p class="lede">
+      Every <span class="mono">badgeVariants</span> cva variant from
+      <span class="mono">src/components/ui/badge.tsx</span>, resolved to literal CSS
+      from the stock shadcn &ldquo;slate&rdquo; tokens. No brand pink/blue/green reaches
+      these &mdash; the semantic layer was never rebranded.
+    </p>
+
+    <div class="rows">
+
+      <!-- DEFAULT -->
+      <div class="row">
+        <div>
+          <span class="vname">default</span>
+          <span class="vsub mono">variant="default" (defaultVariant)</span>
+        </div>
+        <div>
+          <div class="specimen">
+            <span class="badge badge--default">Verified</span>
+            <span class="badge badge--default">new</span>
+            <span class="badge badge--default">2ad4fc</span>
+          </div>
+          <div class="tokens mono" style="margin-top:12px">
+            <div><span class="sw" style="background:hsl(222.2 47.4% 11.2%)"></span><span class="k">bg-primary</span> &rarr; hsl(222.2 47.4% 11.2%) &middot; #0f172a</div>
+            <div><span class="sw" style="background:hsl(210 40% 98%)"></span><span class="k">text-primary-foreground</span> &rarr; hsl(210 40% 98%) &middot; #f8fafc</div>
+            <div>border-transparent &middot; hover:bg-primary/80</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- SECONDARY -->
+      <div class="row">
+        <div>
+          <span class="vname">secondary</span>
+          <span class="vsub mono">variant="secondary"</span>
+        </div>
+        <div>
+          <div class="specimen">
+            <span class="badge badge--secondary">Draft</span>
+            <span class="badge badge--secondary">social</span>
+            <span class="badge badge--secondary">pending</span>
+          </div>
+          <div class="tokens mono" style="margin-top:12px">
+            <div><span class="sw" style="background:hsl(210 40% 96.1%)"></span><span class="k">bg-secondary</span> &rarr; hsl(210 40% 96.1%) &middot; #f1f5f9</div>
+            <div><span class="sw" style="background:hsl(222.2 47.4% 11.2%)"></span><span class="k">text-secondary-foreground</span> &rarr; hsl(222.2 47.4% 11.2%) &middot; #0f172a</div>
+            <div>border-transparent &middot; hover:bg-secondary/80</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- DESTRUCTIVE -->
+      <div class="row">
+        <div>
+          <span class="vname">destructive</span>
+          <span class="vsub mono">variant="destructive"</span>
+        </div>
+        <div>
+          <div class="specimen">
+            <span class="badge badge--destructive">Removed</span>
+            <span class="badge badge--destructive">error</span>
+            <span class="badge badge--destructive">revoked</span>
+          </div>
+          <div class="tokens mono" style="margin-top:12px">
+            <div><span class="sw" style="background:hsl(0 84.2% 60.2%)"></span><span class="k">bg-destructive</span> &rarr; hsl(0 84.2% 60.2%) &middot; #ef4444</div>
+            <div><span class="sw" style="background:hsl(210 40% 98%)"></span><span class="k">text-destructive-foreground</span> &rarr; hsl(210 40% 98%) &middot; #f8fafc</div>
+            <div>border-transparent &middot; hover:bg-destructive/80</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- OUTLINE -->
+      <div class="row">
+        <div>
+          <span class="vname">outline</span>
+          <span class="vsub mono">variant="outline"</span>
+        </div>
+        <div>
+          <div class="specimen">
+            <span class="badge badge--outline">Listen</span>
+            <span class="badge badge--outline">web3</span>
+            <span class="badge badge--outline">optional</span>
+          </div>
+          <div class="tokens mono" style="margin-top:12px">
+            <div><span class="sw" style="background:transparent"></span>bg &rarr; transparent (no bg utility)</div>
+            <div><span class="sw" style="background:hsl(222.2 84% 4.9%)"></span><span class="k">text-foreground</span> &rarr; hsl(222.2 84% 4.9%) &middot; #020817</div>
+            <div><span class="sw" style="background:hsl(214.3 31.8% 91.4%)"></span>border &rarr; base <span class="k">border</span> = hsl(214.3 31.8% 91.4%) &middot; #e2e8f0</div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <div class="base">
+      <b>Base recipe</b> (applies to all variants):
+      <span class="mono">inline-flex items-center <b>rounded-full</b> (9999px) border
+      <b>px-2.5</b> (10px) <b>py-0.5</b> (2px) <b>text-xs</b> (12/16px)
+      <b>font-semibold</b> (600) transition-colors</span>. Focus ring:
+      <span class="mono">focus:ring-2 focus:ring-ring focus:ring-offset-2</span>.
+      Note badges use full pill rounding, not <span class="mono">--radius: 0.5rem</span>.
+    </div>
+
+    <div class="note">
+      Font reality: the badge text renders in the system sans stack. KoHo is the declared
+      brand typeface but never loads in the React app, so all <span class="mono">text-xs</span>
+      badges fall back to <span class="mono">-apple-system / Segoe UI / Roboto</span>.
+    </div>
+  </div>
+</body>
+</html>

--- a/design-system/components/button.html
+++ b/design-system/components/button.html
@@ -1,0 +1,365 @@
+<!-- @dsCard group="Buttons" name="Button" subtitle="6 cva variants × 4 sizes + legacy pink-btn" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  :root {
+    /* Resolved light-mode semantic tokens (stock shadcn slate, globals.css :root) */
+    --primary: #0f172a;             /* hsl(222.2 47.4% 11.2%) */
+    --primary-foreground: #f8fafc;  /* hsl(210 40% 98%)       */
+    --destructive: #ef4444;         /* hsl(0 84.2% 60.2%)     */
+    --destructive-foreground: #f8fafc;
+    --secondary: #f1f5f9;           /* hsl(210 40% 96.1%)     */
+    --secondary-foreground: #0f172a;
+    --accent: #f1f5f9;              /* hsl(210 40% 96.1%)     */
+    --accent-foreground: #0f172a;
+    --background: #ffffff;          /* hsl(0 0% 100%)         */
+    --foreground: #020817;          /* hsl(222.2 84% 4.9%)    */
+    --input: #e2e8f0;               /* hsl(214.3 31.8% 91.4%) */
+    --ring: #020817;                /* hsl(222.2 84% 4.9%)    */
+    --md-radius: 6px;               /* rounded-md = calc(--radius[.5rem] - 2px) */
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    padding: 32px;
+    background: var(--background);
+    color: var(--foreground);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    line-height: 1.4;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap { max-width: 860px; margin: 0 auto; }
+
+  header { margin-bottom: 28px; }
+  h1 {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin: 0 0 4px;
+  }
+  .sub { font-size: 13px; color: #64748b; margin: 0 0 6px; }
+  .src {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 11px;
+    color: #94a3b8;
+  }
+
+  section { margin-top: 34px; }
+  .sec-title {
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #475569;
+    margin: 0 0 4px;
+  }
+  .sec-note {
+    font-size: 12px;
+    color: #94a3b8;
+    margin: 0 0 18px;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 16px;
+  }
+
+  .cell {
+    border: 1px solid #eef2f6;
+    border-radius: 10px;
+    padding: 18px 16px 14px;
+    background: #fbfcfd;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .cell .stage {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+  }
+  .cell .name {
+    font-size: 12px;
+    font-weight: 600;
+    color: #0f172a;
+  }
+  .cell .cap {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 10.5px;
+    line-height: 1.55;
+    color: #64748b;
+    word-break: break-word;
+  }
+  .cap .k { color: #94a3b8; }
+
+  /* ── shared cva base: real classes from button.tsx line 8 ── */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+    border-radius: var(--md-radius);       /* rounded-md */
+    font-size: 14px;                        /* text-sm    */
+    line-height: 20px;
+    font-weight: 500;                       /* font-medium */
+    /* font-sans → system stack (KoHo never loads); see note */
+    font-family: inherit;
+    transition: background-color .15s, color .15s;
+    cursor: pointer;
+    border: 1px solid transparent;
+    /* default size: h-10 px-4 py-2 */
+    height: 40px;
+    padding: 8px 16px;
+  }
+  .btn:focus-visible {                      /* focus-visible:ring-2 ring-ring ring-offset-2 */
+    outline: none;
+    box-shadow: 0 0 0 2px var(--background), 0 0 0 4px var(--ring);
+  }
+
+  /* ── variants (resolved) ── */
+  .v-default {
+    background: var(--primary);
+    color: var(--primary-foreground);
+    /* NB: no hover — stock hover:bg-primary/90 was removed */
+  }
+  .v-destructive {
+    background: var(--destructive);
+    color: var(--destructive-foreground);
+  }
+  .v-destructive:hover { background: #f15656; } /* destructive/90 over white */
+  .v-outline {
+    border-color: var(--input);
+    background: var(--background);
+    color: var(--foreground);
+  }
+  .v-outline:hover { background: var(--accent); color: var(--accent-foreground); }
+  .v-secondary {
+    background: var(--secondary);
+    color: var(--secondary-foreground);
+  }
+  .v-secondary:hover { background: #e8eef4; }   /* secondary/80 over white */
+  .v-ghost {
+    background: transparent;
+    color: var(--foreground);
+  }
+  .v-ghost:hover { background: var(--accent); color: var(--accent-foreground); }
+  .v-link {
+    background: transparent;
+    color: var(--primary);
+    text-underline-offset: 4px;
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .v-link:hover { text-decoration: underline; }
+
+  /* ── size scale (default variant) ── */
+  .s-sm    { height: 36px; padding: 0 12px; }   /* h-9  px-3 */
+  .s-lg    { height: 48px; padding: 0 32px; }   /* h-12 px-8 */
+  .s-icon  { height: 40px; width: 40px; padding: 0; }  /* h-10 w-10 */
+
+  .row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 18px;
+  }
+  .sizecell { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+  .sizecell .lab {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 11px;
+    color: #64748b;
+    text-align: center;
+  }
+  .sizecell .lab b { color: #0f172a; font-weight: 600; }
+
+  /* ── legacy pink-btn (globals.css:584) ── */
+  .pink-btn {
+    background-color: #EDADF8;
+    color: #422B46;
+    /* font-family: "KoHo" declared → falls back to system sans (never loads) */
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    border-radius: 5px;                     /* off-scale, not from --radius */
+    padding: 5px 30px;
+    font-size: 18px;
+    border: none;
+    cursor: pointer;
+    line-height: 1.4;
+  }
+  .legacy {
+    border: 1px solid #f0dbf5;
+    background: #fdf7ff;
+    border-radius: 10px;
+    padding: 20px 18px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    max-width: 420px;
+  }
+  .tag {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #7c3a86;
+    background: #f6e4fb;
+    border-radius: 999px;
+    padding: 3px 9px;
+    align-self: flex-start;
+  }
+
+  .notes {
+    margin-top: 36px;
+    border-top: 1px solid #eef2f6;
+    padding-top: 16px;
+  }
+  .notes ul { margin: 0; padding-left: 18px; }
+  .notes li { font-size: 12px; color: #64748b; margin-bottom: 6px; }
+  .notes code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 11px;
+    background: #f1f5f9;
+    padding: 1px 5px;
+    border-radius: 4px;
+    color: #334155;
+  }
+  .swatch {
+    display: inline-block;
+    width: 9px; height: 9px;
+    border-radius: 2px;
+    vertical-align: middle;
+    margin-right: 3px;
+    border: 1px solid rgba(0,0,0,.08);
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>Button</h1>
+    <p class="sub">6 cva variants × 4 sizes + legacy pink-btn — <code style="font-family:ui-monospace,monospace;font-size:12px">buttonVariants</code> resolved to literal CSS from stock shadcn slate tokens.</p>
+    <p class="src">src/components/ui/button.tsx&nbsp;·&nbsp;globals.css :root / .pink-btn</p>
+  </header>
+
+  <!-- ── VARIANTS ── -->
+  <section>
+    <p class="sec-title">6 cva variants</p>
+    <p class="sec-note">Default size (h-10 px-4 py-2), rounded-md 6px, text-sm/font-medium. Rendered on white <span style="font-family:ui-monospace,monospace">--background</span>.</p>
+    <div class="grid">
+
+      <div class="cell">
+        <div class="stage"><button class="btn v-default">Default</button></div>
+        <div class="name">default</div>
+        <div class="cap"><span class="k">bg</span> bg-primary <span class="swatch" style="background:#0f172a"></span>#0f172a<br>
+        <span class="k">text</span> primary-foreground <span class="swatch" style="background:#f8fafc"></span>#f8fafc<br>
+        <span class="k">hover</span> none <span style="color:#b45309">(stock hover removed)</span></div>
+      </div>
+
+      <div class="cell">
+        <div class="stage"><button class="btn v-destructive">Destructive</button></div>
+        <div class="name">destructive</div>
+        <div class="cap"><span class="k">bg</span> bg-destructive <span class="swatch" style="background:#ef4444"></span>#ef4444<br>
+        <span class="k">text</span> destructive-foreground <span class="swatch" style="background:#f8fafc"></span>#f8fafc<br>
+        <span class="k">hover</span> bg-destructive/90</div>
+      </div>
+
+      <div class="cell">
+        <div class="stage"><button class="btn v-outline">Outline</button></div>
+        <div class="name">outline</div>
+        <div class="cap"><span class="k">bd</span> border-input <span class="swatch" style="background:#e2e8f0"></span>#e2e8f0<br>
+        <span class="k">bg</span> background <span class="swatch" style="background:#ffffff"></span>#ffffff · <span class="k">text</span> #020817<br>
+        <span class="k">hover</span> bg-accent <span class="swatch" style="background:#f1f5f9"></span>#f1f5f9</div>
+      </div>
+
+      <div class="cell">
+        <div class="stage"><button class="btn v-secondary">Secondary</button></div>
+        <div class="name">secondary</div>
+        <div class="cap"><span class="k">bg</span> bg-secondary <span class="swatch" style="background:#f1f5f9"></span>#f1f5f9<br>
+        <span class="k">text</span> secondary-foreground <span class="swatch" style="background:#0f172a"></span>#0f172a<br>
+        <span class="k">hover</span> bg-secondary/80</div>
+      </div>
+
+      <div class="cell">
+        <div class="stage"><button class="btn v-ghost">Ghost</button></div>
+        <div class="name">ghost</div>
+        <div class="cap"><span class="k">bg</span> transparent · <span class="k">text</span> #020817<br>
+        <span class="k">hover</span> bg-accent <span class="swatch" style="background:#f1f5f9"></span>#f1f5f9 + accent-foreground</div>
+      </div>
+
+      <div class="cell">
+        <div class="stage"><button class="btn v-link">Link</button></div>
+        <div class="name">link</div>
+        <div class="cap"><span class="k">text</span> text-primary <span class="swatch" style="background:#0f172a"></span>#0f172a<br>
+        underline-offset-4 · <span class="k">hover</span> underline</div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ── SIZES ── -->
+  <section>
+    <p class="sec-title">Size scale — default variant</p>
+    <p class="sec-note">Heights h-9 / h-10 / h-12 = 36 / 40 / 48px; icon is a 40×40 square.</p>
+    <div class="row">
+
+      <div class="sizecell">
+        <button class="btn v-default s-sm">Small</button>
+        <div class="lab"><b>sm</b><br>h-9 px-3<br>36px</div>
+      </div>
+
+      <div class="sizecell">
+        <button class="btn v-default">Default</button>
+        <div class="lab"><b>default</b><br>h-10 px-4 py-2<br>40px</div>
+      </div>
+
+      <div class="sizecell">
+        <button class="btn v-default s-lg">Large</button>
+        <div class="lab"><b>lg</b><br>h-12 px-8<br>48px</div>
+      </div>
+
+      <div class="sizecell">
+        <button class="btn v-default s-icon" aria-label="icon">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
+        </button>
+        <div class="lab"><b>icon</b><br>h-10 w-10<br>40×40</div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ── LEGACY ── -->
+  <section>
+    <p class="sec-title">Legacy · .pink-btn</p>
+    <p class="sec-note">Pre-shadcn global class (the "Log In" button, <span style="font-family:ui-monospace,monospace">LoginBtn</span>). One of three parallel button systems still in the tree.</p>
+    <div class="legacy">
+      <span class="tag">older button system</span>
+      <div><button class="pink-btn">Log In</button></div>
+      <div class="cap" style="font-size:11px">
+        <span class="k">bg</span> <span class="swatch" style="background:#EDADF8"></span>#EDADF8 (third brand pink) ·
+        <span class="k">text</span> <span class="swatch" style="background:#422B46"></span>#422B46 maroon<br>
+        <span class="k">radius</span> 5px (off-scale, not from --radius) ·
+        <span class="k">size</span> 18px · <span class="k">pad</span> 5px 30px<br>
+        <span class="k">font</span> "KoHo" declared → <b>falls back to system sans</b> (KoHo never loads)
+      </div>
+    </div>
+  </section>
+
+  <!-- ── HONEST NOTES ── -->
+  <div class="notes">
+    <ul>
+      <li><b>Reality vs intent — font:</b> all buttons declare <code>font-sans</code> / <code>"KoHo"</code>, but KoHo is never loaded (no <code>next/font</code>, no <code>@font-face</code>), so every specimen here renders in the <b>system sans stack</b> — which is what ships.</li>
+      <li><b>Deviation — no hover on <code>default</code>:</b> stock shadcn ships <code>hover:bg-primary/90</code>; it was removed in <code>button.tsx:12</code>, so the primary button has no hover feedback. Every other variant keeps its hover.</li>
+      <li><b>Semantic layer is 100% stock slate:</b> <code>--primary/--secondary/--accent/--destructive</code> are unmodified shadcn values in both <code>:root</code> and <code>.dark</code> — brand color (maroon/pastypink/pastyblue) never reaches these tokens.</li>
+      <li><b>Three parallel button systems:</b> this cva <code>Button</code>, the legacy <code>.pink-btn</code>, and a hand-rolled <code>ThemeToggle</code> <code>&lt;button&gt;</code>.</li>
+    </ul>
+  </div>
+</div>
+</body>
+</html>

--- a/design-system/components/card.html
+++ b/design-system/components/card.html
@@ -1,0 +1,341 @@
+<!-- @dsCard group="Components" name="Card" subtitle="header/content/footer + glass variant" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root {
+    /* ---- resolved shadcn "slate" tokens (globals.css :root) ---- */
+    --background: hsl(0, 0%, 100%);
+    --card: hsl(0, 0%, 100%);
+    --card-foreground: hsl(222.2, 84%, 4.9%);
+    --muted-foreground: hsl(215.4, 16.3%, 46.9%);
+    --border: hsl(214.3, 31.8%, 91.4%);
+    --primary: hsl(222.2, 47.4%, 11.2%);
+    --primary-foreground: hsl(210, 40%, 98%);
+    --radius: 0.5rem; /* 8px, not overridden in .dark */
+    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    --sys: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
+
+  * { box-sizing: border-box; }
+
+  html, body { margin: 0; }
+
+  body {
+    background: var(--background);
+    color: var(--card-foreground);
+    font-family: var(--sys);
+    -webkit-font-smoothing: antialiased;
+    padding: 40px 32px 56px;
+  }
+
+  .wrap { max-width: 860px; margin: 0 auto; }
+
+  .doc-title {
+    font-size: 22px;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    margin: 0 0 6px;
+  }
+  .doc-sub {
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--muted-foreground);
+    margin: 0 0 32px;
+    max-width: 620px;
+  }
+  .doc-sub code { font-family: var(--mono); font-size: 12.5px; }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 28px;
+    align-items: start;
+  }
+
+  .specimen { min-width: 0; }
+  .specimen-label {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    margin: 0 0 10px;
+  }
+  .specimen-label .badge {
+    font-family: var(--mono);
+    font-weight: 500;
+    font-size: 10.5px;
+    color: var(--muted-foreground);
+    margin-left: 8px;
+  }
+
+  /* ---- a "stage" so each specimen's surface reads ---- */
+  .stage {
+    border-radius: 14px;
+    padding: 34px 30px;
+  }
+  .stage--neutral { background: #f1f5f9; } /* slate-100, so shadow-sm reads */
+  .stage--candy {
+    position: relative;
+    overflow: hidden;
+    background:
+      linear-gradient(135deg, #ff9ce3 0%, #2ad4fc 55%, #19ffb8 100%);
+  }
+  /* blurred brand blobs behind the glass so blur(20px) is visible */
+  .stage--candy::before,
+  .stage--candy::after {
+    content: "";
+    position: absolute;
+    border-radius: 9999px;
+    filter: blur(2px);
+  }
+  .stage--candy::before {
+    width: 150px; height: 150px;
+    background: #ef95ff;
+    top: -30px; left: -20px;
+  }
+  .stage--candy::after {
+    width: 120px; height: 120px;
+    background: #19ffb8;
+    bottom: -24px; right: 10px;
+  }
+
+  /* ============================================================
+     STANDARD CARD  — card.tsx, resolved literally
+     rounded-lg border bg-card text-card-foreground shadow-sm
+     ============================================================ */
+  .card {
+    position: relative;
+    background: var(--card);
+    color: var(--card-foreground);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);      /* 8px */
+    box-shadow: var(--shadow-sm);
+  }
+  .card__header { display: flex; flex-direction: column; gap: 6px; padding: 24px; }  /* space-y-1.5 p-6 */
+  .card__title {
+    font-size: 24px;                   /* text-2xl */
+    line-height: 1;                    /* leading-none */
+    font-weight: 600;                  /* font-semibold */
+    letter-spacing: -0.025em;          /* tracking-tight */
+    margin: 0;
+  }
+  .card__desc {
+    font-size: 14px;                   /* text-sm */
+    line-height: 1.35;
+    color: var(--muted-foreground);
+    margin: 0;
+  }
+  .card__content { padding: 0 24px 24px; }   /* p-6 pt-0 */
+  .card__footer { display: flex; align-items: center; padding: 0 24px 24px; }
+
+  .meta-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 14px;
+  }
+  .pill {
+    font-size: 12px;
+    line-height: 1;
+    padding: 6px 10px;
+    border-radius: 9999px;             /* genre pills use rounded-full */
+    background: hsl(210, 40%, 96.1%);  /* --secondary */
+    color: hsl(222.2, 47.4%, 11.2%);   /* --secondary-foreground */
+  }
+  .stat-line {
+    font-size: 13px;
+    line-height: 1.55;
+    color: var(--muted-foreground);
+  }
+  .stat-line strong { color: var(--card-foreground); font-weight: 600; }
+
+  /* shadcn default Button: bg-primary rounded-md h-10 px-4 text-sm font-medium */
+  .btn-primary {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    height: 40px;
+    padding: 0 16px;
+    border: 0;
+    border-radius: calc(var(--radius) - 2px); /* rounded-md, 6px */
+    background: var(--primary);
+    color: var(--primary-foreground);
+    font-family: var(--sys);
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+  }
+  .btn-primary svg { width: 15px; height: 15px; }
+
+  /* ============================================================
+     GLASS CARD  — .glass recipe from globals.css (off-token)
+     ============================================================ */
+  .glass {
+    position: relative;
+    background: rgba(255, 255, 255, 0.55);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    backdrop-filter: blur(20px) saturate(180%);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 1rem;               /* 16px — hardcoded, NOT from --radius */
+    padding: 20px;                     /* the app's real panel: glass p-4/p-5 */
+    color: #1e1024;
+  }
+  .glass__title {
+    font-size: 24px;
+    line-height: 1;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin: 0 0 6px;
+    color: #2a1330;
+  }
+  .glass__desc {
+    font-size: 14px;
+    line-height: 1.4;
+    margin: 0 0 14px;
+    color: rgba(66, 43, 70, 0.75);     /* maroon #422b46 at ~75% */
+  }
+  .glass .meta-row { margin-bottom: 16px; }
+  .glass .pill {
+    background: rgba(255, 255, 255, 0.55);
+    color: #422b46;                    /* maroon */
+    border: 1px solid rgba(255, 255, 255, 0.6);
+  }
+
+  /* .pink-btn from globals.css (third brand pink, KoHo never loads) */
+  .pink-btn {
+    display: inline-block;
+    background-color: #EDADF8;
+    color: #422B46;                    /* maroon */
+    font-family: "KoHo", var(--sys);   /* KoHo declared; falls back to system */
+    border: 0;
+    border-radius: 5px;                /* off-scale */
+    padding: 5px 30px;
+    font-size: 18px;
+    cursor: pointer;
+  }
+
+  /* ---- shared value captions ---- */
+  .notes {
+    margin-top: 12px;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 4px;
+  }
+  .notes li {
+    font-family: var(--mono);
+    font-size: 11px;
+    line-height: 1.45;
+    color: var(--muted-foreground);
+  }
+  .notes b { color: var(--card-foreground); font-weight: 600; }
+
+  .footnote {
+    margin-top: 34px;
+    padding-top: 18px;
+    border-top: 1px solid var(--border);
+    font-size: 12.5px;
+    line-height: 1.6;
+    color: var(--muted-foreground);
+  }
+  .footnote code { font-family: var(--mono); font-size: 11.5px; color: var(--card-foreground); }
+  .footnote strong { color: var(--card-foreground); font-weight: 600; }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <h1 class="doc-title">Card</h1>
+    <p class="doc-sub">
+      Two card-like surfaces coexist in MusicNerdWeb. Left: the stock shadcn
+      <code>Card</code> primitive (<code>card.tsx</code>) — an opaque slate token
+      surface. Right: the brand's real workhorse, the off-token <code>.glass</code>
+      panel used across 13+ artist-page components. Every class below is resolved
+      to the literal CSS it compiles to.
+    </p>
+
+    <div class="grid">
+      <!-- ===================== STANDARD CARD ===================== -->
+      <div class="specimen">
+        <p class="specimen-label">Standard Card<span class="badge">card.tsx</span></p>
+        <div class="stage stage--neutral">
+          <div class="card">
+            <div class="card__header">
+              <h3 class="card__title">Phoebe Bridgers</h3>
+              <p class="card__desc">Indie &middot; Singer-songwriter &middot; Los Angeles</p>
+            </div>
+            <div class="card__content">
+              <div class="meta-row">
+                <span class="pill">indie</span>
+                <span class="pill">folk</span>
+                <span class="pill">emo</span>
+              </div>
+              <p class="stat-line">
+                <strong>14</strong> platform links &middot;
+                added by <strong>@clt</strong><br>
+                4.2M monthly listeners on Spotify
+              </p>
+            </div>
+            <div class="card__footer">
+              <button class="btn-primary">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+                View artist
+              </button>
+            </div>
+          </div>
+        </div>
+        <ul class="notes">
+          <li><b>radius</b> rounded-lg = var(--radius) = 8px</li>
+          <li><b>border</b> hsl(214.3 31.8% 91.4%)</li>
+          <li><b>bg-card</b> hsl(0 0% 100%) &middot; opaque</li>
+          <li><b>shadow-sm</b> 0 1px 2px 0 rgb(0 0 0/.05)</li>
+          <li><b>header / content / footer</b> p-6 = 24px</li>
+          <li><b>title</b> text-2xl/600, leading-none, tracking-tight</li>
+        </ul>
+      </div>
+
+      <!-- ===================== GLASS CARD ===================== -->
+      <div class="specimen">
+        <p class="specimen-label">Glass variant<span class="badge">.glass (globals.css)</span></p>
+        <div class="stage stage--candy">
+          <div class="glass">
+            <h3 class="glass__title">Jamie xx</h3>
+            <p class="glass__desc">Electronic &middot; Producer &middot; London</p>
+            <div class="meta-row">
+              <span class="pill">house</span>
+              <span class="pill">uk garage</span>
+            </div>
+            <p class="stat-line" style="color:rgba(66,43,70,.72);margin-bottom:16px;">
+              9 platform links &middot; last edited 2d ago
+            </p>
+            <button class="pink-btn">Support artist</button>
+          </div>
+        </div>
+        <ul class="notes">
+          <li><b>bg</b> rgba(255,255,255,0.55) &middot; translucent</li>
+          <li><b>filter</b> blur(20px) saturate(180%)</li>
+          <li><b>border</b> 1px rgba(255,255,255,0.3)</li>
+          <li><b>radius</b> 1rem = 16px &middot; hardcoded, not --radius</li>
+          <li><b>padding</b> real usage: glass p-4/p-5 (16&ndash;20px)</li>
+          <li><b>.pink-btn</b> #EDADF8 on #422B46, radius 5px</li>
+        </ul>
+      </div>
+    </div>
+
+    <p class="footnote">
+      <strong>Reality notes.</strong>
+      The app mostly reaches for <code>.glass</code> panels, not the stock
+      <code>Card</code> — so <strong>two padding conventions coexist</strong>
+      (Card's rigid <code>p-6</code> vs. glass <code>p-4/p-5</code>) and two radii
+      (<code>8px</code> token vs. glass <code>16px</code> literal).
+      The <code>.pink-btn</code> declares <code>font-family:"KoHo"</code>, but
+      KoHo is never actually loaded in the app, so all text here renders in the
+      real system sans stack (<code>-apple-system, "Segoe UI", Roboto</code>) —
+      shown faithfully. Semantic colors are unmodified shadcn "slate";
+      the brand's candy-neon pink/blue/green live outside the tokens as hex literals.
+    </p>
+  </div>
+</body>
+</html>

--- a/design-system/components/form-controls.html
+++ b/design-system/components/form-controls.html
@@ -1,0 +1,372 @@
+<!-- @dsCard group="Forms" name="Form controls" subtitle="input · textarea · select · checkbox · label" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Form controls</title>
+<style>
+  /* ---- Resolved design tokens (from src/app/globals.css :root / .dark) ---- */
+  :root{
+    /* LIGHT — stock shadcn "slate" */
+    --background:      hsl(0 0% 100%);         /* #ffffff */
+    --foreground:      hsl(222.2 84% 4.9%);    /* #020817 */
+    --muted:           hsl(210 40% 96.1%);     /* #f1f5f9 */
+    --muted-foreground:hsl(215.4 16.3% 46.9%); /* #64748b */
+    --input:           hsl(214.3 31.8% 91.4%); /* #e2e8f0 */
+    --ring:            hsl(222.2 84% 4.9%);    /* #020817 */
+    --primary:         hsl(222.2 47.4% 11.2%); /* #0f172a */
+    --radius: 0.5rem;                          /* 8px  */
+    --radius-md: calc(var(--radius) - 2px);    /* 6px  → rounded-md */
+    --radius-sm: calc(var(--radius) - 4px);    /* 4px  → rounded-sm */
+    --checked: #ff9ce3;                        /* light checkbox accent */
+  }
+  /* DARK surface tokens, used only inside .dark-surface below */
+  .dark-surface{
+    --background:      hsl(222.2 84% 4.9%);    /* #020817 */
+    --foreground:      hsl(210 40% 98%);       /* #f8fafc */
+    --muted:           hsl(217.2 32.6% 17.5%); /* #1e293b */
+    --muted-foreground:hsl(215 20.2% 65.1%);   /* #94a3b8 */
+    --input:           hsl(217.2 32.6% 17.5%); /* #1e293b */
+    --ring:            hsl(212.7 26.8% 83.9%); /* #cbd5e1 */
+    --primary:         hsl(210 40% 98%);       /* #f8fafc */
+    --checked: #2ad4fc;                        /* dark checkbox accent */
+  }
+
+  *{ box-sizing:border-box; }
+  html,body{ margin:0; }
+  body{
+    background:#ffffff;
+    color:var(--foreground);
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+    line-height:1.5;
+    -webkit-font-smoothing:antialiased;
+    padding:32px 28px 40px;
+  }
+  .wrap{ max-width:920px; margin:0 auto; }
+
+  h1{ font-size:22px; font-weight:650; letter-spacing:-0.02em; margin:0 0 2px; }
+  .sub{ font-size:13px; color:var(--muted-foreground); margin:0 0 4px;
+        font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
+  .lead{ font-size:13px; color:var(--muted-foreground); margin:10px 0 26px; max-width:640px; }
+
+  .grid{ display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); gap:18px; }
+
+  .card{
+    border:1px solid var(--input);
+    border-radius:12px;
+    background:#ffffff;
+    padding:18px 18px 16px;
+    display:flex; flex-direction:column; gap:14px;
+  }
+  .card.span2{ grid-column:1 / -1; }
+  .card-h{ display:flex; align-items:baseline; justify-content:space-between; gap:10px; flex-wrap:wrap; }
+  .card-h .name{ font-size:14px; font-weight:650; letter-spacing:-0.01em; }
+  .card-h .file{ font-size:11px; color:var(--muted-foreground);
+                 font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
+
+  .row{ display:flex; flex-direction:column; gap:6px; }
+  .row-label{ display:flex; align-items:center; gap:8px; }
+  .state{ font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:0.06em;
+          color:var(--muted-foreground); }
+  .mono{ font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; font-size:11px;
+         color:var(--muted-foreground); }
+  .mono b{ color:var(--foreground); font-weight:600; }
+
+  /* ------------------------------------------------------------------ */
+  /*  Real primitives — every class resolved to literal token values     */
+  /* ------------------------------------------------------------------ */
+
+  /* Label — text-sm font-medium leading-none */
+  .ui-label{ font-size:14px; font-weight:500; line-height:1; color:var(--foreground); }
+
+  /* Input, form-restyled (border-input + h-10 + focus ring the primitive omits) */
+  .ui-input{
+    display:flex; width:100%; height:40px;              /* h-10 */
+    border:1px solid var(--input);                       /* border border-input */
+    border-radius:var(--radius-md);                      /* rounded-md 6px */
+    background:var(--background);                         /* bg-background */
+    padding:8px 12px;                                    /* px-3 py-2 */
+    font:inherit; font-size:16px;                        /* text-base */
+    color:var(--foreground);
+    outline:none;
+  }
+  .ui-input::placeholder{ color:var(--muted-foreground); }/* placeholder:text-muted-foreground */
+  .ui-input.is-focused{
+    /* ring-offset-background(2) + focus-visible:ring-2 ring-ring */
+    box-shadow:0 0 0 2px var(--background), 0 0 0 4px var(--ring);
+  }
+  .ui-input.is-disabled{ opacity:.5; cursor:not-allowed; }/* disabled:opacity-50 */
+
+  /* Input primitive AS-IS — stripped: no border, no height, no ring */
+  .ui-input-bare{
+    display:flex; width:100%;
+    border:0;
+    border-radius:var(--radius-md);
+    background:var(--background);
+    padding:8px 12px;
+    font:inherit; font-size:16px; color:var(--foreground);
+    outline:none;
+  }
+  .ui-input-bare::placeholder{ color:var(--muted-foreground); }
+  .bare-field{ background:var(--muted); border-radius:var(--radius-md); }
+
+  /* Textarea — min-h-[50px] border-input, focus ring is MISSING in source */
+  .ui-textarea{
+    display:block; width:100%; min-height:50px;          /* min-h-[50px] */
+    border:1px solid var(--input);
+    border-radius:var(--radius-md);
+    background:var(--background);
+    padding:8px 12px;
+    font:inherit; font-size:14px;                        /* md:text-sm */
+    color:var(--foreground);
+    resize:none; outline:none;
+  }
+  .ui-textarea::placeholder{ color:var(--muted-foreground); }
+
+  /* Select trigger — h-10 border-input, focus:ring-2 (this one DOES ring) */
+  .ui-select{
+    display:flex; align-items:center; justify-content:space-between;
+    width:100%; height:40px;                             /* h-10 */
+    border:1px solid var(--input);
+    border-radius:var(--radius-md);
+    background:var(--background);
+    padding:8px 12px;
+    font:inherit; font-size:14px;                        /* text-sm */
+    color:var(--foreground);
+    outline:none;
+  }
+  .ui-select.is-focused{ box-shadow:0 0 0 2px var(--background), 0 0 0 4px var(--ring); }
+  .ui-select svg{ width:16px; height:16px; opacity:.5; }  /* ChevronDown h-4 w-4 opacity-50 */
+
+  /* Checkbox — h-4 w-4 rounded-sm border border-primary */
+  .ui-check{
+    display:inline-flex; align-items:center; justify-content:center;
+    width:16px; height:16px;                             /* h-4 w-4 */
+    border:1px solid var(--primary);                     /* border-primary */
+    border-radius:var(--radius-sm);                      /* rounded-sm 4px */
+    background:var(--background);
+    flex:0 0 auto;
+  }
+  .ui-check svg{ width:14px; height:14px; color:#fff; display:none; }
+  .ui-check.checked{
+    background:var(--checked);                            /* [data-state=checked] */
+    border-color:var(--checked);
+  }
+  .ui-check.checked svg{ display:block; }
+  .check-line{ display:flex; align-items:center; gap:10px; }
+  .check-line span{ font-size:14px; }
+
+  /* dark surface panel */
+  .dark-surface{
+    background:var(--background);
+    border:1px solid var(--input);
+    border-radius:10px;
+    padding:16px;
+    color:var(--foreground);
+    display:flex; flex-direction:column; gap:14px;
+  }
+  .dark-surface .ui-label{ color:var(--foreground); }
+  .dark-surface .mono{ color:var(--muted-foreground); }
+  .dark-surface .mono b{ color:var(--foreground); }
+  .dark-surface .state{ color:var(--muted-foreground); }
+
+  .swatchrow{ display:flex; flex-wrap:wrap; gap:10px; margin-top:2px; }
+  .chip{ display:flex; align-items:center; gap:7px; font-size:11px;
+         font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; color:var(--muted-foreground); }
+  .chip i{ width:13px; height:13px; border-radius:3px; display:inline-block;
+           border:1px solid rgba(0,0,0,.12); }
+
+  .note{ font-size:12px; color:var(--muted-foreground);
+         border-left:2px solid var(--input); padding:2px 0 2px 12px; margin-top:2px; }
+  .note b{ color:var(--foreground); font-weight:600; }
+  .warn{ color:#b45309; }
+
+  .legend{ display:flex; flex-wrap:wrap; gap:14px 22px; margin:26px 0 0;
+           padding-top:18px; border-top:1px solid var(--input); }
+  .legend .chip i{ width:14px; height:14px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Form controls</h1>
+  <p class="sub">input · textarea · select · checkbox · label</p>
+  <p class="lead">
+    Primitives from <b style="font-family:inherit">src/components/ui/</b>, resolved to literal CSS.
+    Border = <code style="font-family:ui-monospace,monospace">--input</code>, focus ring =
+    <code style="font-family:ui-monospace,monospace">--ring</code>, radius from
+    <code style="font-family:ui-monospace,monospace">--radius: 0.5rem</code>. Semantic tokens are
+    stock shadcn <b style="font-family:inherit">slate</b> — brand color never reaches this layer.
+  </p>
+
+  <div class="grid">
+
+    <!-- LABEL + INPUT -->
+    <div class="card">
+      <div class="card-h">
+        <span class="name">Label + Input</span>
+        <span class="file">label.tsx · input.tsx</span>
+      </div>
+
+      <div class="row">
+        <label class="ui-label" for="a">Email address</label>
+        <div class="row-label"><span class="state">default</span></div>
+        <input id="a" class="ui-input" placeholder="you@example.com">
+      </div>
+      <div class="mono">
+        Label <b>text-sm 14px · font-medium 500 · leading-none</b><br>
+        Input restyled: border <b>--input #e2e8f0</b> · h-10 <b>40px</b> · rounded-md <b>6px</b> · text-base <b>16px</b>
+      </div>
+
+      <div class="row">
+        <div class="row-label"><span class="state">focused</span></div>
+        <input class="ui-input is-focused" value="you@example.com">
+      </div>
+      <div class="mono">Ring <b>0 0 0 2px --background</b> + <b>0 0 0 4px --ring #020817</b> &nbsp;(ring-offset-2 + ring-2)</div>
+
+      <div class="row">
+        <div class="row-label"><span class="state">disabled</span></div>
+        <input class="ui-input is-disabled" placeholder="you@example.com" disabled>
+      </div>
+      <div class="mono">disabled:opacity-50 &nbsp;→&nbsp; <b>opacity: .5</b></div>
+    </div>
+
+    <!-- INPUT PRIMITIVE AS-IS -->
+    <div class="card">
+      <div class="card-h">
+        <span class="name">Input — the primitive as-is</span>
+        <span class="file">input.tsx</span>
+      </div>
+      <div class="row">
+        <div class="row-label"><span class="state">stripped</span></div>
+        <div class="bare-field">
+          <input class="ui-input-bare" placeholder="search…">
+        </div>
+      </div>
+      <p class="note">
+        The real <b>Input</b> is heavily stripped: <b>no <code style="font-family:ui-monospace,monospace">border border-input</code></b>,
+        no fixed height, and <b class="warn">no <code style="font-family:ui-monospace,monospace">focus-visible</code> ring</b> — so it renders
+        borderless with no focus affordance (shown on a <code style="font-family:ui-monospace,monospace">--muted</code> field so the box is visible).
+        It also uses <code style="font-family:ui-monospace,monospace">text-base</code> where stock shadcn uses <code style="font-family:ui-monospace,monospace">text-sm</code>.
+        Every form must re-add chrome via <code style="font-family:ui-monospace,monospace">className</code> — that's the restyled input on the left.
+      </p>
+    </div>
+
+    <!-- TEXTAREA -->
+    <div class="card">
+      <div class="card-h">
+        <span class="name">Textarea</span>
+        <span class="file">textarea.tsx</span>
+      </div>
+      <div class="row">
+        <div class="row-label"><span class="state">default</span></div>
+        <textarea class="ui-textarea" placeholder="Add context for this artist…" rows="3"></textarea>
+      </div>
+      <div class="mono">
+        min-h-[50px] <b>50px</b> · border <b>--input #e2e8f0</b> · rounded-md <b>6px</b> · md:text-sm <b>14px</b>
+      </div>
+      <p class="note">
+        <b class="warn">Focus ring never renders:</b> the source has <code style="font-family:ui-monospace,monospace">ring-ring</code>
+        + <code style="font-family:ui-monospace,monospace">ring-offset-2</code> but is <b>missing <code style="font-family:ui-monospace,monospace">focus-visible:ring-2</code></b>
+        (no ring width). Unlike Select/Button, it stays un-ringed on focus.
+      </p>
+    </div>
+
+    <!-- SELECT -->
+    <div class="card">
+      <div class="card-h">
+        <span class="name">Select — trigger</span>
+        <span class="file">select.tsx</span>
+      </div>
+      <div class="row">
+        <div class="row-label"><span class="state">default</span></div>
+        <button class="ui-select" type="button">
+          <span>Sort by contributions</span>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+        </button>
+      </div>
+      <div class="row">
+        <div class="row-label"><span class="state">focused</span></div>
+        <button class="ui-select is-focused" type="button">
+          <span>Sort by contributions</span>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+        </button>
+      </div>
+      <div class="mono">
+        h-10 <b>40px</b> · border <b>--input</b> · text-sm <b>14px</b> · ChevronDown <b>16px opacity-.5</b><br>
+        focus:ring-2 ring-ring <b>--ring #020817</b> &nbsp;(this one <b>does</b> ring)
+      </div>
+    </div>
+
+    <!-- CHECKBOX -->
+    <div class="card span2">
+      <div class="card-h">
+        <span class="name">Checkbox</span>
+        <span class="file">checkbox.tsx · globals.css [data-state=checked]</span>
+      </div>
+
+      <div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:16px; align-items:start;">
+        <!-- light -->
+        <div class="row">
+          <span class="state">light theme</span>
+          <div class="check-line">
+            <span class="ui-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span>
+            <span>Unchecked</span>
+          </div>
+          <div class="check-line">
+            <span class="ui-check checked"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span>
+            <span>Checked</span>
+          </div>
+          <div class="mono">
+            h-4 w-4 <b>16px</b> · rounded-sm <b>4px</b><br>
+            border <b>--primary #0f172a</b><br>
+            checked fill <b style="color:#d81b9b">#ff9ce3</b> · check <b>#fff</b>
+          </div>
+        </div>
+
+        <!-- dark -->
+        <div class="dark-surface">
+          <span class="state">dark theme</span>
+          <div class="check-line">
+            <span class="ui-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span>
+            <span>Unchecked</span>
+          </div>
+          <div class="check-line">
+            <span class="ui-check checked"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span>
+            <span>Checked</span>
+          </div>
+          <div class="mono">
+            border <b>--primary #f8fafc</b><br>
+            checked fill <b style="color:#2ad4fc">#2ad4fc</b> · check <b>#fff</b>
+          </div>
+        </div>
+      </div>
+
+      <p class="note">
+        <b>Light → dark accent swap.</b> The checked box is <b style="color:#d81b9b">pink #ff9ce3</b> in light and
+        <b style="color:#0891b2">cyan #2ad4fc</b> in dark — hardcoded in <code style="font-family:ui-monospace,monospace">globals.css</code>
+        as <code style="font-family:ui-monospace,monospace">[data-state="checked"]</code> overrides, <b>not</b> from the semantic
+        <code style="font-family:ui-monospace,monospace">--primary</code> token (which stays slate). The unchecked border still
+        follows <code style="font-family:ui-monospace,monospace">--primary</code>. #ff9ce3 is the real on-screen pink (57 uses); it isn't in any palette.
+      </p>
+    </div>
+
+  </div>
+
+  <div class="legend">
+    <div class="chip"><i style="background:#e2e8f0"></i> --input <b style="color:#020817;font-weight:600">#e2e8f0</b> / dark #1e293b</div>
+    <div class="chip"><i style="background:#020817"></i> --ring <b style="color:#020817;font-weight:600">#020817</b> / dark #cbd5e1</div>
+    <div class="chip"><i style="background:#0f172a"></i> --primary <b style="color:#020817;font-weight:600">#0f172a</b> / dark #f8fafc</div>
+    <div class="chip"><i style="background:#ff9ce3"></i> checked-light <b style="color:#020817;font-weight:600">#ff9ce3</b></div>
+    <div class="chip"><i style="background:#2ad4fc"></i> checked-dark <b style="color:#020817;font-weight:600">#2ad4fc</b></div>
+    <div class="chip"><i style="background:#f1f5f9"></i> --muted <b style="color:#020817;font-weight:600">#f1f5f9</b></div>
+    <div class="chip"><i style="border-color:#cbd5e1;background:#fff"></i> radius <b style="color:#020817;font-weight:600">8 · md 6 · sm 4px</b></div>
+  </div>
+
+  <p class="lead" style="margin-top:22px">
+    Font: KoHo is declared for <code style="font-family:ui-monospace,monospace">.koho-*</code>/<code style="font-family:ui-monospace,monospace">.pink-btn</code>
+    but never loads in the app, so all control text renders in the <b>system sans</b> stack shown here — that's the reality this card documents.
+  </p>
+</div>
+</body>
+</html>

--- a/design-system/components/tabs.html
+++ b/design-system/components/tabs.html
@@ -1,0 +1,283 @@
+<!-- @dsCard group="Components" name="Tabs" subtitle="list + active/inactive triggers" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  :root {
+    /* Resolved shadcn "slate" semantic tokens — light (globals.css :root) */
+    --background: hsl(0 0% 100%);          /* #ffffff */
+    --foreground: hsl(222.2 84% 4.9%);     /* ~#020817 */
+    --muted: hsl(210 40% 96.1%);           /* ~#f1f5f9 */
+    --muted-foreground: hsl(215.4 16.3% 46.9%); /* ~#64748b */
+    --ring: hsl(222.2 84% 4.9%);
+    --radius: 0.5rem;                       /* 8px base */
+    /* Resolved dark tokens (globals.css .dark) */
+    --d-background: hsl(222.2 84% 4.9%);    /* ~#020817 */
+    --d-foreground: hsl(210 40% 98%);       /* ~#f8fafc */
+    --d-muted: hsl(217.2 32.6% 17.5%);      /* ~#1e293b */
+    --d-muted-foreground: hsl(215 20.2% 65.1%); /* ~#94a3b8 */
+
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: #ffffff;
+    color: var(--foreground);
+    font-family: var(--sans);
+    -webkit-font-smoothing: antialiased;
+    padding: 40px 36px 48px;
+  }
+
+  .wrap { max-width: 760px; margin: 0 auto; }
+
+  h1 {
+    font-size: 20px;
+    font-weight: 650;
+    letter-spacing: -0.01em;
+    margin: 0 0 6px;
+  }
+  .lede {
+    font-size: 13.5px;
+    line-height: 1.55;
+    color: #475569;
+    margin: 0 0 8px;
+    max-width: 60ch;
+  }
+  code.k {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    background: #f1f5f9;
+    color: #334155;
+    padding: 1px 5px;
+    border-radius: 4px;
+  }
+
+  .section-label {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #94a3b8;
+    margin: 34px 0 12px;
+    font-weight: 600;
+  }
+
+  /* ---- Real Tabs component, resolved to literal CSS ---- */
+
+  /* TabsList: inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground */
+  .tabs-list {
+    display: inline-flex;
+    height: 40px;                 /* h-10 */
+    align-items: center;
+    justify-content: center;
+    border-radius: 6px;           /* rounded-md = calc(0.5rem - 2px) */
+    background: var(--muted);
+    padding: 4px;                 /* p-1 */
+    color: var(--muted-foreground);
+  }
+
+  /* TabsTrigger base: rounded-sm px-3 py-1.5 text-sm font-medium transition-all */
+  .tabs-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+    border-radius: 4px;           /* rounded-sm = calc(0.5rem - 4px) */
+    padding: 6px 12px;            /* py-1.5 px-3 */
+    font-size: 14px;             /* text-sm */
+    line-height: 20px;
+    font-weight: 500;            /* font-medium */
+    font-family: var(--sans);
+    background: transparent;      /* inactive: no bg, inherits list color */
+    color: inherit;              /* inactive → muted-foreground */
+    border: 0;
+    cursor: pointer;
+    transition: all .15s ease;
+  }
+
+  /* data-[state=active]: bg-background text-foreground shadow-sm */
+  .tabs-trigger[data-state="active"] {
+    background: var(--background);
+    color: var(--foreground);
+    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);   /* shadow-sm */
+  }
+
+  /* TabsContent: mt-2 */
+  .tabs-content {
+    margin-top: 8px;             /* mt-2 */
+    font-size: 14px;
+    line-height: 1.6;
+    color: #334155;
+    border: 1px solid hsl(214.3 31.8% 91.4%);   /* --border, for panel framing only */
+    border-radius: 6px;
+    padding: 16px 18px;
+    max-width: 420px;
+  }
+  .tabs-content h4 {
+    margin: 0 0 4px;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--foreground);
+  }
+  .tabs-content p { margin: 0; color: var(--muted-foreground); }
+
+  /* Callout markers pointing at active vs inactive */
+  .specimen { margin: 4px 0 0; }
+
+  .legend {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14px;
+    margin-top: 22px;
+  }
+  .leg {
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    padding: 13px 15px;
+    background: #fff;
+  }
+  .leg .tag {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    padding: 2px 7px;
+    border-radius: 999px;
+    margin-bottom: 9px;
+  }
+  .leg.active .tag { background: #020817; color: #fff; }
+  .leg.inactive .tag { background: #f1f5f9; color: #64748b; }
+  .leg ul { margin: 0; padding: 0; list-style: none; }
+  .leg li {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    line-height: 1.9;
+    color: #475569;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .sw {
+    width: 13px; height: 13px;
+    border-radius: 3px;
+    border: 1px solid rgba(0,0,0,0.12);
+    flex: none;
+  }
+  .leg li b { color: #0f172a; font-weight: 600; }
+
+  /* Dark specimen block */
+  .dark-stage {
+    margin-top: 12px;
+    background: var(--d-background);
+    border-radius: 10px;
+    padding: 22px 22px 24px;
+    border: 1px solid #1e293b;
+  }
+  .dark-stage .tabs-list {
+    background: var(--d-muted);
+    color: var(--d-muted-foreground);
+  }
+  .dark-stage .tabs-trigger[data-state="active"] {
+    background: var(--d-background);
+    color: var(--d-foreground);
+    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.4);
+  }
+  .dark-stage .tabs-content {
+    border-color: #1e293b;
+    color: #cbd5e1;
+  }
+  .dark-stage .tabs-content h4 { color: var(--d-foreground); }
+  .dark-stage .tabs-content p { color: var(--d-muted-foreground); }
+  .dark-cap { color: #64748b; }
+
+  .note {
+    margin-top: 30px;
+    border-left: 3px solid #cbd5e1;
+    background: #f8fafc;
+    padding: 11px 14px;
+    border-radius: 0 6px 6px 0;
+    font-size: 12.5px;
+    line-height: 1.6;
+    color: #475569;
+  }
+  .note b { color: #0f172a; }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Tabs</h1>
+    <p class="lede">
+      Radix <code class="k">TabsPrimitive</code> wrapped in <code class="k">tabs.tsx</code>. Stock shadcn treatment:
+      a <code class="k">bg-muted</code> track holds triggers; the active trigger lifts to <code class="k">bg-background</code>
+      with <code class="k">text-foreground</code> and <code class="k">shadow-sm</code>. Inactive triggers stay transparent and
+      inherit <code class="k">text-muted-foreground</code> from the list. All classes below are resolved to literal CSS from
+      the real slate tokens.
+    </p>
+
+    <div class="section-label">Light — TabsList · 3 triggers · content panel</div>
+
+    <div class="specimen">
+      <div class="tabs-list" role="tablist">
+        <button class="tabs-trigger" data-state="active" role="tab">Overview</button>
+        <button class="tabs-trigger" role="tab">Links</button>
+        <button class="tabs-trigger" role="tab">Activity</button>
+      </div>
+      <div class="tabs-content" role="tabpanel">
+        <h4>Overview</h4>
+        <p>Content for the active tab renders here (<code class="k" style="background:#f1f5f9">mt-2</code> below the list).</p>
+      </div>
+    </div>
+
+    <div class="legend">
+      <div class="leg active">
+        <span class="tag">Active trigger</span>
+        <ul>
+          <li><span class="sw" style="background:#ffffff"></span> bg <b>#ffffff</b> — bg-background</li>
+          <li><span class="sw" style="background:#020817"></span> text <b>hsl(222 84% 4.9%)</b> — foreground</li>
+          <li><span class="sw" style="background:linear-gradient(#fff,#e8eaee)"></span> shadow-sm <b>0 1px 2px /.05</b></li>
+          <li><span class="sw" style="border-radius:4px;background:#eef2f7"></span> radius <b>4px</b> — rounded-sm</li>
+        </ul>
+      </div>
+      <div class="leg inactive">
+        <span class="tag">Inactive triggers</span>
+        <ul>
+          <li><span class="sw" style="background:transparent;border-style:dashed"></span> bg <b>transparent</b></li>
+          <li><span class="sw" style="background:#64748b"></span> text <b>hsl(215 16% 47%)</b> — muted-fg</li>
+          <li><span class="sw" style="background:#f1f5f9"></span> track <b>hsl(210 40% 96%)</b> — bg-muted</li>
+          <li><span class="sw" style="border-radius:6px;background:#eef2f7"></span> list radius <b>6px</b> — rounded-md</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="section-label">Dark — same tokens, <code class="k" style="background:#1e293b;color:#cbd5e1">.dark</code> scope</div>
+    <div class="dark-stage">
+      <div class="tabs-list" role="tablist">
+        <button class="tabs-trigger" data-state="active" role="tab">Overview</button>
+        <button class="tabs-trigger" role="tab">Links</button>
+        <button class="tabs-trigger" role="tab">Activity</button>
+      </div>
+      <div class="tabs-content" role="tabpanel">
+        <h4>Overview</h4>
+        <p>Active lifts to <span style="font-family:var(--mono);font-size:12px">bg #020817</span> on a
+        <span style="font-family:var(--mono);font-size:12px">#1e293b</span> track.</p>
+      </div>
+    </div>
+
+    <div class="note">
+      <b>Reality note.</b> DESIGN.md marks Tabs <b>&ldquo;Stock&rdquo;</b> — no brand color touches this component.
+      Type renders in the <b>system sans</b> stack (KoHo is declared project-wide but never actually loads),
+      not a custom face. Radius derives from <code class="k">--radius: 0.5rem</code>:
+      list <code class="k">rounded-md</code> = 6px, trigger <code class="k">rounded-sm</code> = 4px. The content-panel
+      border here is only for framing the specimen; <code class="k">TabsContent</code> itself ships with just
+      <code class="k">mt-2</code> and a focus ring.
+    </div>
+  </div>
+</body>
+</html>

--- a/design-system/foundations/glass.html
+++ b/design-system/foundations/glass.html
@@ -1,0 +1,349 @@
+<!-- @dsCard group="Surfaces" name="Glass surfaces" subtitle=".glass / .glass-subtle · blur(20px) saturate(180%)" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  :root {
+    --bg: #ffffff;
+    --ink: #1a1420;
+    --muted: #6b6472;
+    --hairline: #ece7f0;
+    --maroon: #422b46;
+    --pastyblue: #2ad4fc;
+    --pastypink: #ef95ff;
+    --jellygreen: #19ffb8;
+    --screenpink: #ff9ce3;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--sans);
+    -webkit-font-smoothing: antialiased;
+    padding: 32px;
+  }
+
+  .wrap { max-width: 920px; margin: 0 auto; }
+
+  header { margin-bottom: 26px; }
+  h1 {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin: 0 0 6px;
+  }
+  .sub {
+    font-family: var(--mono);
+    font-size: 12.5px;
+    color: var(--muted);
+  }
+  .lede {
+    margin-top: 12px;
+    font-size: 13.5px;
+    line-height: 1.55;
+    color: #4a4451;
+    max-width: 640px;
+  }
+  .lede code {
+    font-family: var(--mono);
+    font-size: 12px;
+    background: #f4f0f7;
+    padding: 1px 5px;
+    border-radius: 4px;
+  }
+
+  .section-label {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin: 30px 0 12px;
+  }
+
+  /* ---- Neon stage: the colorful backdrop that makes blur visible ---- */
+  .stage {
+    position: relative;
+    border-radius: 18px;
+    padding: 34px;
+    overflow: hidden;
+    display: flex;
+    gap: 22px;
+    flex-wrap: wrap;
+  }
+  .stage.light {
+    background:
+      radial-gradient(circle at 12% 20%, var(--pastypink) 0%, transparent 42%),
+      radial-gradient(circle at 88% 15%, var(--pastyblue) 0%, transparent 45%),
+      radial-gradient(circle at 25% 95%, var(--jellygreen) 0%, transparent 48%),
+      radial-gradient(circle at 85% 90%, var(--screenpink) 0%, transparent 46%),
+      linear-gradient(135deg, #fff4fd 0%, #eefcff 100%);
+  }
+  .stage.dark {
+    background:
+      radial-gradient(circle at 15% 18%, rgba(239,149,255,0.85) 0%, transparent 42%),
+      radial-gradient(circle at 85% 12%, rgba(42,212,252,0.8) 0%, transparent 44%),
+      radial-gradient(circle at 30% 92%, rgba(25,255,184,0.75) 0%, transparent 46%),
+      radial-gradient(circle at 90% 88%, rgba(255,156,227,0.7) 0%, transparent 44%),
+      linear-gradient(135deg, #2a1c2d 0%, #1a1420 100%);
+  }
+
+  /* Crisp elements BEHIND the panels so the backdrop blur is obvious */
+  .behind {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    font-family: var(--sans);
+  }
+  .behind .stripe {
+    position: absolute;
+    font-weight: 800;
+    font-size: 15px;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+    opacity: 0.9;
+  }
+  .stage.light .behind .stripe { color: var(--maroon); }
+  .stage.dark  .behind .stripe { color: #fff; }
+  .behind .s1 { top: 30px;  left: -10px; }
+  .behind .s2 { top: 128px; left: -30px; }
+  .behind .s3 { top: 226px; left: 40px; }
+  .behind .dots {
+    position: absolute;
+    inset: 0;
+    background-image: radial-gradient(currentColor 1.5px, transparent 1.6px);
+    background-size: 16px 16px;
+    opacity: 0.18;
+  }
+  .stage.light .behind .dots { color: var(--maroon); }
+  .stage.dark  .behind .dots { color: #ffffff; }
+
+  /* ---- The glass panels ---- */
+  .panel {
+    position: relative;
+    z-index: 1;
+    width: 250px;
+    min-height: 176px;
+    padding: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .glass {
+    background: rgba(255, 255, 255, 0.55);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    backdrop-filter: blur(20px) saturate(180%);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 1rem;
+  }
+  .glass-subtle {
+    background: rgba(255, 255, 255, 0.35);
+    -webkit-backdrop-filter: blur(12px) saturate(150%);
+    backdrop-filter: blur(12px) saturate(150%);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 0.75rem;
+  }
+  /* dark stage overrides — mirror ".dark .glass" in globals.css */
+  .stage.dark .glass {
+    background: rgba(30, 30, 30, 0.55);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+  }
+  .stage.dark .glass-subtle {
+    background: rgba(40, 40, 40, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  .p-name {
+    font-family: var(--mono);
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+  }
+  .stage.dark .p-name { color: #fff; }
+  .p-css {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    line-height: 1.5;
+    color: #33313a;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .stage.dark .p-css { color: rgba(255,255,255,0.82); }
+  .p-tag {
+    margin-top: auto;
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #7b7482;
+  }
+  .stage.dark .p-tag { color: rgba(255,255,255,0.55); }
+
+  /* ---- scrollbar-glass sample ---- */
+  .scroll-panel {
+    position: relative;
+    z-index: 1;
+    width: 250px;
+    padding: 16px 8px 16px 16px;
+    display: flex;
+    flex-direction: column;
+  }
+  .scroll-box {
+    height: 108px;
+    overflow-y: scroll;
+    padding-right: 10px;
+    margin-top: 8px;
+  }
+  .scrollbar-glass {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+  }
+  .scrollbar-glass::-webkit-scrollbar { width: 6px; height: 6px; }
+  .scrollbar-glass::-webkit-scrollbar-track { background: transparent; }
+  .scrollbar-glass::-webkit-scrollbar-thumb {
+    background-color: rgba(255, 255, 255, 0.18);
+    border-radius: 9999px;
+  }
+  .scrollbar-glass::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(255, 255, 255, 0.32);
+  }
+  .scroll-row {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: rgba(255,255,255,0.9);
+    padding: 5px 0;
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+  }
+
+  .note {
+    margin-top: 12px;
+    font-size: 12px;
+    line-height: 1.55;
+    color: var(--muted);
+    display: flex;
+    gap: 8px;
+    align-items: flex-start;
+  }
+  .note b { color: #4a4451; font-weight: 600; }
+  .note .ic { flex: none; margin-top: 1px; }
+  .note code {
+    font-family: var(--mono);
+    font-size: 11px;
+    background: #f4f0f7;
+    padding: 1px 4px;
+    border-radius: 4px;
+    color: #5a3f60;
+  }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <h1>Glass surfaces</h1>
+      <div class="sub">.glass / .glass-subtle · blur(20px) saturate(180%)</div>
+      <p class="lede">
+        The primary surface language. Translucent white over a <code>backdrop-filter</code> blur —
+        no semantic token involved. Defined by hand in <code>globals.css</code>, used across 13+
+        artist-page components and admin. Panels float over color so the blur reads.
+      </p>
+    </header>
+
+    <div class="section-label">Light — over neon brand gradient</div>
+    <div class="stage light">
+      <div class="behind">
+        <div class="dots"></div>
+        <div class="stripe s1">music nerd ✦ pastypink ✦ pastyblue</div>
+        <div class="stripe s2">jellygreen ✦ #ff9ce3 ✦ maroon ✦ candy-neon</div>
+        <div class="stripe s3">frosted ✦ blur ✦ saturate ✦ glassy</div>
+      </div>
+
+      <div class="panel glass">
+        <div class="p-name">.glass</div>
+        <div class="p-css">background: rgba(255,255,255,.55);
+backdrop-filter:
+  blur(20px) saturate(180%);
+border: 1px solid
+  rgba(255,255,255,.3);
+border-radius: 1rem;</div>
+        <div class="p-tag">radius 16px · primary panel</div>
+      </div>
+
+      <div class="panel glass-subtle">
+        <div class="p-name">.glass-subtle</div>
+        <div class="p-css">background: rgba(255,255,255,.35);
+backdrop-filter:
+  blur(12px) saturate(150%);
+border: 1px solid
+  rgba(255,255,255,.25);
+border-radius: .75rem;</div>
+        <div class="p-tag">radius 12px · nested panel</div>
+      </div>
+    </div>
+
+    <div class="section-label">Dark — .dark .glass overrides + .scrollbar-glass thumb</div>
+    <div class="stage dark">
+      <div class="behind">
+        <div class="dots"></div>
+        <div class="stripe s1">music nerd ✦ pastypink ✦ pastyblue</div>
+        <div class="stripe s2">jellygreen ✦ #ff9ce3 ✦ maroon ✦ candy-neon</div>
+        <div class="stripe s3">frosted ✦ blur ✦ saturate ✦ glassy</div>
+      </div>
+
+      <div class="panel glass">
+        <div class="p-name">.dark .glass</div>
+        <div class="p-css">background: rgba(30,30,30,.55);
+border: 1px solid
+  rgba(255,255,255,.08);
+/* blur/saturate/radius
+   inherited from .glass */</div>
+        <div class="p-tag">radius 16px · dark surface</div>
+      </div>
+
+      <div class="panel glass-subtle">
+        <div class="p-name">.dark .glass-subtle</div>
+        <div class="p-css">background: rgba(40,40,40,.4);
+border: 1px solid
+  rgba(255,255,255,.06);
+/* blur(12px) saturate(150%)
+   inherited */</div>
+        <div class="p-tag">radius 12px · dark nested</div>
+      </div>
+
+      <div class="panel glass scroll-panel">
+        <div class="p-name">.scrollbar-glass</div>
+        <div class="p-css" style="color:rgba(255,255,255,.82)">thumb rgba(255,255,255,.18)
+hover 0.32 · track transparent
+6px · radius 9999px ↓ scroll</div>
+        <div class="scroll-box scrollbar-glass">
+          <div class="scroll-row">deezer id</div>
+          <div class="scroll-row">apple music</div>
+          <div class="scroll-row">musicbrainz</div>
+          <div class="scroll-row">wikidata</div>
+          <div class="scroll-row">tidal</div>
+          <div class="scroll-row">amazon music</div>
+          <div class="scroll-row">youtube music</div>
+          <div class="scroll-row">spotify</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="note">
+      <span class="ic">ℹ</span>
+      <span><b>Fidelity notes.</b> This is the exact recipe from <code>globals.css</code>.
+      The glass utilities define <b>no box-shadow</b> — only a translucent border — so panels read as
+      edges, not drop-shadows. Their radii (16px / 12px) are <b>off the <code>--radius</code> scale</b>
+      (which is 8/6/4px) — hardcoded brand exceptions. The <code>.scrollbar-glass</code> thumb is near-invisible
+      on light surfaces by design; it's tuned for dark/glass. WebKit renders the 6px pill; Firefox uses the
+      thin <code>scrollbar-color</code> fallback.</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/design-system/foundations/gradients.html
+++ b/design-system/foundations/gradients.html
@@ -1,0 +1,267 @@
+<!-- @dsCard group="Surfaces" name="Gradients" subtitle="hero / accent gradients" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  :root {
+    --bg: #ffffff;
+    --ink: #1a1420;
+    --muted: #6b6472;
+    --line: #ece7ef;
+    --card: #faf8fb;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    --radius: 0.5rem; /* real --radius base */
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    line-height: 1.5;
+  }
+  .wrap { max-width: 760px; margin: 0 auto; padding: 40px 28px 56px; }
+
+  header { margin-bottom: 8px; }
+  h1 {
+    margin: 0 0 4px;
+    font-size: 26px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+  .sub { margin: 0; color: var(--muted); font-size: 14px; }
+  .intro {
+    margin: 16px 0 30px;
+    font-size: 13.5px;
+    color: var(--muted);
+    border-left: 3px solid #ef95ff;
+    padding: 8px 0 8px 14px;
+    background: linear-gradient(90deg, rgba(239,149,255,.07), transparent 70%);
+  }
+  .intro code { font-family: var(--mono); font-size: 12px; color: var(--ink); }
+
+  .stack { display: flex; flex-direction: column; gap: 26px; }
+
+  .card {
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    overflow: hidden;
+    background: var(--card);
+  }
+
+  /* ---- swatch panel ---- */
+  .swatch {
+    height: 190px;
+    position: relative;
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-start;
+  }
+  .swatch .tag {
+    margin: 12px;
+    font-family: var(--mono);
+    font-size: 10.5px;
+    letter-spacing: .02em;
+    background: rgba(255,255,255,.86);
+    color: #2a2230;
+    padding: 4px 8px;
+    border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(0,0,0,.18);
+  }
+
+  /* simulated dark, blurred artist photo (hero context) */
+  .photo-dark {
+    background:
+      radial-gradient(60% 80% at 74% 18%, rgba(37,99,235,.55), transparent 60%),
+      radial-gradient(70% 75% at 18% 82%, rgba(16,185,129,.42), transparent 62%),
+      linear-gradient(135deg, #3b4453, #131820);
+  }
+  /* simulated lighter photo so darkening reads */
+  .photo-light {
+    background:
+      radial-gradient(60% 80% at 28% 22%, #fde68a, transparent 60%),
+      radial-gradient(70% 72% at 82% 72%, #93c5fd, transparent 60%),
+      linear-gradient(135deg, #e8ebf0, #9aa2ae);
+  }
+  /* transparency checkerboard — signals a translucent fallback fill */
+  .checker {
+    background-color: #ffffff;
+    background-image:
+      linear-gradient(45deg, #e7e2ea 25%, transparent 25%),
+      linear-gradient(-45deg, #e7e2ea 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, #e7e2ea 75%),
+      linear-gradient(-45deg, transparent 75%, #e7e2ea 75%);
+    background-size: 18px 18px;
+    background-position: 0 0, 0 9px, 9px -9px, -9px 0;
+  }
+
+  /* the REAL gradients, as an overlay layer above the backdrop */
+  .g-hero-wash::before {
+    content: "";
+    position: absolute; inset: 0;
+    background: linear-gradient(to bottom right,
+      rgba(239,149,255,.20), transparent, rgba(124,58,237,.15));
+  }
+  .g-hero-dark::before {
+    content: "";
+    position: absolute; inset: 0;
+    background: linear-gradient(to bottom,
+      rgba(0,0,0,.20), rgba(0,0,0,.50));
+  }
+  .g-press::before {
+    content: "";
+    position: absolute; inset: 0;
+    background: linear-gradient(to bottom right,
+      rgba(239,149,255,.10), rgba(88,28,135,.20), transparent);
+  }
+
+  /* ---- meta block under each swatch ---- */
+  .meta { padding: 14px 16px 16px; }
+  .meta .name {
+    font-size: 14.5px; font-weight: 650; margin: 0 0 2px;
+  }
+  .meta .where {
+    font-family: var(--mono); font-size: 11px; color: var(--muted); margin: 0 0 12px;
+  }
+
+  .chips { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-family: var(--mono); font-size: 10.5px; color: #2a2230;
+    background: #fff; border: 1px solid var(--line);
+    padding: 3px 7px 3px 4px; border-radius: 20px;
+  }
+  .dot {
+    width: 14px; height: 14px; border-radius: 50%;
+    border: 1px solid rgba(0,0,0,.12);
+    /* alpha dots sit on their own mini-checker so opacity reads */
+    background-color: #fff;
+    background-image:
+      linear-gradient(45deg, #ddd 25%, transparent 25%),
+      linear-gradient(-45deg, #ddd 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, #ddd 75%),
+      linear-gradient(-45deg, transparent 75%, #ddd 75%);
+    background-size: 8px 8px;
+    background-position: 0 0, 0 4px, 4px -4px, -4px 0;
+    position: relative;
+  }
+  .dot::after { content:""; position:absolute; inset:0; border-radius:50%; background: var(--c); }
+
+  .code {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    line-height: 1.65;
+    color: #2a2230;
+    background: #fff;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 10px 12px;
+    overflow-x: auto;
+    white-space: pre;
+  }
+  .code .k { color: #a3369b; }
+  .code .lbl { display:block; color: var(--muted); font-size: 10px; letter-spacing:.04em; text-transform: uppercase; margin: 0 0 4px; }
+  .code + .code { margin-top: 8px; }
+
+  footer {
+    margin-top: 34px;
+    padding-top: 18px;
+    border-top: 1px solid var(--line);
+    font-size: 12.5px;
+    color: var(--muted);
+  }
+  footer b { color: var(--ink); font-weight: 650; }
+  footer code { font-family: var(--mono); font-size: 11.5px; color:#2a2230; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>Gradients</h1>
+    <p class="sub">Surfaces &middot; hero / accent gradients</p>
+  </header>
+
+  <p class="intro">
+    Every gradient in the app is a <b>translucent overlay on a <code>&lt;div&gt;</code></b> — composited over
+    artist imagery, never gradient-clipped text (<code>bg-clip-text</code> = 0 hits). Three exist, all authored
+    as Tailwind <code>bg-gradient-*</code> utilities. Backdrops below are simulated to reveal the low-alpha stops.
+  </p>
+
+  <div class="stack">
+
+    <!-- 1. Hero brand wash -->
+    <div class="card">
+      <div class="swatch photo-dark g-hero-wash">
+        <span class="tag">over blurred artist photo</span>
+      </div>
+      <div class="meta">
+        <p class="name">Hero brand wash</p>
+        <p class="where">artist/[id]/_components/HeroSection.tsx:79</p>
+        <div class="chips">
+          <span class="chip"><span class="dot" style="--c:rgba(239,149,255,.20)"></span>#ef95ff / 20%</span>
+          <span class="chip"><span class="dot" style="--c:transparent"></span>transparent</span>
+          <span class="chip"><span class="dot" style="--c:rgba(124,58,237,.15)"></span>#7c3aed / 15%</span>
+        </div>
+        <div class="code"><span class="lbl">Tailwind</span>bg-gradient-to-br from-[#ef95ff]/20 via-transparent to-[#7c3aed]/15</div>
+        <div class="code"><span class="lbl">Resolved CSS</span><span class="k">linear-gradient(</span>to bottom right,
+  rgba(239,149,255,.20),
+  transparent,
+  rgba(124,58,237,.15)<span class="k">)</span></div>
+      </div>
+    </div>
+
+    <!-- 2. Hero dark overlay -->
+    <div class="card">
+      <div class="swatch photo-light g-hero-dark">
+        <span class="tag">over lighter photo — bottom darkens</span>
+      </div>
+      <div class="meta">
+        <p class="name">Hero dark overlay</p>
+        <p class="where">artist/[id]/_components/HeroSection.tsx:82</p>
+        <div class="chips">
+          <span class="chip"><span class="dot" style="--c:rgba(0,0,0,.20)"></span>black / 20%</span>
+          <span class="chip"><span class="dot" style="--c:rgba(0,0,0,.50)"></span>black / 50%</span>
+        </div>
+        <div class="code"><span class="lbl">Tailwind</span>bg-gradient-to-b from-black/20 to-black/50</div>
+        <div class="code"><span class="lbl">Resolved CSS</span><span class="k">linear-gradient(</span>to bottom,
+  rgba(0,0,0,.20),
+  rgba(0,0,0,.50)<span class="k">)</span></div>
+      </div>
+    </div>
+
+    <!-- 3. Press thumb fallback -->
+    <div class="card">
+      <div class="swatch checker g-press">
+        <span class="tag">translucent fallback fill (no image)</span>
+      </div>
+      <div class="meta">
+        <p class="name">Press thumb fallback</p>
+        <p class="where">artist/[id]/_components/PressAndFeatures.tsx:68</p>
+        <div class="chips">
+          <span class="chip"><span class="dot" style="--c:rgba(239,149,255,.10)"></span>pastypink #ef95ff / 10%</span>
+          <span class="chip"><span class="dot" style="--c:rgba(88,28,135,.20)"></span>purple-900 #581c87 / 20%</span>
+          <span class="chip"><span class="dot" style="--c:transparent"></span>transparent</span>
+        </div>
+        <div class="code"><span class="lbl">Tailwind</span>bg-gradient-to-br from-pastypink/10 via-purple-900/20 to-transparent</div>
+        <div class="code"><span class="lbl">Resolved CSS</span><span class="k">linear-gradient(</span>to bottom right,
+  rgba(239,149,255,.10),
+  rgba(88,28,135,.20),
+  transparent<span class="k">)</span></div>
+      </div>
+    </div>
+
+  </div>
+
+  <footer>
+    <b>Two vocabularies for the same pink&rarr;purple wash.</b> The hero uses raw hex
+    (<code>from-[#ef95ff] to-[#7c3aed]</code>); the press thumb uses the <code>pastypink</code> token
+    + Tailwind <code>purple-900</code>. Note the palette pink here is <code>#ef95ff</code> — not the
+    <code>#ff9ce3</code> pink users actually see on the wordmark. Base <code>--radius: 0.5rem</code>;
+    swatch corners are illustrative. KoHo is declared but never loads, so all type renders in the
+    system sans stack.
+  </footer>
+</div>
+</body>
+</html>

--- a/design-system/foundations/motion.html
+++ b/design-system/foundations/motion.html
@@ -1,0 +1,293 @@
+<!-- @dsCard group="Motion" name="Motion" subtitle="fadeSlideIn · accordion · spin · live ping" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root{
+    /* Resolved from globals.css :root (shadcn "slate") */
+    --background: hsl(0 0% 100%);
+    --foreground: hsl(222.2 84% 4.9%);
+    --muted-foreground: hsl(215.4 16.3% 46.9%);
+    --border: hsl(214.3 31.8% 91.4%);
+    --card: hsl(0 0% 100%);
+    --primary: hsl(222.2 47.4% 11.2%);
+    /* Brand */
+    --maroon:#422b46;
+    --pastyblue:#2ad4fc;
+    --pastypink:#ef95ff;
+    --jellygreen:#19ffb8;
+    --radius:0.5rem;
+    --mono:"SF Mono",ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+  }
+  *{box-sizing:border-box}
+  body{
+    margin:0;
+    background:var(--background);
+    color:var(--foreground);
+    font-family:var(--sans);
+    -webkit-font-smoothing:antialiased;
+    padding:28px 24px 32px;
+  }
+  .wrap{max-width:920px;margin:0 auto}
+  header{margin-bottom:22px}
+  h1{
+    font-size:26px;
+    letter-spacing:-0.02em;
+    margin:0 0 6px;
+    font-weight:650;
+  }
+  .lede{
+    color:var(--muted-foreground);
+    font-size:14px;
+    margin:0;
+    max-width:640px;
+    line-height:1.5;
+  }
+  .lede code{font-family:var(--mono);font-size:12.5px;color:var(--maroon)}
+
+  .grid{
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(210px,1fr));
+    gap:16px;
+    margin-top:22px;
+  }
+  .demo{
+    border:1px solid var(--border);
+    border-radius:var(--radius);
+    background:var(--card);
+    overflow:hidden;
+    display:flex;
+    flex-direction:column;
+  }
+  .stage{
+    position:relative;
+    height:150px;
+    background:
+      radial-gradient(120% 120% at 50% 0%, #fbfcfe 0%, #f4f6fa 100%);
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    padding:16px;
+    overflow:hidden;
+  }
+  .meta{
+    padding:12px 14px 14px;
+    border-top:1px solid var(--border);
+  }
+  .name{
+    font-family:var(--mono);
+    font-size:13px;
+    font-weight:600;
+    color:var(--foreground);
+    letter-spacing:-0.01em;
+  }
+  .spec{
+    font-family:var(--mono);
+    font-size:11px;
+    color:var(--muted-foreground);
+    margin-top:4px;
+    line-height:1.5;
+  }
+  .spec b{color:var(--maroon);font-weight:600}
+  .src{
+    display:inline-block;
+    margin-top:8px;
+    font-family:var(--mono);
+    font-size:10px;
+    color:#8a93a3;
+  }
+
+  /* ---------- 1. fadeSlideIn : fadeSlideIn 0.3s ease-out both ---------- */
+  .fsi-card{
+    width:150px;
+    border-radius:var(--radius);
+    background:#fff;
+    border:1px solid var(--border);
+    box-shadow:0 6px 18px -10px rgba(66,43,70,0.35);
+    padding:12px 13px;
+    animation:fsi-loop 2.6s infinite;
+  }
+  .fsi-card .bar{height:8px;border-radius:4px;background:var(--pastypink);width:70%;margin-bottom:8px}
+  .fsi-card .bar.two{background:#e7ebf1;width:100%}
+  .fsi-card .bar.three{background:#e7ebf1;width:45%;margin-bottom:0}
+  @keyframes fsi-loop{
+    0%   {opacity:0;transform:translateY(-8px);animation-timing-function:ease-out}
+    11.5%{opacity:1;transform:translateY(0)}
+    85%  {opacity:1;transform:translateY(0)}
+    100% {opacity:0;transform:translateY(-8px)}
+  }
+
+  /* ---------- 2. accordion : accordion-down/up 0.2s ease-out ---------- */
+  .acc{width:160px;border:1px solid var(--border);border-radius:var(--radius);background:#fff;overflow:hidden}
+  .acc .trigger{
+    display:flex;align-items:center;justify-content:space-between;
+    padding:9px 12px;font-family:var(--sans);font-size:12px;font-weight:600;color:var(--foreground);
+  }
+  .acc .chev{
+    width:9px;height:9px;border-right:2px solid var(--maroon);border-bottom:2px solid var(--maroon);
+    transform:rotate(45deg);transform-origin:55% 55%;
+    animation:chev-loop 2.8s infinite;
+  }
+  .acc .panel{
+    height:0;overflow:hidden;
+    animation:acc-loop 2.8s infinite;
+  }
+  .acc .panel .inner{padding:0 12px 11px;font-family:var(--sans);font-size:11px;line-height:1.55;color:var(--muted-foreground)}
+  @keyframes acc-loop{
+    0%  {height:0;animation-timing-function:ease-out}
+    7%  {height:60px}
+    50% {height:60px;animation-timing-function:ease-out}
+    57% {height:0}
+    100%{height:0}
+  }
+  @keyframes chev-loop{
+    0%  {transform:rotate(45deg);animation-timing-function:ease-out}
+    7%  {transform:rotate(-135deg)}
+    50% {transform:rotate(-135deg);animation-timing-function:ease-out}
+    57% {transform:rotate(45deg)}
+    100%{transform:rotate(45deg)}
+  }
+
+  /* ---------- 3. spin (hover logo) : spin 3s linear infinite ---------- */
+  .disc{
+    width:74px;height:74px;border-radius:50%;position:relative;
+    background:
+      radial-gradient(circle at 50% 50%, #5a3f60 0 17%, transparent 17%),
+      repeating-radial-gradient(circle at 50% 50%, #2c1c30 0 3px, #3a2740 3px 6px);
+    box-shadow:0 4px 14px -4px rgba(66,43,70,0.5);
+    animation:spin360 3s linear infinite;
+  }
+  .disc::before{
+    content:"";position:absolute;inset:0;margin:auto;
+    width:22px;height:22px;border-radius:50%;
+    background:radial-gradient(circle at 50% 40%,var(--pastypink),var(--maroon));
+  }
+  .disc::after{
+    content:"";position:absolute;top:9px;left:50%;width:4px;height:4px;border-radius:50%;
+    background:var(--jellygreen);transform:translateX(-50%);box-shadow:0 0 6px var(--jellygreen);
+  }
+  @keyframes spin360{to{transform:rotate(360deg)}}
+
+  /* ---------- 4. Live ping : Tailwind animate-ping ---------- */
+  .pings{display:flex;gap:26px;align-items:center}
+  .pingcol{display:flex;flex-direction:column;align-items:center;gap:9px}
+  .chip{
+    padding:10px 14px;border-radius:var(--radius);display:flex;align-items:center;gap:8px;
+  }
+  .chip.light{background:#fff;border:1px solid var(--border)}
+  .chip.dark{background:#221226;border:1px solid #3a2740}
+  .ping{position:relative;display:inline-flex;height:8px;width:8px}
+  .ping .wave{position:absolute;inset:0;border-radius:50%;opacity:.75;animation:ping 1s cubic-bezier(0,0,.2,1) infinite}
+  .ping .dot{position:relative;display:inline-flex;border-radius:50%;height:8px;width:8px}
+  .light .wave,.light .dot{background:#059669}
+  .dark  .wave,.dark  .dot{background:var(--jellygreen)}
+  .livelabel{font-family:var(--sans);font-size:10px;letter-spacing:0.2em;text-transform:uppercase;font-weight:600}
+  .light .livelabel{color:rgba(90,77,94,0.75)}
+  .dark  .livelabel{color:rgba(198,191,199,0.75)}
+  .cap{font-family:var(--mono);font-size:10px;color:var(--muted-foreground)}
+  @keyframes ping{75%,100%{transform:scale(2.2);opacity:0}}
+
+  footer{
+    margin-top:24px;padding-top:14px;border-top:1px dashed var(--border);
+    font-family:var(--mono);font-size:11px;color:var(--muted-foreground);line-height:1.6;
+  }
+  footer b{color:var(--maroon);font-weight:600}
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <h1>Motion</h1>
+      <p class="lede">
+        The real animation tokens shipped in <code>tailwind.config.ts</code> and <code>globals.css</code>.
+        Slow, eased, ambient — motion that feels alive but calm. Demos loop for preview; in the app each
+        fires once (or on hover / when live).
+      </p>
+    </header>
+
+    <div class="grid">
+
+      <!-- fadeSlideIn -->
+      <div class="demo">
+        <div class="stage">
+          <div class="fsi-card">
+            <div class="bar"></div>
+            <div class="bar two"></div>
+            <div class="bar three"></div>
+          </div>
+        </div>
+        <div class="meta">
+          <div class="name">fadeSlideIn</div>
+          <div class="spec"><b>0.3s ease-out both</b><br>opacity 0→1 · translateY(−8px)→0</div>
+          <span class="src">tailwind.config.ts › keyframes.fadeSlideIn</span>
+        </div>
+      </div>
+
+      <!-- accordion -->
+      <div class="demo">
+        <div class="stage">
+          <div class="acc">
+            <div class="trigger">Details <span class="chev"></span></div>
+            <div class="panel"><div class="inner">crowd-sourced links, verified across 40+ platforms.</div></div>
+          </div>
+        </div>
+        <div class="meta">
+          <div class="name">accordion-down / -up</div>
+          <div class="spec"><b>0.2s ease-out</b><br>height 0 ⇄ var(--radix-accordion-content-height)</div>
+          <span class="src">tailwind.config.ts › keyframes.accordion-*</span>
+        </div>
+      </div>
+
+      <!-- spin -->
+      <div class="demo">
+        <div class="stage">
+          <div class="disc"></div>
+        </div>
+        <div class="meta">
+          <div class="name">spin (hover logo)</div>
+          <div class="spec"><b>spin 3s linear infinite</b><br>rotate 0deg→360deg · on <b>:hover</b></div>
+          <span class="src">NavContent.tsx › hover:animate-[spin_3s_linear_infinite]</span>
+        </div>
+      </div>
+
+      <!-- live ping -->
+      <div class="demo">
+        <div class="stage">
+          <div class="pings">
+            <div class="pingcol">
+              <div class="chip light">
+                <span class="ping"><span class="wave"></span><span class="dot"></span></span>
+                <span class="livelabel">Live</span>
+              </div>
+              <span class="cap">light #059669</span>
+            </div>
+            <div class="pingcol">
+              <div class="chip dark">
+                <span class="ping"><span class="wave"></span><span class="dot"></span></span>
+                <span class="livelabel">Live</span>
+              </div>
+              <span class="cap">dark #19ffb8</span>
+            </div>
+          </div>
+        </div>
+        <div class="meta">
+          <div class="name">animate-ping (Live dot)</div>
+          <div class="spec"><b>ping 1s cubic-bezier(0,0,.2,1) ∞</b><br>scale→2 · opacity 0.75→0 · accent swaps light→dark</div>
+          <span class="src">ActivityFeed.tsx › --feed-live-dot</span>
+        </div>
+      </div>
+
+    </div>
+
+    <footer>
+      Notes: <b>spin</b> and <b>ping</b> reuse Tailwind's built-in keyframes (nav overrides spin's duration to 3s).
+      Also present: <b>slow-spin 10s linear infinite</b> (profile avatar hover) and marquee
+      <b>scroll-left / scroll-right 20s linear infinite</b>. Labels render in system sans — the app declares
+      <b>KoHo</b> but it never loads, so type falls back to the platform font.
+    </footer>
+  </div>
+</body>
+</html>

--- a/design-system/foundations/spacing-radius.html
+++ b/design-system/foundations/spacing-radius.html
@@ -1,0 +1,308 @@
+<!-- @dsCard group="Spacing" name="Spacing & radius" subtitle="container 1400px/2rem · breakpoints · radius scale" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Spacing &amp; radius</title>
+<style>
+  :root{
+    --maroon:#422b46;
+    --pastyblue:#2ad4fc;
+    --pastypink:#ff9ce3;
+    --jellygreen:#19ffb8;
+    --ink:#1c1420;
+    --muted:#7a6f80;
+    --line:#e7e2ea;
+    --canvas:#ffffff;
+    --panel:#faf8fb;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+    --mono:ui-monospace,SFMono-Regular,Menlo,Monaco,"Cascadia Code",monospace;
+  }
+  *{box-sizing:border-box}
+  body{
+    margin:0;
+    background:var(--canvas);
+    color:var(--ink);
+    font-family:var(--sans);
+    -webkit-font-smoothing:antialiased;
+    line-height:1.5;
+    padding:32px;
+  }
+  .wrap{max-width:960px;margin:0 auto}
+  header.hd{margin-bottom:28px}
+  .kicker{
+    font-family:var(--mono);
+    font-size:11px;
+    letter-spacing:.14em;
+    text-transform:uppercase;
+    color:var(--pastyblue);
+    filter:saturate(.7) brightness(.72);
+    margin:0 0 6px;
+  }
+  h1{font-size:26px;letter-spacing:-.02em;margin:0 0 6px;color:var(--maroon)}
+  .sub{margin:0;color:var(--muted);font-size:14px}
+  .sub code{font-family:var(--mono);font-size:12.5px;background:var(--panel);border:1px solid var(--line);border-radius:4px;padding:1px 5px;color:var(--maroon)}
+
+  section.block{margin-top:30px}
+  .blkhead{display:flex;align-items:baseline;gap:10px;margin:0 0 14px;flex-wrap:wrap}
+  .blkhead h2{font-size:15px;margin:0;color:var(--ink);letter-spacing:-.01em}
+  .blkhead .note{font-family:var(--mono);font-size:11.5px;color:var(--muted)}
+
+  /* ---- Radius scale ---- */
+  .radii{
+    display:grid;
+    grid-template-columns:repeat(5,1fr);
+    gap:14px;
+  }
+  @media(max-width:640px){.radii{grid-template-columns:repeat(2,1fr)}}
+  .rcell{
+    background:var(--panel);
+    border:1px solid var(--line);
+    border-radius:10px;
+    padding:16px 14px 14px;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    text-align:center;
+  }
+  .swatch{
+    width:74px;height:74px;
+    background:linear-gradient(135deg,#f6d9ff 0%, #d7f3ff 100%);
+    border:2px solid var(--maroon);
+    position:relative;
+    margin-bottom:14px;
+  }
+  /* corner tick to make rounding legible */
+  .swatch::after{
+    content:"";
+    position:absolute;
+    inset:0;
+    border-top:6px solid var(--pastypink);
+    border-left:6px solid var(--pastypink);
+    border-radius:inherit;
+    -webkit-mask:linear-gradient(135deg,#000 0 34%,transparent 40%);
+            mask:linear-gradient(135deg,#000 0 34%,transparent 40%);
+    opacity:.9;
+  }
+  .r-sm{border-radius:calc(0.5rem - 4px)}   /* 4px */
+  .r-md{border-radius:calc(0.5rem - 2px)}   /* 6px */
+  .r-lg{border-radius:0.5rem}               /* 8px */
+  .r-2xl{border-radius:1rem}                /* 16px */
+  .r-full{border-radius:9999px}
+  .rname{font-weight:600;font-size:13px;color:var(--maroon)}
+  .rval{font-family:var(--mono);font-size:11px;color:var(--muted);margin-top:3px}
+  .rpx{font-family:var(--mono);font-size:11px;color:var(--ink);margin-top:2px;font-weight:600}
+
+  /* ---- Container diagram ---- */
+  .viewport{
+    border:1px solid var(--line);
+    border-radius:12px;
+    background:
+      repeating-linear-gradient(45deg,#f2ecf5 0 6px,#faf8fb 6px 12px);
+    padding:0;
+    position:relative;
+    overflow:hidden;
+  }
+  .vp-bar{
+    background:var(--maroon);
+    color:#fff;
+    font-family:var(--mono);
+    font-size:11px;
+    padding:6px 12px;
+    display:flex;
+    justify-content:space-between;
+    align-items:center;
+  }
+  .vp-bar .dot{display:inline-block;width:9px;height:9px;border-radius:9999px;background:var(--pastypink);margin-right:5px;vertical-align:middle}
+  .vp-body{position:relative;padding:22px 0 26px}
+  .content-col{
+    max-width:520px;
+    margin:0 auto;
+    background:#fff;
+    border:1.5px dashed var(--pastyblue);
+    border-radius:8px;
+    min-height:96px;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    text-align:center;
+    padding:16px 18px;
+  }
+  .content-col .ctitle{font-size:13px;font-weight:600;color:var(--maroon)}
+  .content-col .cval{font-family:var(--mono);font-size:11px;color:var(--muted);margin-top:4px}
+  .gutter-tag{
+    position:absolute;top:50%;transform:translateY(-50%);
+    font-family:var(--mono);font-size:10.5px;color:var(--maroon);
+    background:rgba(255,255,255,.85);
+    border:1px solid var(--line);border-radius:4px;
+    padding:2px 6px;white-space:nowrap;
+  }
+  .gutter-tag.l{left:14px}
+  .gutter-tag.r{right:14px}
+  .cap-max{
+    text-align:center;
+    font-family:var(--mono);
+    font-size:11px;
+    color:var(--muted);
+    margin-top:10px;
+  }
+  .cap-max b{color:var(--maroon)}
+  .deadnote{
+    margin-top:12px;
+    font-size:12.5px;
+    color:var(--muted);
+    background:#fff7ed;
+    border:1px solid #f4dcc0;
+    border-left:3px solid #e0993f;
+    border-radius:6px;
+    padding:9px 12px;
+  }
+  .deadnote code{font-family:var(--mono);font-size:11.5px;color:var(--maroon)}
+
+  /* ---- lower grid: breakpoints + ramp ---- */
+  .lower{display:grid;grid-template-columns:1fr 1fr;gap:22px}
+  @media(max-width:640px){.lower{grid-template-columns:1fr}}
+
+  table.bp{border-collapse:collapse;width:100%;font-size:13px}
+  table.bp th,table.bp td{text-align:left;padding:7px 8px;border-bottom:1px solid var(--line)}
+  table.bp th{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);font-weight:600}
+  table.bp td.tok{font-family:var(--mono);font-weight:600;color:var(--maroon)}
+  table.bp td.val{font-family:var(--mono);color:var(--ink)}
+  table.bp .track{height:8px;background:var(--panel);border:1px solid var(--line);border-radius:9999px;position:relative;overflow:hidden;min-width:60px}
+  table.bp .fill{position:absolute;left:0;top:0;bottom:0;background:linear-gradient(90deg,var(--pastyblue),var(--pastypink));border-radius:9999px}
+  .bp-foot{font-family:var(--mono);font-size:10.5px;color:var(--muted);margin-top:8px}
+
+  .ramp{display:flex;flex-direction:column;gap:9px}
+  .rrow{display:flex;align-items:center;gap:10px}
+  .rbar{height:16px;border-radius:4px;background:var(--jellygreen);border:1px solid #12d69a}
+  .rlabel{font-family:var(--mono);font-size:11px;color:var(--ink);white-space:nowrap}
+  .rlabel b{color:var(--maroon)}
+  .rtok{font-family:var(--mono);font-size:10.5px;color:var(--muted)}
+  .ramp-foot{font-family:var(--mono);font-size:10.5px;color:var(--muted);margin-top:10px}
+
+  footer.ft{
+    margin-top:30px;padding-top:16px;border-top:1px solid var(--line);
+    font-family:var(--mono);font-size:11px;color:var(--muted);line-height:1.7;
+  }
+  footer.ft b{color:var(--maroon)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="hd">
+    <p class="kicker">Foundations · Spacing</p>
+    <h1>Spacing &amp; radius</h1>
+    <p class="sub">Stock shadcn scale on <code>--radius: 0.5rem</code>. Container config (<code>center · 2rem · 1400px</code>) exists in <code>tailwind.config.ts</code> but the <code>.container</code> class is unused — real columns are 800–1000px.</p>
+  </header>
+
+  <!-- Block 1: Radius scale -->
+  <section class="block">
+    <div class="blkhead">
+      <h2>Radius scale</h2>
+      <span class="note">tailwind.config.ts · borderRadius</span>
+    </div>
+    <div class="radii">
+      <div class="rcell">
+        <div class="swatch r-sm"></div>
+        <div class="rname">rounded-sm</div>
+        <div class="rval">calc(0.5rem − 4px)</div>
+        <div class="rpx">4px</div>
+      </div>
+      <div class="rcell">
+        <div class="swatch r-md"></div>
+        <div class="rname">rounded-md</div>
+        <div class="rval">calc(0.5rem − 2px)</div>
+        <div class="rpx">6px</div>
+      </div>
+      <div class="rcell">
+        <div class="swatch r-lg"></div>
+        <div class="rname">rounded-lg</div>
+        <div class="rval">var(--radius)</div>
+        <div class="rpx">8px</div>
+      </div>
+      <div class="rcell">
+        <div class="swatch r-2xl"></div>
+        <div class="rname">rounded-2xl</div>
+        <div class="rval">1rem (default)</div>
+        <div class="rpx">16px</div>
+      </div>
+      <div class="rcell">
+        <div class="swatch r-full"></div>
+        <div class="rname">rounded-full</div>
+        <div class="rval">9999px</div>
+        <div class="rpx">pill</div>
+      </div>
+    </div>
+    <p class="bp-foot" style="margin-top:12px">sm/md/lg derive from <b style="color:var(--maroon)">--radius</b>. Off-scale hardcoded radii in globals.css bypass the token: <b style="color:var(--maroon)">.glass</b> 16px · <b style="color:var(--maroon)">.glass-subtle</b> 12px · <b style="color:var(--maroon)">.search-bar / .pink-btn</b> 5px.</p>
+  </section>
+
+  <!-- Block 2: Container rules -->
+  <section class="block">
+    <div class="blkhead">
+      <h2>Container rules</h2>
+      <span class="note">theme.container · centered · padded · capped</span>
+    </div>
+    <div class="viewport">
+      <div class="vp-bar">
+        <span><span class="dot"></span>2xl viewport — <b>1400px</b> cap</span>
+        <span>center: true</span>
+      </div>
+      <div class="vp-body">
+        <span class="gutter-tag l">padding 2rem</span>
+        <span class="gutter-tag r">padding 2rem</span>
+        <div class="content-col">
+          <div>
+            <div class="ctitle">centered content column</div>
+            <div class="cval">margin-inline: auto · max-width 1400px @ 2xl</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <p class="cap-max">screens: { <b>"2xl": "1400px"</b> } &nbsp;·&nbsp; padding: <b>"2rem"</b> &nbsp;·&nbsp; center: <b>true</b></p>
+    <p class="deadnote"><b>Reality:</b> this config is <b>dead</b> — <code>.container</code> is used nowhere in <code>src/</code>. Each page rolls its own centered column: <code>max-w-[800px]</code> (artist), <code>max-w-[1000px]</code> (nav), <code>max-w-2xl</code> (home / add-artist). Gutters cluster on <code>px-4/px-5 → sm:px-8/sm:px-10</code>.</p>
+  </section>
+
+  <!-- Block 3: breakpoints + ramp -->
+  <section class="block">
+    <div class="blkhead">
+      <h2>Breakpoints &amp; spacing ramp</h2>
+      <span class="note">stock Tailwind screens · 4px base scale</span>
+    </div>
+    <div class="lower">
+      <div>
+        <table class="bp">
+          <thead>
+            <tr><th>Token</th><th>Min-width</th><th style="width:34%">Scale</th></tr>
+          </thead>
+          <tbody>
+            <tr><td class="tok">sm</td><td class="val">640px</td><td><div class="track"><div class="fill" style="width:42%"></div></div></td></tr>
+            <tr><td class="tok">md</td><td class="val">768px</td><td><div class="track"><div class="fill" style="width:50%"></div></div></td></tr>
+            <tr><td class="tok">lg</td><td class="val">1024px</td><td><div class="track"><div class="fill" style="width:67%"></div></div></td></tr>
+            <tr><td class="tok">xl</td><td class="val">1280px</td><td><div class="track"><div class="fill" style="width:83%"></div></div></td></tr>
+            <tr><td class="tok">2xl</td><td class="val">1536px</td><td><div class="track"><div class="fill" style="width:100%"></div></div></td></tr>
+          </tbody>
+        </table>
+        <p class="bp-foot">All defaults — <b style="color:var(--maroon)">theme.screens</b> is never overridden. The 2xl <b style="color:var(--maroon)">breakpoint</b> is 1536px; the container's 2xl <b style="color:var(--maroon)">max-width</b> cap (1400px, above) is separate. Effective use is near-two-breakpoint: sm 157× · md 41×. One raw SCSS <code style="font-family:var(--mono)">@media (max-width:768px)</code> duplicates <b style="color:var(--maroon)">md</b>.</p>
+      </div>
+      <div>
+        <div class="ramp">
+          <div class="rrow"><div class="rbar" style="width:12px"></div><span class="rlabel"><b>4px</b></span><span class="rtok">gap-1 · space-1</span></div>
+          <div class="rrow"><div class="rbar" style="width:24px"></div><span class="rlabel"><b>8px</b></span><span class="rtok">gap-2 · space-2</span></div>
+          <div class="rrow"><div class="rbar" style="width:36px"></div><span class="rlabel"><b>12px</b></span><span class="rtok">gap-3 · space-3</span></div>
+          <div class="rrow"><div class="rbar" style="width:48px"></div><span class="rlabel"><b>16px</b></span><span class="rtok">gap-4 · space-y-4</span></div>
+          <div class="rrow"><div class="rbar" style="width:72px"></div><span class="rlabel"><b>24px</b></span><span class="rtok">space-y-6 (sections)</span></div>
+          <div class="rrow"><div class="rbar" style="width:96px"></div><span class="rlabel"><b>32px</b></span><span class="rtok">gap-8 · p-8</span></div>
+        </div>
+        <p class="ramp-foot">4px base grid. Favorites: <b style="color:var(--maroon)">gap-2</b> (65×) inline · <b style="color:var(--maroon)">space-y-4</b> (24×) stacks · <b style="color:var(--maroon)">space-y-6</b> page sections.</p>
+      </div>
+    </div>
+  </section>
+
+  <footer class="ft">
+    <b>Sources:</b> tailwind.config.ts (container, borderRadius) · src/app/globals.css (--radius: 0.5rem) · DESIGN.md §Layout &amp; spacing<br>
+    <b>Honest note:</b> KoHo never loads → captions render in system sans. Container config &amp; the 2xl 1400px cap are declared but unused; radius scale &amp; breakpoints are unmodified shadcn/Tailwind defaults.
+  </footer>
+</div>
+</body>
+</html>

--- a/design-system/foundations/typography.html
+++ b/design-system/foundations/typography.html
@@ -1,0 +1,442 @@
+<!-- @dsCard group="Type" name="Typography" subtitle="system sans (KoHo intended, never loads) · scale + display" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root{
+    /* real --background / --foreground from globals.css :root (stock shadcn slate) */
+    --bg: hsl(0 0% 100%);
+    --fg: hsl(222.2 84% 4.9%);
+    --muted-fg: hsl(215.4 16.3% 46.9%);
+    --border: hsl(214.3 31.8% 91.4%);
+    --card: hsl(210 40% 98%);
+    --radius: 0.5rem; /* base radius token */
+    /* the real on-screen pink (57 hardcoded uses, in no palette) */
+    --wordmark-pink: #ff9ce3;
+    /* home-text-h2 subtitle colors */
+    --h2-light: #9b83a0;
+    --h2-dark: #a08ba8;
+    /* the real Tailwind default font-sans stack the app actually renders in */
+    --sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  }
+  *{box-sizing:border-box;}
+  html,body{margin:0;}
+  body{
+    background:var(--bg);
+    color:var(--fg);
+    font-family:var(--sans);
+    -webkit-font-smoothing:antialiased;
+    line-height:1.4;
+    padding:40px clamp(20px,4vw,56px) 56px;
+  }
+  .wrap{max-width:1040px;margin:0 auto;}
+
+  header.head{margin-bottom:36px;}
+  .eyebrow{
+    font-family:var(--mono);
+    font-size:11px;
+    letter-spacing:.14em;
+    text-transform:uppercase;
+    color:var(--muted-fg);
+    margin:0 0 10px;
+  }
+  h1.title{
+    font-size:34px;
+    font-weight:700;
+    letter-spacing:-.02em;
+    margin:0 0 8px;
+  }
+  .subtitle{
+    color:var(--muted-fg);
+    font-size:15px;
+    margin:0;
+    max-width:62ch;
+  }
+
+  section{margin-top:44px;}
+  .sec-head{
+    display:flex;
+    align-items:baseline;
+    gap:12px;
+    border-bottom:1px solid var(--border);
+    padding-bottom:10px;
+    margin-bottom:20px;
+    flex-wrap:wrap;
+  }
+  .sec-head h2{
+    font-size:13px;
+    font-weight:600;
+    text-transform:uppercase;
+    letter-spacing:.09em;
+    margin:0;
+  }
+  .sec-head .note{
+    font-family:var(--mono);
+    font-size:11.5px;
+    color:var(--muted-fg);
+  }
+
+  /* ---- honest KoHo caption banner ---- */
+  .honest{
+    display:flex;
+    gap:12px;
+    align-items:flex-start;
+    background:var(--card);
+    border:1px solid var(--border);
+    border-left:3px solid var(--wordmark-pink);
+    border-radius:var(--radius);
+    padding:14px 16px;
+    margin-top:24px;
+    font-size:13.5px;
+    color:#4a4152;
+    line-height:1.5;
+  }
+  .honest .icon{
+    flex:0 0 auto;
+    width:18px;height:18px;
+    border-radius:50%;
+    background:var(--wordmark-pink);
+    color:#422b46;
+    font-weight:700;
+    font-size:12px;
+    display:flex;align-items:center;justify-content:center;
+    margin-top:1px;
+  }
+  .honest code{font-family:var(--mono);font-size:12px;background:rgba(66,43,70,.07);padding:1px 5px;border-radius:4px;}
+
+  /* ---- scale table ---- */
+  .scale-scroll{overflow-x:auto;}
+  .scale{
+    display:grid;
+    grid-template-columns:max-content 1fr;
+    gap:0;
+    min-width:520px;
+    border:1px solid var(--border);
+    border-radius:var(--radius);
+    overflow:hidden;
+  }
+  .row{display:contents;}
+  .cell-meta,.cell-spec{
+    border-top:1px solid var(--border);
+    padding:14px 18px;
+    display:flex;
+    align-items:center;
+  }
+  .row:first-child .cell-meta,.row:first-child .cell-spec{border-top:none;}
+  .cell-meta{
+    flex-direction:column;
+    align-items:flex-start;
+    justify-content:center;
+    gap:5px;
+    background:var(--card);
+    min-width:210px;
+    border-right:1px solid var(--border);
+  }
+  .cls{
+    font-family:var(--mono);
+    font-size:12.5px;
+    font-weight:600;
+    color:var(--fg);
+  }
+  .dims{font-family:var(--mono);font-size:11px;color:var(--muted-fg);}
+  .use{
+    font-family:var(--mono);
+    font-size:10.5px;
+    color:var(--muted-fg);
+  }
+  .tag{
+    display:inline-block;
+    font-family:var(--mono);
+    font-size:10px;
+    padding:1px 6px;
+    border-radius:999px;
+    letter-spacing:.02em;
+  }
+  .tag-used{background:rgba(25,255,184,.16);color:#0b7d5a;}
+  .tag-unused{background:hsl(210 40% 92%);color:var(--muted-fg);}
+  .cell-spec{
+    overflow:hidden;
+    white-space:nowrap;
+    color:var(--fg);
+  }
+  .cell-spec .sample{line-height:1.05;font-weight:400;}
+
+  /* ---- weights ---- */
+  .weights{
+    display:grid;
+    grid-template-columns:repeat(auto-fill,minmax(160px,1fr));
+    gap:14px;
+  }
+  .w-card{
+    border:1px solid var(--border);
+    border-radius:var(--radius);
+    padding:16px 16px 14px;
+    background:var(--bg);
+  }
+  .w-card.dead{background:var(--card);border-style:dashed;}
+  .w-sample{font-size:30px;line-height:1;margin-bottom:12px;}
+  .w-name{font-family:var(--mono);font-size:12px;font-weight:600;}
+  .w-sub{font-family:var(--mono);font-size:10.5px;color:var(--muted-fg);margin-top:4px;line-height:1.45;}
+
+  /* ---- display / fluid headings ---- */
+  .display{
+    display:flex;
+    flex-direction:column;
+    gap:22px;
+  }
+  .disp-card{
+    border:1px solid var(--border);
+    border-radius:12px; /* off-scale, matches glass family */
+    padding:26px 26px 22px;
+    background:var(--bg);
+    overflow:hidden;
+  }
+  .disp-label{
+    font-family:var(--mono);
+    font-size:11px;
+    color:var(--muted-fg);
+    margin-bottom:16px;
+    letter-spacing:.02em;
+  }
+  .disp-label b{color:var(--fg);font-weight:600;}
+
+  /* the real homepage wordmark, faithful to HomePageSplash.tsx */
+  .wordmark{
+    text-transform:lowercase;
+    font-weight:700;
+    color:var(--wordmark-pink);
+    line-height:1;
+    margin:0;
+    font-size:clamp(32px, calc(32px + (84 - 32) * ((100vw - 360px) / (1440 - 360))), 84px);
+    letter-spacing:clamp(-1px, calc(-1px + (-4 - -1) * ((100vw - 360px) / (1440 - 360))), -4px);
+    text-shadow:0 0 40px rgba(255,156,227,0.25);
+  }
+  /* the legacy .home-text-h2 (dead code — only referenced inside globals.css) */
+  .h2legacy{
+    margin:0;
+    font-weight:700;
+    color:var(--h2-light);
+    font-size:clamp(28px, calc(28px + (78 - 28) * ((100vw - 360px) / (1440 - 360))), 70px);
+    letter-spacing:clamp(-1px, calc(-1px + (-3 - -1) * ((100vw - 360px) / (1440 - 360))), -3px);
+    line-height:clamp(36px, calc(36px + (78 - 36) * ((100vw - 360px) / (1440 - 360))), 70px);
+  }
+  .disp-meta{
+    margin-top:18px;
+    font-family:var(--mono);
+    font-size:11px;
+    color:var(--muted-fg);
+    line-height:1.7;
+    border-top:1px dashed var(--border);
+    padding-top:12px;
+  }
+  .disp-meta .k{color:#7a5c7f;}
+  .swatch{
+    display:inline-block;width:10px;height:10px;border-radius:2px;
+    vertical-align:middle;margin-right:5px;border:1px solid rgba(0,0,0,.12);
+  }
+
+  /* dark chip: wordmark stays pink in both modes; h2 subtitle shifts */
+  .darkchip{
+    margin-top:22px;
+    background:#141414;
+    border:1px solid rgba(255,255,255,.09);
+    border-radius:12px;
+    padding:22px 24px;
+    color:#e7e0ea;
+    overflow:hidden;
+  }
+  .darkchip .disp-label{color:#9b8aa0;}
+  .darkchip .disp-label b{color:#e7e0ea;}
+  .darkchip .wordmark{color:var(--wordmark-pink);}
+  .darkchip .h2legacy{color:var(--h2-dark);}
+  .darkchip .darknote{
+    font-family:var(--mono);font-size:11px;color:#9b8aa0;margin-top:14px;line-height:1.6;
+  }
+
+  .foot{
+    margin-top:40px;
+    font-family:var(--mono);
+    font-size:11px;
+    color:var(--muted-fg);
+    border-top:1px solid var(--border);
+    padding-top:14px;
+    line-height:1.7;
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="head">
+    <p class="eyebrow">Foundations · Type</p>
+    <h1 class="title">Typography</h1>
+    <p class="subtitle">Stock Tailwind type scale rendered in the system sans stack the app actually ships. No custom <code style="font-family:var(--mono);font-size:13px">fontSize</code> scale, no font tokens — the only bespoke type is two hand-rolled fluid <code style="font-family:var(--mono);font-size:13px">clamp()</code> display headings.</p>
+  </header>
+
+  <!-- honest KoHo caption -->
+  <div class="honest">
+    <span class="icon">i</span>
+    <div>
+      <b>KoHo is declared but never loads.</b> <code>.koho-extralight</code> (200), <code>.koho-light</code> (300) and the shipping <code>.pink-btn</code> all declare <code>font-family: "KoHo", sans-serif</code> — but there is no <code>next/font</code>, <code>&lt;link&gt;</code>, <code>@font-face</code> or font package anywhere in the app, so every one silently falls back to <b>system sans-serif</b>. Everything below renders in the real fallback stack. (KoHo only loads on two standalone <code>public/*privacy.html</code> legal pages.)
+    </div>
+  </div>
+
+  <!-- TYPE SCALE -->
+  <section>
+    <div class="sec-head">
+      <h2>Type scale</h2>
+      <span class="note">stock Tailwind defaults · 16px root (never overridden) · px + rem · line-height</span>
+    </div>
+    <div class="scale-scroll">
+      <div class="scale">
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-xs</span><span class="dims">12px · 0.75rem / lh 16px</span><span class="use"><span class="tag tag-used">108×</span> badges · captions · meta</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:12px">music nerd — discover artists</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-sm</span><span class="dims">14px · 0.875rem / lh 20px</span><span class="use"><span class="tag tag-used">138×</span> de-facto body / UI</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:14px">music nerd — discover artists</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-base</span><span class="dims">16px · 1rem / lh 24px</span><span class="use"><span class="tag tag-used">22×</span> Input default</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:16px">music nerd — discover artists</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-lg</span><span class="dims">18px · 1.125rem / lh 28px</span><span class="use"><span class="tag tag-used">40×</span> sub-headings</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:18px">music nerd — discover artists</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-xl</span><span class="dims">20px · 1.25rem / lh 28px</span><span class="use"><span class="tag tag-used">22×</span> section headings</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:20px">music nerd — discover</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-2xl</span><span class="dims">24px · 1.5rem / lh 32px</span><span class="use"><span class="tag tag-used">14×</span> CardTitle · artist name</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:24px;font-weight:600">music nerd — discover</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-3xl</span><span class="dims">30px · 1.875rem / lh 36px</span><span class="use"><span class="tag tag-used">5×</span> page H1s · font-bold</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:30px;font-weight:700">music nerd</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-4xl</span><span class="dims">36px · 2.25rem / lh 40px</span><span class="use"><span class="tag tag-used">1×</span> .artist-name only</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:36px;font-weight:700">music nerd</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-5xl</span><span class="dims">48px · 3rem / lh 1</span><span class="use"><span class="tag tag-unused">0×</span> unused in src/</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:48px;line-height:1;font-weight:700;color:var(--muted-fg)">music nerd</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-6xl</span><span class="dims">60px · 3.75rem / lh 1</span><span class="use"><span class="tag tag-unused">0×</span> unused in src/</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:60px;line-height:1;font-weight:700;color:var(--muted-fg)">music nerd</span></div>
+        </div>
+
+      </div>
+    </div>
+    <p style="font-family:var(--mono);font-size:11px;color:var(--muted-fg);margin:12px 2px 0;line-height:1.6">The app tops out at <b>text-4xl</b> — <b>text-5xl / text-6xl</b> (greyed) are stock Tailwind but appear nowhere in <code style="font-family:var(--mono)">src/</code>. All display type at that scale is hand-rolled clamp, below.</p>
+  </section>
+
+  <!-- WEIGHTS -->
+  <section>
+    <div class="sec-head">
+      <h2>Weights</h2>
+      <span class="note">rendered at 30px · same fallback stack</span>
+    </div>
+    <div class="weights">
+      <div class="w-card dead">
+        <div class="w-sample" style="font-weight:200">Aa nerd</div>
+        <div class="w-name">.koho-extralight</div>
+        <div class="w-sub">weight 200 · KoHo intended<br>never renders (falls back)</div>
+      </div>
+      <div class="w-card dead">
+        <div class="w-sample" style="font-weight:300">Aa nerd</div>
+        <div class="w-name">.koho-light</div>
+        <div class="w-sub">weight 300 · KoHo intended<br>never renders (falls back)</div>
+      </div>
+      <div class="w-card">
+        <div class="w-sample" style="font-weight:400">Aa nerd</div>
+        <div class="w-name">font-normal</div>
+        <div class="w-sub">weight 400 · 8×<br>occasional body reset</div>
+      </div>
+      <div class="w-card">
+        <div class="w-sample" style="font-weight:500">Aa nerd</div>
+        <div class="w-name">font-medium</div>
+        <div class="w-sub">weight 500 · 41×<br>buttons · labels</div>
+      </div>
+      <div class="w-card">
+        <div class="w-sample" style="font-weight:600">Aa nerd</div>
+        <div class="w-name">font-semibold</div>
+        <div class="w-sub">weight 600 · 62×<br>dominant heading weight</div>
+      </div>
+      <div class="w-card">
+        <div class="w-sample" style="font-weight:700">Aa nerd</div>
+        <div class="w-name">font-bold</div>
+        <div class="w-sub">weight 700 · 33×<br>page H1s</div>
+      </div>
+    </div>
+    <p style="font-family:var(--mono);font-size:11px;color:var(--muted-fg);margin:14px 2px 0;line-height:1.6">The two light weights the brand cares about — <b>200</b> &amp; <b>300</b> — are the KoHo weights that never render (dashed cards). What you see for them is whatever the system font supplies at that weight.</p>
+  </section>
+
+  <!-- DISPLAY / FLUID CLAMP -->
+  <section>
+    <div class="sec-head">
+      <h2>Display type — two hand-rolled fluid clamp headings</h2>
+      <span class="note">clamp() over 360px → 1440px viewport · resize this card to watch them scale</span>
+    </div>
+    <div class="display">
+
+      <!-- 1. the pink wordmark -->
+      <div class="disp-card">
+        <div class="disp-label"><b>1 · "music nerd" wordmark</b> — HomePageSplash.tsx (largest type on the site, inline-styled)</div>
+        <h1 class="wordmark">music nerd</h1>
+        <div class="disp-meta">
+          <span class="k">font-size</span>&nbsp;&nbsp;clamp(32px, …, 84px)<br>
+          <span class="k">letter-spacing</span>&nbsp;&nbsp;clamp(-1px, …, -4px) &nbsp;·&nbsp; <span class="k">line-height</span> 1 &nbsp;·&nbsp; lowercase font-bold<br>
+          <span class="k">color</span>&nbsp;&nbsp;<span class="swatch" style="background:#ff9ce3"></span>#ff9ce3 &nbsp;·&nbsp; <span class="k">text-shadow</span> 0 0 40px rgba(255,156,227,.25) &nbsp;— a pink glow, <b>not</b> a gradient<br>
+          <span style="color:#7a5c7f">note</span>&nbsp;&nbsp;#ff9ce3 is the on-screen pink (57 hardcoded uses) — defined in no palette, ≠ pastypink #ef95ff. Forced pink in both light &amp; dark.
+        </div>
+      </div>
+
+      <!-- 2. .home-text-h2 legacy -->
+      <div class="disp-card">
+        <div class="disp-label"><b>2 · .home-text-h2</b> — globals.css:616 &nbsp;<span style="color:#b08; background:hsl(210 40% 92%); padding:1px 6px; border-radius:999px; font-size:10px">legacy / dead</span> (referenced only inside globals.css, never applied by any .tsx)</div>
+        <h2 class="h2legacy">crowd-sourced directory</h2>
+        <div class="disp-meta">
+          <span class="k">font-size</span>&nbsp;&nbsp;clamp(28px, …, 70px)<br>
+          <span class="k">letter-spacing</span>&nbsp;&nbsp;clamp(-1px, …, -3px) &nbsp;·&nbsp; <span class="k">line-height</span> clamp(36px, …, 70px)<br>
+          <span class="k">color</span>&nbsp;&nbsp;<span class="swatch" style="background:#9b83a0"></span>#9b83a0 (light subtitle) / <span class="swatch" style="background:#a08ba8"></span>#a08ba8 (dark) &nbsp;·&nbsp; or #ff9ce3 as a title variant
+        </div>
+      </div>
+
+    </div>
+
+    <!-- dark chip -->
+    <div class="darkchip">
+      <div class="disp-label"><b>Dark mode</b> — the wordmark is the one element forced to stay pink; the h2 subtitle shifts #9b83a0 → #a08ba8</div>
+      <h1 class="wordmark">music nerd</h1>
+      <h2 class="h2legacy" style="margin-top:10px">crowd-sourced directory</h2>
+      <div class="darknote">wordmark <span class="swatch" style="background:#ff9ce3"></span>#ff9ce3 (unchanged) &nbsp;·&nbsp; h2 <span class="swatch" style="background:#a08ba8"></span>#a08ba8</div>
+    </div>
+  </section>
+
+  <p class="foot">
+    Font stack (real, Tailwind default font-sans):<br>
+    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif<br>
+    Semantic tokens: stock shadcn slate · --radius 0.5rem · body font-family: unset (no override) · sources: globals.css, HomePageSplash.tsx, DESIGN.md §Typography
+  </p>
+
+</div>
+</body>
+</html>

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -1,0 +1,113 @@
+<!-- Local review gallery for the design-system preview bundle. Not a @dsCard — exclude from design-sync. -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MusicNerd — Design System Preview Bundle</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: #0f1115;
+    color: #e7e7ea;
+    padding: 32px clamp(16px, 4vw, 56px) 96px;
+  }
+  header { max-width: 1200px; margin: 0 auto 8px; }
+  h1 { font-size: clamp(24px, 4vw, 40px); margin: 0 0 6px; letter-spacing: -0.02em; }
+  h1 .pink { color: #ff9ce3; text-shadow: 0 0 18px rgba(255,156,227,.5); }
+  .sub { color: #9aa0aa; font-size: 15px; margin: 0 0 4px; }
+  .meta { color: #6d7481; font-size: 13px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+  .group { max-width: 1200px; margin: 40px auto 0; }
+  .group > h2 {
+    font-size: 13px; text-transform: uppercase; letter-spacing: .14em;
+    color: #8a90fb; margin: 0 0 14px; padding-bottom: 8px; border-bottom: 1px solid #23262e;
+  }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); gap: 20px; }
+  .card { background: #161922; border: 1px solid #23262e; border-radius: 14px; overflow: hidden; }
+  .card .cap { padding: 12px 14px 10px; border-bottom: 1px solid #23262e; }
+  .card .name { font-weight: 650; font-size: 15px; }
+  .card .st { color: #8b93a1; font-size: 12.5px; margin-top: 2px; }
+  .card .pth { color: #5f6773; font-size: 11.5px; font-family: ui-monospace, Menlo, monospace; margin-top: 4px; }
+  .card iframe { width: 100%; height: 460px; border: 0; background: #fff; display: block; }
+  .pill { display:inline-block; font-size:11px; color:#0f1115; background:#19ffb8; border-radius:999px; padding:2px 8px; font-weight:700; margin-left:8px; vertical-align:middle;}
+</style>
+</head>
+<body>
+<header>
+  <h1><span class="pink">music nerd</span> — Design System <span class="pill">13 cards</span></h1>
+  <p class="sub">Self-contained preview cards generated from DESIGN.md and real source. This is the payload for Claude Design / design-sync.</p>
+  <p class="meta">Each tile is one <code>@dsCard</code> preview file · all offline / no external requests</p>
+</header>
+
+<section class="group">
+  <h2>Colors</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Brand palette</div><div class="st">maroon · pastyblue · pastypink · jellygreen + the 3 pinks</div><div class="pth">colors/brand-palette.html</div></div><iframe src="colors/brand-palette.html"></iframe></div>
+    <div class="card"><div class="cap"><div class="name">Semantic tokens</div><div class="st">stock shadcn slate · light + dark</div><div class="pth">colors/semantic-tokens.html</div></div><iframe src="colors/semantic-tokens.html"></iframe></div>
+  </div>
+</section>
+
+<section class="group">
+  <h2>Type</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Typography</div><div class="st">system sans (KoHo intended, never loads) · scale + display</div><div class="pth">foundations/typography.html</div></div><iframe src="foundations/typography.html"></iframe></div>
+  </div>
+</section>
+
+<section class="group">
+  <h2>Spacing</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Spacing &amp; radius</div><div class="st">container 1400px/2rem · breakpoints · radius scale</div><div class="pth">foundations/spacing-radius.html</div></div><iframe src="foundations/spacing-radius.html"></iframe></div>
+  </div>
+</section>
+
+<section class="group">
+  <h2>Surfaces</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Glass surfaces</div><div class="st">.glass / .glass-subtle · blur(20px) saturate(180%)</div><div class="pth">foundations/glass.html</div></div><iframe src="foundations/glass.html"></iframe></div>
+    <div class="card"><div class="cap"><div class="name">Gradients</div><div class="st">hero / accent gradients</div><div class="pth">foundations/gradients.html</div></div><iframe src="foundations/gradients.html"></iframe></div>
+  </div>
+</section>
+
+<section class="group">
+  <h2>Motion</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Motion</div><div class="st">fadeSlideIn · accordion · spin · live ping</div><div class="pth">foundations/motion.html</div></div><iframe src="foundations/motion.html"></iframe></div>
+  </div>
+</section>
+
+<section class="group">
+  <h2>Buttons</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Button</div><div class="st">6 cva variants × 4 sizes + legacy pink-btn</div><div class="pth">components/button.html</div></div><iframe src="components/button.html"></iframe></div>
+  </div>
+</section>
+
+<section class="group">
+  <h2>Components</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Badge</div><div class="st">all cva variants</div><div class="pth">components/badge.html</div></div><iframe src="components/badge.html"></iframe></div>
+    <div class="card"><div class="cap"><div class="name">Card</div><div class="st">header/content/footer + glass variant</div><div class="pth">components/card.html</div></div><iframe src="components/card.html"></iframe></div>
+    <div class="card"><div class="cap"><div class="name">Tabs</div><div class="st">list + active/inactive triggers</div><div class="pth">components/tabs.html</div></div><iframe src="components/tabs.html"></iframe></div>
+  </div>
+</section>
+
+<section class="group">
+  <h2>Forms</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Form controls</div><div class="st">input · textarea · select · checkbox · label</div><div class="pth">components/form-controls.html</div></div><iframe src="components/form-controls.html"></iframe></div>
+  </div>
+</section>
+
+<section class="group">
+  <h2>Patterns</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Artist links grid</div><div class="st">signature neon platform-link icons</div><div class="pth">patterns/artist-links.html</div></div><iframe src="patterns/artist-links.html"></iframe></div>
+  </div>
+</section>
+
+</body>
+</html>

--- a/design-system/patterns/artist-links.html
+++ b/design-system/patterns/artist-links.html
@@ -1,0 +1,192 @@
+<!-- @dsCard group="Patterns" name="Artist links grid" subtitle="signature neon platform-link icons" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  :root{
+    /* resolved shadcn "slate" tokens from globals.css :root (light) */
+    --background: hsl(0 0% 100%);
+    --muted-foreground: hsl(215.4 16.3% 46.9%);
+    --foreground: hsl(222.2 84% 4.9%);
+    /* brand */
+    --maroon:#422b46;
+    --pink-glow: 239,149,255;   /* #ef95ff — ArtistLinksGrid hover glow */
+    --blue-glow: 0,199,242;     /* #00c7f2 — "listen" (Deezer) variant glow */
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{
+    background:var(--background);
+    color:var(--foreground);
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+    -webkit-font-smoothing:antialiased;
+    padding:32px 28px 40px;
+    line-height:1.5;
+  }
+  .wrap{max-width:860px;margin:0 auto}
+  h1{font-size:22px;font-weight:650;letter-spacing:-.01em;margin:0 0 4px}
+  .lede{font-size:13.5px;color:var(--muted-foreground);margin:0 0 6px;max-width:60ch}
+  .intent{
+    font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
+    font-size:11px;color:var(--muted-foreground);
+    background:#f6f7f9;border:1px solid hsl(214.3 31.8% 91.4%);
+    border-radius:6px;padding:7px 10px;margin:12px 0 26px;
+  }
+  .intent b{color:var(--maroon)}
+
+  section{margin:0 0 30px}
+  .sechead{display:flex;align-items:baseline;gap:10px;margin:0 0 12px;flex-wrap:wrap}
+  .sechead h2{font-size:14px;font-weight:620;margin:0}
+  .sechead .tag{
+    font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
+    font-size:10.5px;color:var(--muted-foreground);
+  }
+
+  /* the surface the glass tiles sit over — artist pages have imagery/gradients behind.
+     A soft candy panel lets the translucent white + neon glow read. */
+  .stage{
+    border-radius:16px;
+    padding:26px 24px;
+    background:
+      radial-gradient(120% 130% at 18% 12%, rgba(42,212,252,.16), transparent 55%),
+      radial-gradient(120% 130% at 85% 90%, rgba(239,149,255,.20), transparent 55%),
+      radial-gradient(120% 130% at 60% 40%, rgba(25,255,184,.10), transparent 60%),
+      #eef1f5;
+    border:1px solid hsl(214.3 31.8% 91.4%);
+  }
+
+  /* ---- ArtistLinksGrid tile: literal resolution of the Tailwind classes ---- */
+  /* w-12 h-12 rounded-full backdrop-blur-sm bg-white/70 border border-white/40
+     shadow-sm  +  group-hover:scale-110 shadow-[0_0_15px_rgba(239,149,255,.45)] bg-white/90 */
+  .grid{display:grid;grid-template-columns:repeat(7,minmax(0,1fr));gap:12px}
+  @media(max-width:560px){.grid{grid-template-columns:repeat(4,minmax(0,1fr))}}
+
+  .chip{display:flex;flex-direction:column;align-items:center;gap:6px;text-decoration:none}
+  .tile{
+    width:48px;height:48px;border-radius:9999px;
+    background:rgba(255,255,255,.70);
+    border:1px solid rgba(255,255,255,.40);
+    -webkit-backdrop-filter:blur(4px);backdrop-filter:blur(4px);
+    box-shadow:0 1px 2px 0 rgba(0,0,0,.05);   /* shadow-sm */
+    display:flex;align-items:center;justify-content:center;overflow:hidden;
+    transition:all .3s ease;
+  }
+  .tile svg{width:28px;height:28px;display:block}          /* w-7 h-7 */
+  .label{font-size:12px;color:var(--muted-foreground);line-height:1.15;text-align:center}
+
+  /* live hover — the real "pink-glow lift" (default / social + web3 platforms) */
+  .chip:hover .tile,
+  .tile.is-hover{
+    transform:scale(1.1);
+    background:rgba(255,255,255,.90);
+    box-shadow:0 0 15px rgba(var(--pink-glow),.45);
+  }
+  /* the "listen" variant swaps the glow to blue */
+  .chip.listen:hover .tile,
+  .tile.is-hover.listen{
+    box-shadow:0 0 15px rgba(var(--blue-glow),.45);
+  }
+
+  .statecap{display:flex;gap:26px;flex-wrap:wrap;margin-top:16px}
+  .statecap div{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:10.5px;color:var(--muted-foreground);max-width:34ch}
+  .statecap b{color:var(--maroon);font-weight:600}
+  .hint{font-size:11.5px;color:var(--muted-foreground);margin:14px 0 0}
+
+  /* frozen specimens row: resting vs accented, side by side & visually distinct */
+  .compare{display:flex;gap:36px;flex-wrap:wrap;align-items:flex-end}
+  .compare .col{display:flex;flex-direction:column;align-items:center;gap:10px}
+  .compare .col .name{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:10.5px;color:var(--muted-foreground);text-align:center}
+
+  /* ---- legacy list-row renderer (ArtistLinks / StaticPlatformLink) ---- */
+  .rows{display:flex;flex-direction:column;gap:2px;max-width:340px}
+  .row{
+    display:grid;grid-template-columns:auto 1fr;align-items:center;   /* .link-item-grid */
+    column-gap:16px;                                                  /* gap-x-4 */
+    border-radius:12px;padding:8px 10px;text-decoration:none;color:#000;
+    transition:background .15s ease;
+  }
+  .row:hover{background:rgba(255,255,255,.6)}
+  .row .ico{width:34px;height:34px;border-radius:8px;overflow:hidden;display:flex;align-items:center;justify-content:center;background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.06)}
+  .row .ico svg{width:22px;height:22px}
+  .row .lab{font-size:14px;color:#000}
+</style>
+</head>
+<body>
+<!-- icon defs: same-document SVG symbols, referenced with <use> (no network, no JS) -->
+<svg width="0" height="0" style="position:absolute" aria-hidden="true" focusable="false">
+  <symbol id="g-sp" viewBox="0 0 24 24"><circle cx="12" cy="12" r="12" fill="#1DB954"/><g fill="none" stroke="#fff" stroke-linecap="round"><path d="M6.5 9.2c3.6-1 7.4-.7 10.6 1.1" stroke-width="1.9"/><path d="M7.1 12.4c2.9-.8 6-.5 8.6 1" stroke-width="1.6"/><path d="M7.7 15.3c2.3-.6 4.7-.4 6.7.8" stroke-width="1.3"/></g></symbol>
+  <symbol id="g-dz" viewBox="0 0 24 24"><g fill="#00c7f2"><rect x="3.5" y="14" width="3" height="5" rx=".6"/><rect x="8" y="11" width="3" height="8" rx=".6"/><rect x="12.5" y="8" width="3" height="11" rx=".6"/><rect x="17" y="5" width="3" height="14" rx=".6"/></g><rect x="17" y="5" width="3" height="2.2" rx=".6" fill="#ef95ff"/></symbol>
+  <symbol id="g-sc" viewBox="0 0 24 24"><g fill="#FF5500"><rect x="4" y="10" width="1.7" height="7" rx=".8"/><rect x="7" y="8" width="1.7" height="9" rx=".8"/><rect x="10" y="6.5" width="1.7" height="10.5" rx=".8"/><rect x="13" y="9" width="1.7" height="8" rx=".8"/></g><path d="M15 8.5a5 5 0 0 1 5 5 3.5 3.5 0 0 1-3.5 3.5H15z" fill="#FF7A33"/></symbol>
+  <symbol id="g-ig" viewBox="0 0 24 24"><defs><linearGradient id="igg" x1="0" y1="1" x2="1" y2="0"><stop offset="0" stop-color="#feda75"/><stop offset=".5" stop-color="#ef95ff"/><stop offset="1" stop-color="#7c3aed"/></linearGradient></defs><rect x="2.5" y="2.5" width="19" height="19" rx="5.5" fill="url(#igg)"/><circle cx="12" cy="12" r="4.4" fill="none" stroke="#fff" stroke-width="1.8"/><circle cx="17.2" cy="6.8" r="1.25" fill="#fff"/></symbol>
+  <symbol id="g-x" viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="20" rx="5" fill="#0f0f0f"/><path d="M7 6.5l4.1 5.2L7.2 17.5h1.7l3-3.9 3 3.9H19l-4.4-5.6L18.6 6.5h-1.7l-2.7 3.5-2.7-3.5z" fill="#fff"/></symbol>
+  <symbol id="g-yt" viewBox="0 0 24 24"><rect x="1.5" y="5" width="21" height="14" rx="4.5" fill="#FF0000"/><path d="M10 8.7l5.2 3.3L10 15.3z" fill="#fff"/></symbol>
+  <symbol id="g-bc" viewBox="0 0 24 24"><rect x="2.5" y="2.5" width="19" height="19" rx="4" fill="#1DA0C3"/><path d="M8 8.5h9l-3 7H5z" fill="#fff"/></symbol>
+</svg>
+<div class="wrap">
+  <h1>Artist links grid</h1>
+  <p class="lede">The signature MusicNerd platform-link renderer: circular frosted-glass tiles that lift and glow on hover — the "pink-glow lift" gesture. Two renderers coexist in the app; the glass grid is the newer, signature one.</p>
+  <p class="intent"><b>Reality note:</b> labels are declared <code>font-family:"KoHo"</code> in globals.css, but the webfont never loads — so text renders in the system sans stack, shown here. Glow uses <code>#ef95ff</code> <code>rgba(239,149,255,.45)</code>, not the <code>#ff9ce3</code> title glow (two pink hexes coexist).</p>
+
+  <!-- SPECIMEN 1 — the live grid -->
+  <section>
+    <div class="sechead">
+      <h2>ArtistLinksGrid — live tiles (hover me)</h2>
+      <span class="tag">grid-cols-7 · gap-3 · w-12 h-12 rounded-full</span>
+    </div>
+    <div class="stage">
+      <div class="grid">
+        <a class="chip" href="#" onclick="return false"><span class="tile"><svg><use href="#g-sp"/></svg></span><span class="label">Spotify</span></a>
+        <a class="chip listen" href="#" onclick="return false"><span class="tile"><svg><use href="#g-dz"/></svg></span><span class="label">Deezer</span></a>
+        <a class="chip" href="#" onclick="return false"><span class="tile"><svg><use href="#g-sc"/></svg></span><span class="label">SoundCloud</span></a>
+        <a class="chip" href="#" onclick="return false"><span class="tile"><svg><use href="#g-ig"/></svg></span><span class="label">Instagram</span></a>
+        <a class="chip" href="#" onclick="return false"><span class="tile"><svg><use href="#g-x"/></svg></span><span class="label">X</span></a>
+        <a class="chip" href="#" onclick="return false"><span class="tile"><svg><use href="#g-yt"/></svg></span><span class="label">YouTube</span></a>
+        <a class="chip" href="#" onclick="return false"><span class="tile"><svg><use href="#g-bc"/></svg></span><span class="label">Bandcamp</span></a>
+      </div>
+      <p class="hint">Hover any tile — <code style="font-family:ui-monospace,monospace">transition:all .3s</code> → <code style="font-family:ui-monospace,monospace">scale(1.1)</code> + colored glow. Social &amp; web3 = pink glow; the "listen" tile (Deezer) swaps to blue.</p>
+    </div>
+  </section>
+
+  <!-- SPECIMEN 2 — frozen states, guaranteed distinct -->
+  <section>
+    <div class="sechead">
+      <h2>Resting → accented (frozen)</h2>
+      <span class="tag">the two visual states side by side</span>
+    </div>
+    <div class="stage">
+      <div class="compare">
+        <div class="col">
+          <span class="tile"><svg><use href="#g-sc"/></svg></span>
+          <span class="name">resting<br>bg rgba(255,255,255,.70)<br>shadow-sm · scale 1.0</span>
+        </div>
+        <div class="col">
+          <span class="tile is-hover"><svg><use href="#g-ig"/></svg></span>
+          <span class="name">accented — social/web3<br>bg .90 · scale 1.10<br>glow rgba(239,149,255,.45)</span>
+        </div>
+        <div class="col">
+          <span class="tile is-hover listen"><svg><use href="#g-sp"/></svg></span>
+          <span class="name">accented — "listen"<br>bg .90 · scale 1.10<br>glow rgba(0,199,242,.45)</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- SPECIMEN 3 — the coexisting legacy renderer -->
+  <section>
+    <div class="sechead">
+      <h2>ArtistLinks — legacy list rows</h2>
+      <span class="tag">.link-item-grid · .corners-rounded · StaticPlatformLink</span>
+    </div>
+    <div class="stage" style="background:#f2f4f7">
+      <div class="rows">
+        <a class="row" href="#" onclick="return false"><span class="ico"><svg><use href="#g-sp"/></svg></span><span class="lab">Listen on Spotify</span></a>
+        <a class="row" href="#" onclick="return false"><span class="ico"><svg><use href="#g-ig"/></svg></span><span class="lab">Follow on Instagram</span></a>
+        <a class="row" href="#" onclick="return false"><span class="ico"><svg><use href="#g-yt"/></svg></span><span class="lab">Watch on YouTube</span></a>
+      </div>
+      <p class="hint">The older renderer draws links as full-width rows (icon + descriptor) rather than glass tiles — no glow, softer <code style="font-family:ui-monospace,monospace">:hover</code> background wash. Documented as a known duplication (DESIGN.md §Two artist-link renderers).</p>
+    </div>
+  </section>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds a design-system source of truth and the component-preview bundle used to sync it into **Claude Design**.

### `DESIGN.md`
A grounded design-system doc extracted from the actual code — brand + semantic tokens, typography, layout, components, motion — with **every value verified against source**. Notably documents three real, non-obvious facts about how styling works today:

- **Three disconnected color layers** that never reconcile: the Tailwind brand palette (`tailwind.config.ts`), an *unmodified stock shadcn "slate"* semantic-token layer (`globals.css` — `--primary` is navy slate, not brand pink), and a **dead `_colors.scss`** imported nowhere. Brand identity is applied via ~200 hardcoded hex literals + a ~330-line `!important` dark-mode override wall, not tokens.
- **Brand pink is fragmented across 3 hex values** — `#ef95ff` (token), `#ff9ce3` (the one actually on screen, 57×), `#edadf8` (`.pink-btn`).
- **KoHo is declared but never loads** in the app (no `next/font`/`<link>`/`@import`); `.koho-*` classes silently fall back to system sans. KoHo only loads in two orphaned `public/*privacy.html` files.

Ends with a **42-row "known inconsistencies to reconcile"** table — the design-debt backlog.

### `design-system/`
13 self-contained `@dsCard` preview HTML files (colors, type, spacing, surfaces, motion, buttons, components, forms, patterns) + an `index.html` review gallery. This is the payload for the `DesignSync` tool / `/design-sync` skill — each renders as a card in the Claude Design **Design System pane**. Every file is offline (no external requests) with Tailwind classes resolved to literal CSS, so the previews are faithful to the app's real resolved styles.

## Scope

Docs + standalone static HTML only. Nothing under `src/`/`app/`/`components/`, not in any tsconfig/eslint/jest/tailwind glob, imported nowhere — **zero effect on type-check, lint, test, or build**.

## Notes
- `design-system/index.html` is a local review aid (no `@dsCard` marker); it's excluded when syncing to Claude Design.
- Open `design-system/index.html` in a browser to review all 13 cards at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)