### PR TITLE
feat: sync design system to claude.ai/design

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,171 @@
+# design-sync notes — MusicNerdWeb
+
+Repo-specific gotchas for future syncs. Read this before re-running the converter.
+
+## The big one: this is an app, not a component library
+
+There is no `dist/`, no published package, no `.d.ts` tree. Three consequences drive most of the
+config:
+
+- **`.design-sync/ds-entry.ts` IS the library boundary.** It is hand-written and committed, and the
+  converter runs with `--entry ./.design-sync/ds-entry.ts`. Do NOT let the converter synthesize an
+  entry from `src/` — a synth entry does `export * from` every source file, which drags the async
+  server components (`ArtistLinks`, `ArtistLinksGrid`) and through them Drizzle/postgres/next-auth
+  into a browser bundle.
+- **`componentSrcMap` IS the component list**, not a set of tweaks to a discovered one. Anything you
+  add to `ds-entry.ts` must also be added there or it ships in the bundle without getting a card.
+- **Never `ln -s` the repo into `node_modules/musicnerdweb`.** It looks like the obvious way to make
+  the converter's `PKG_DIR` resolve, but it creates a symlink cycle
+  (`node_modules/musicnerdweb/node_modules/musicnerdweb/…`) that OOM'd the v8 heap during the
+  ts-morph glob. `--entry` is what makes `PKG_DIR` resolve; no symlink needed.
+
+## Tailwind must be COMPILED before the converter runs
+
+`src/app/globals.css` is raw `@tailwind` directives. Pointing `cssEntry` at it ships a stylesheet
+with no utilities in it and every component renders unstyled. `cfg.buildCmd` compiles
+`.design-sync/tailwind.ds.config.ts` → `.design-sync/.cache/ds-tailwind.css` first. **Re-run
+`buildCmd` before every converter run.**
+
+`tailwind.ds.config.ts` extends the app's real config (never redefines design values) and adds:
+1. content globs covering `.design-sync/previews/**` so authored-preview classes compile;
+2. a **safelist** of the general utility surface.
+
+The safelist is not optional. A rendered design receives only `styles.css` — there is no Tailwind
+JIT at the other end — so any class the design agent writes that isn't already in the sheet is
+silently dead. Curating the palette (brand + shadcn semantic + the ~20 hues the app actually uses,
+rather than all 22 Tailwind hues) is what keeps this at ~7MB / 464KB gzipped instead of 29MB.
+If you widen the safelist, re-check the size.
+
+## Two forked lib adapters (`.design-sync/overrides/`)
+
+Both exist because the upstream converter assumes `pkgDir == node_modules/<pkg>`, which is false here.
+
+- **`dts.mjs`** — props are extracted from the `.tsx` SOURCES, not a `.d.ts` tree. Without it every
+  contract was `{ [key: string]: unknown }` (the agent would never learn `Button` has `variant`).
+  Also bounds the ts-morph glob to `src/` (the repo-root glob walked `.next/`, 2.4GB, and OOM'd) and
+  drops props declared in `next/dist/compiled/` — Next's vendored satori injects a global
+  `tw?: string` JSX prop into every element, documented as "Specify styles using Tailwind CSS
+  classes", which would invite the agent to write `tw=` instead of `className=`. The node_modules
+  filter is deliberately scoped to that one path: Radix declares real API under node_modules
+  (`Dialog.open`, `Checkbox.checked`) and must survive.
+- **`source-kit.mjs`** — Next's App Router `_components` private-folder prefix and the `app/` router
+  root aren't in the generic-dir set, so brand components were forced into a group literally named
+  "components", which then OUTRANKED the `category:` frontmatter and made the regroup stubs no-ops.
+  Also seeds the component list from `componentSrcMap` (see above).
+
+`.design-sync/node_modules` is a gitignored symlink → `.ds-sync/node_modules`, needed so the forks
+can resolve their bare `ts-morph` import. **Recreate it on a fresh clone:**
+`ln -sfn ../.ds-sync/node_modules .design-sync/node_modules`
+
+## Component-set decisions
+
+- **`HomePageSplash` is deliberately NOT synced.** It mounts `ActivityFeed`, which imports
+  `next/link`, whose module scope reads `process.env.__NEXT_*` — Next-compiler-substituted globals
+  that don't exist in a plain browser bundle. That was a hard `ReferenceError: process is not
+  defined` at IIFE init which took down **all 28 components**, not just this one. ActivityFeed also
+  fetches `/api/activity`, which no design runtime can serve. The wordmark is documented as a
+  copyable recipe in `conventions.md` instead. **If you ever re-add it, check for `process.env` in
+  `_ds_bundle.js` — a single Next import re-breaks the whole bundle.**
+- **Sub-parts get no cards.** `ds-entry.ts` exports ~109 symbols; only 28 get cards. `CardHeader`,
+  `DialogFooter`, `SelectItem` etc. all still ship and are importable — they just don't each get a
+  duplicate preview and a near-empty contract. Each compound's authored preview demonstrates its
+  sub-parts in a real composition instead.
+- Excluded as unrenderable (DB/session/fetch-bound): `ArtistLinks`, `ArtistLinksGrid`,
+  `EditablePlatformLink`, `EditableLinkIcon`, `ActivityFeed`, `Providers`, `PrivyProviderWrapper`,
+  `nav/*`. `ArtistLinksGrid`'s glass-tile look is brand-defining, so it's captured as a documented
+  pattern in `conventions.md` rather than shipped as a component that can't render.
+
+## Authoring previews — what was learned the hard way
+
+- Import from `"musicnerdweb"` (shimmed to `window.MusicNerd`). `@/` aliases resolve too.
+- **Overlays portal to `document.body` and are viewport-`fixed`** (Dialog, Drawer, DropdownMenu,
+  Popover, Tooltip, Select, Toast). They escape their cell and get clipped. Fix with
+  `cfg.overrides.<Name> = {cardMode:"single", primaryStory:"…", viewport:"WxH"}`.
+  **Do NOT pass `className="relative"` to fight it** — `cn()` is tailwind-merge, so `relative`
+  *replaces* `fixed`, and the `-translate-50%` then yanks the content off the top edge. It renders
+  worse, not better. Pass `open` (and `modal={false}` to avoid inert/scroll-lock).
+- **`.glass` is invisible on white.** It's `rgba(255,255,255,0.55)` + a white border. It only reads
+  over color. Any preview showing a glass surface needs a saturated backdrop — the app always has
+  one (hero gradient, artist photography).
+- **`Input` ships with no border, no height, and no focus ring** (DESIGN.md #10 — it's stripped
+  bare). A bare `<Input/>` renders as an invisible blank and trips `[RENDER_BLANK]`. Form previews
+  must add `h-10 rounded-md border border-input px-3 py-2` — which is what every real form in the
+  app does. Same story for `Textarea`'s missing ring width (#11).
+- Use MusicNerd-real content (artists, platforms, contributors, MCP keys) — never foo/bar.
+
+## Findings from the preview-authoring wave
+
+Two claims came back from the parallel agents that were WRONG. Both are recorded here because they
+are exactly the mistakes a future run would repeat.
+
+- **"`bg-primary` is brand pink."** It is NOT. `--primary` is stock slate navy
+  (`222.2 47.4% 11.2%`) and the default Button renders navy. What the agent actually saw was
+  `globals.css:485` — an **unscoped** `[data-state="checked"] { background-color: #ff9ce3
+  !important }`. That selector isn't limited to Checkbox: it hits ANY Radix element in the checked
+  state, so a selected `SelectItem` and a checked `DropdownMenuCheckboxItem` also go pink. It is the
+  one place brand color reaches the primitives without a call-site class.
+- **"`text-[#ff9ce3]` renders black / arbitrary utilities don't apply."** They DO. Verified by
+  computed style in headless chromium: `text-[#ff9ce3]` → `rgb(255, 156, 227)`. The agent observed
+  truthfully but the cause was a moving stylesheet — the orchestrator recompiled and swapped
+  `_ds_bundle.css` **mid-wave**, so early captures ran against a sheet that genuinely lacked the
+  class. **Lesson: never swap the shared stylesheet while agents are capturing.** Recompile before
+  dispatch, or after the wave — never during.
+
+Real findings worth keeping:
+
+- **`.home-text-h2` is a colour trap, not a type class.** It looks like pure fluid-type
+  (font-size/letter-spacing clamps) but `globals.css:186-260` also pins `color: … !important`
+  (`:first-child` → `#ff9ce3`, otherwise → `#9b83a0`), silently overriding any `text-*` utility on
+  it. Don't use it for hero markup.
+- **`TableCell`'s truncation is conditional.** `whitespace-nowrap overflow-hidden text-ellipsis` on
+  a `<td>` does nothing under the default `table-layout: auto` (the wrapper scrolls instead). It
+  only ellipsizes under `table-fixed`, which `UserEntriesTable` never sets.
+- **`Checkbox` indeterminate is genuinely broken.** The Indicator renders for both `checked` and
+  `indeterminate`, but the fill is gated on `data-[state=checked]` only — so indeterminate paints a
+  checkmark on an *unfilled* square. Stock shadcn shows a dash. The admin select-all header hits
+  this on every partial page selection. A real fix candidate in the app.
+- **`LoadingPage` is `fixed inset-0 z-[9999]`** — it blankets anything it's dropped into unless an
+  ancestor establishes a containing block (an inline `transform` does it).
+- **The capture server can't serve SVG.** `.ds-sync/storybook/http-serve.mjs`'s MIME table has no
+  `.svg`, and it doesn't serve Next's `public/`. `previews/LoadingPage.tsx` inlines the real
+  `public/spinner.svg` as a data URI to work around it (the shipped asset, not a substitute).
+- **The safelist had real gaps** the app's own source never exercised: `basis-*` (Carousel slides
+  collapsed without it), `table-fixed`, and arbitrary gradient stops. Added. Expect more gaps in
+  this shape — the design agent writes classes the app never did.
+- `react-hook-form` resolves inside previews, and hooks run during capture — so validation error
+  states can be injected with `form.setError` in a `useEffect` (no submit needed).
+- A preview cell whose only axis is a sub-30% opacity delta will not read on a downscaled review
+  sheet. Pair it with a full-strength baseline.
+
+## Known render warns (expected — not new findings)
+
+Check new warns against this list; anything not here is genuinely new.
+
+- `[FONT_MISSING] "KoHo"` — **expected, and correct.** KoHo is declared in `globals.css`
+  (`.koho-extralight`, `.koho-light`, `.pink-btn`) but is loaded NOWHERE in the app: no `next/font`,
+  no `<link>`, no `@font-face`. It silently falls back to system sans in production today (DESIGN.md
+  headline typography finding; design-debt #7 is still open). **The user explicitly chose to match
+  production and NOT ship KoHo** — shipping it would make every design render in a typeface the real
+  site doesn't have. The warn is a truthful signal; leave it firing.
+- `[FONT_MISSING] "Cambria"` — false alarm. It's just a member of Tailwind's default `font-serif`
+  fallback stack (`ui-serif, Georgia, Cambria, …`). No `@font-face` is wanted.
+- `[TOKENS_MISSING]` (9 vars) — all set at runtime, never by a stylesheet:
+  `--radix-accordion-content-height` (Radix measures it), `--tw-shadow-color` (Tailwind internal),
+  `--scrollbar-*` (the `tailwind-scrollbar` plugin emits them per-utility).
+- `[RENDER_BLANK]` on a bare `Input`/`Textarea`/`Checkbox` floor card — a true statement about a
+  borderless primitive, resolved by authoring the preview (see above).
+
+## Re-sync risks
+
+- **`buildCmd` (the Tailwind compile) is a hard prerequisite.** Skip it and `cssEntry` points at a
+  stale or missing file. The driver does not know to run it for you.
+- **The safelist can silently rot.** It's a hand-maintained approximation of "what the design agent
+  might write". If the app adopts a new hue or a plugin, add it — a missing class doesn't error, it
+  just renders unstyled.
+- **The two lib forks are pinned to upstream internals** (`projectFor`, `isOwnProp`, the group
+  derivation, the component-list seed). On re-sync, diff them against `.ds-sync/lib/*.mjs` and merge
+  upstream changes; if the converter's shape changed, the forks may need rework rather than a merge.
+- **`.next/` size is load-bearing for build time.** The dts fork bounds its glob to `src/`, so a big
+  `.next/` is fine now — but any change that re-widens a glob to the repo root will OOM again.
+- `HomePageSplash`/`ActivityFeed` are the tripwire for Next imports leaking into the bundle. Grep
+  `_ds_bundle.js` for `process.env` after any change to `ds-entry.ts`.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,146 @@
+{
+  "projectId": "5c842a8e-3d59-454b-8153-4249ee34a66f",
+  "shape": "package",
+  "pkg": "musicnerdweb",
+  "globalName": "MusicNerd",
+  "srcDir": "src",
+  "tsconfig": "tsconfig.json",
+  "buildCmd": "npx tailwindcss -c .design-sync/tailwind.ds.config.ts -i src/app/globals.css -o .design-sync/.cache/ds-tailwind.css",
+  "cssEntry": ".design-sync/.cache/ds-tailwind.css",
+  "libOverrides": {
+    "dts.mjs": "app repo has no shipped .d.ts tree \u2014 extract props from the .tsx sources (and bound the glob to src/, since the repo-root scan OOM'd on .next/)",
+    "source-kit.mjs": "Next.js App Router `_components` private-folder prefix defeated the generic-dir test, forcing a group named \"components\" that outranked the category frontmatter"
+  },
+  "provider": {
+    "component": "ThemeProvider",
+    "inner": {
+      "component": "EditModeProvider",
+      "props": {
+        "canEdit": true
+      }
+    }
+  },
+  "componentSrcMap": {
+    "AspectRatio": "src/components/ui/aspect-ratio.tsx",
+    "Badge": "src/components/ui/badge.tsx",
+    "Button": "src/components/ui/button.tsx",
+    "Calendar": "src/components/ui/calendar.tsx",
+    "Card": "src/components/ui/card.tsx",
+    "Carousel": "src/components/ui/carousel.tsx",
+    "Checkbox": "src/components/ui/checkbox.tsx",
+    "Dialog": "src/components/ui/dialog.tsx",
+    "Drawer": "src/components/ui/drawer.tsx",
+    "DropdownMenu": "src/components/ui/dropdown-menu.tsx",
+    "Form": "src/components/ui/form.tsx",
+    "Input": "src/components/ui/input.tsx",
+    "Label": "src/components/ui/label.tsx",
+    "Popover": "src/components/ui/popover.tsx",
+    "Select": "src/components/ui/select.tsx",
+    "Table": "src/components/ui/table.tsx",
+    "Tabs": "src/components/ui/tabs.tsx",
+    "Textarea": "src/components/ui/textarea.tsx",
+    "Toast": "src/components/ui/toast.tsx",
+    "Tooltip": "src/components/ui/tooltip.tsx",
+    "BookmarkButton": "src/app/_components/BookmarkButton.tsx",
+    "EditModeToggle": "src/app/_components/EditModeToggle.tsx",
+    "Footer": "src/app/_components/Footer.tsx",
+    "LoadingPage": "src/app/_components/LoadingPage.tsx",
+    "PleaseLoginPage": "src/app/_components/PleaseLoginPage.tsx",
+    "SlidingText": "src/app/_components/SlidingText.tsx",
+    "ThemeToggle": "src/app/_components/ThemeToggle.tsx",
+    "TypeWriter": "src/app/_components/TypeWriter.tsx"
+  },
+  "guidelinesGlob": [
+    "DESIGN.md"
+  ],
+  "docsMap": {
+    "AspectRatio": ".design-sync/groups/AspectRatio.md",
+    "Badge": ".design-sync/groups/Badge.md",
+    "BookmarkButton": ".design-sync/groups/BookmarkButton.md",
+    "Button": ".design-sync/groups/Button.md",
+    "Calendar": ".design-sync/groups/Calendar.md",
+    "Card": ".design-sync/groups/Card.md",
+    "Carousel": ".design-sync/groups/Carousel.md",
+    "Checkbox": ".design-sync/groups/Checkbox.md",
+    "Dialog": ".design-sync/groups/Dialog.md",
+    "Drawer": ".design-sync/groups/Drawer.md",
+    "DropdownMenu": ".design-sync/groups/DropdownMenu.md",
+    "EditModeToggle": ".design-sync/groups/EditModeToggle.md",
+    "Footer": ".design-sync/groups/Footer.md",
+    "Form": ".design-sync/groups/Form.md",
+    "Input": ".design-sync/groups/Input.md",
+    "Label": ".design-sync/groups/Label.md",
+    "LoadingPage": ".design-sync/groups/LoadingPage.md",
+    "PleaseLoginPage": ".design-sync/groups/PleaseLoginPage.md",
+    "Popover": ".design-sync/groups/Popover.md",
+    "Select": ".design-sync/groups/Select.md",
+    "SlidingText": ".design-sync/groups/SlidingText.md",
+    "Table": ".design-sync/groups/Table.md",
+    "Tabs": ".design-sync/groups/Tabs.md",
+    "Textarea": ".design-sync/groups/Textarea.md",
+    "ThemeToggle": ".design-sync/groups/ThemeToggle.md",
+    "Toast": ".design-sync/groups/Toast.md",
+    "Tooltip": ".design-sync/groups/Tooltip.md",
+    "TypeWriter": ".design-sync/groups/TypeWriter.md"
+  },
+  "overrides": {
+    "Dialog": {
+      "cardMode": "single",
+      "primaryStory": "Open",
+      "viewport": "680x460"
+    },
+    "Drawer": {
+      "cardMode": "single",
+      "primaryStory": "Open",
+      "viewport": "680x540"
+    },
+    "DropdownMenu": {
+      "cardMode": "single",
+      "primaryStory": "Open",
+      "viewport": "560x440"
+    },
+    "Popover": {
+      "cardMode": "single",
+      "primaryStory": "Open",
+      "viewport": "560x400"
+    },
+    "Tooltip": {
+      "cardMode": "single",
+      "primaryStory": "Open",
+      "viewport": "480x280"
+    },
+    "Select": {
+      "cardMode": "single",
+      "primaryStory": "Open",
+      "viewport": "560x440"
+    },
+    "Toast": {
+      "cardMode": "single",
+      "primaryStory": "Default",
+      "viewport": "640x340"
+    },
+    "Table": {
+      "cardMode": "column"
+    },
+    "Calendar": {
+      "cardMode": "column"
+    },
+    "EditModeToggle": {
+      "cardMode": "column"
+    },
+    "Carousel": {
+      "cardMode": "column"
+    },
+    "AspectRatio": {
+      "cardMode": "column"
+    },
+    "Tabs": {
+      "cardMode": "column"
+    },
+    "LoadingPage": {
+      "cardMode": "single",
+      "primaryStory": "Default"
+    }
+  },
+  "readmeHeader": ".design-sync/conventions.md"
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,130 @@
+# Building with the MusicNerd design system
+
+MusicNerd is a **playful, indie, candy-neon music directory dressed in Apple-style frosted glass.**
+Neon accents on quiet chrome; glass surfaces; round everything; calm ambient motion; a lowercase,
+friendly voice. When in doubt, the `music nerd` wordmark and the `.glass` panel are the templates.
+
+## Setup: wrap the tree in ThemeProvider
+
+`ThemeProvider` owns the light/dark class on the root and is what `ThemeToggle` reads through
+`useTheme()`. Without it, `ThemeToggle` throws. `EditModeProvider` gates the artist-page edit
+affordances (`EditModeToggle` renders inert unless `canEdit` is true).
+
+```jsx
+<ThemeProvider>
+  <EditModeProvider canEdit={false}>
+    <YourScreen />
+  </EditModeProvider>
+</ThemeProvider>
+```
+
+Dark mode is **class-based** (`.dark` on `<html>`), driven by this custom provider — *not*
+`next-themes`. Don't reach for `next-themes` APIs.
+
+## The styling idiom: Tailwind utilities
+
+Everything is styled with **Tailwind utility classes** — there are no CSS modules and no style props.
+Compose layout with utilities; use components for the controls.
+
+**Brand palette** (real Tailwind classes — `bg-`, `text-`, `border-`):
+
+| Class | Value | Use |
+|---|---|---|
+| `pastypink` | `#ef95ff` | the brand token — accents, borders, glows |
+| `pastyblue` | `#2ad4fc` | cyan accent; takes over from pink in dark mode |
+| `jellygreen` | `#19ffb8` | mint accent (live/success) |
+| `maroon` | `#422b46` | deep-aubergine ink for body/footer text |
+
+**Semantic tokens** (shadcn slate, consumed as `bg-*`/`text-*`): `background`, `foreground`, `card`,
+`popover`, `primary`, `secondary`, `muted`, `accent`, `destructive`, `border`, `input`, `ring`, each
+with a `-foreground` counterpart. Radius derives from `--radius` (8px): `rounded-lg` 8, `rounded-md`
+6, `rounded-sm` 4.
+
+⚠️ **The semantic layer is stock shadcn slate and carries NO brand color.** `bg-primary` is navy,
+not pink. To put brand color on a component, add a brand class at the call site — never fork the
+primitive. This is exactly what the real app does:
+
+```jsx
+<Button variant="outline" size="sm"
+  className="border-pastypink/50 text-pastypink hover:bg-pastypink hover:text-white">
+  Edit mode
+</Button>
+```
+
+**The pink users actually see is `#ff9ce3`** — the wordmark, highlight glows, focus rings. It is in
+no palette. `text-[#ff9ce3]`, `bg-[#ff9ce3]` and `border-[#ff9ce3]` are available. Three pinks exist
+(`#ef95ff`, `#ff9ce3`, `#EDADF8`); prefer `pastypink` for chrome and `#ff9ce3` for the identity
+glow. **Do not invent a fourth pink or a new blue.**
+
+**One exception, and it is a global one:** `globals.css` ships an *unscoped* `!important` rule —
+`[data-state="checked"] { background-color: #ff9ce3 }` (cyan `#2ad4fc` in dark). It matches **any**
+Radix element in the checked state, so a checked `Checkbox`, the selected `SelectItem`, and a
+checked `DropdownMenuCheckboxItem` all pick up brand pink automatically. That is the one place brand
+color reaches the primitives without a call-site class. Don't fight it, and don't try to restyle a
+checked state with a utility — `!important` will win.
+
+⚠️ **This stylesheet is pre-compiled — there is no Tailwind JIT at render time.** The standard
+utility scale is fully available (spacing, sizing, color, type, flex/grid, radius, shadow, opacity,
+transitions, and the `sm:`/`md:`/`lg:`/`hover:`/`focus:`/`dark:`/`group-hover:` variants). But an
+**arbitrary value you invent** (`p-[13px]`, `bg-[#123456]`) will silently not resolve unless it
+already appears above or in the app's source. For a genuine one-off, use an inline `style` — which
+is what the app itself does for the wordmark.
+
+## Glass is the surface language
+
+`.glass` and `.glass-subtle` are global utility classes — the primary panel surface, used in
+preference to `Card` for page sections.
+
+```jsx
+<section className="glass space-y-3 p-4 sm:p-5">…</section>
+```
+
+`.glass` = `rgba(255,255,255,0.55)` + `backdrop-filter: blur(20px) saturate(180%)` + 16px radius.
+**It is invisible on a white background** — it only reads over color, so give it a backdrop
+(a gradient wash, artwork, a photo). `.glass-subtle` is the lighter 12px-radius variant.
+
+## Signature patterns worth copying
+
+**The wordmark** — the single most recognizable element. Lowercase, fluid-clamped, pink glow (not a
+gradient):
+
+```jsx
+<h1 className="lowercase font-bold" style={{
+  fontSize: 'clamp(32px, calc(32px + 52 * ((100vw - 360px) / 1080)), 84px)',
+  letterSpacing: 'clamp(-1px, calc(-1px + -3 * ((100vw - 360px) / 1080)), -4px)',
+  lineHeight: 1, color: '#ff9ce3',
+  textShadow: '0 0 40px rgba(255, 156, 227, 0.25)',
+}}>music nerd</h1>
+```
+
+**The pink-glow lift** — the signature hover, on circular link tiles and cards:
+`transition-all duration-300 group-hover:scale-110 group-hover:shadow-[0_0_15px_rgba(239,149,255,0.45)]`.
+Listen-platform tiles swap the glow to blue (`rgba(0,199,242,0.45)`).
+
+**Glass icon tiles** (the artist-page link grid — a component you won't find in this library, so
+build it from utilities):
+`w-12 h-12 rounded-full backdrop-blur-sm bg-white/70 dark:bg-white/10 border border-white/40`.
+
+**Page shell** — a centered column; there is no container primitive:
+`w-full max-w-[800px] mx-auto px-4 py-5 space-y-6`. Sections stack on `space-y-6`, content inside a
+panel on `space-y-3`, inline clusters on `gap-2`. `duration-300` is the de-facto motion standard.
+
+## Traps
+
+- **`Input` ships with no border, no height, and no focus ring.** A bare `<Input/>` is an invisible
+  blank. Always add chrome: `<Input className="h-10 rounded-md border border-input px-3 py-2" />`.
+  `Textarea` is likewise missing its focus-ring width.
+- **The `default` Button variant has no hover state** (stock `hover:bg-primary/90` was removed).
+- **KoHo is not a usable font.** `globals.css` declares `.koho-extralight`, `.koho-light`, and
+  `.pink-btn` in `"KoHo", sans-serif`, but KoHo is loaded nowhere — those classes silently render as
+  system sans. **Assume the app font is the default Tailwind sans stack.** Don't apply `.koho-*`.
+- Prefer token swaps over `!important` dark-mode patches, and prefer `.glass` panels over opaque,
+  hard-edged flat cards.
+- Avoid ALL-CAPS shouting, corporate copy, and sharp brutalist geometry — they contradict the
+  lowercase, glassy, playful personality.
+
+## Where the truth lives
+
+Read `styles.css` (and the `_ds_bundle.css` it imports) for the real token and utility definitions,
+`guidelines/DESIGN.md` for the full design system of record, and each component's `.prompt.md` +
+`.d.ts` for its actual API.

--- a/.design-sync/ds-entry.ts
+++ b/.design-sync/ds-entry.ts
@@ -1,0 +1,149 @@
+// Design-system entry for design-sync (--entry). MusicNerdWeb is a Next.js app, not a published
+// component library, so there is no dist/ to point the converter at. This file IS the library
+// boundary: it re-exports exactly the components that belong in the design system.
+//
+// Why hand-written rather than letting the converter synthesize an entry from src/: a synthesized
+// entry does `export * from` EVERY source file, which would pull the async server components
+// (ArtistLinks, ArtistLinksGrid) — and through them Drizzle, postgres and next-auth — into a
+// browser bundle. Those cannot render in a design runtime anyway. Enumerating keeps the bundle
+// to real, renderable UI.
+//
+// Anything added here must also be listed in .design-sync/config.json `componentSrcMap` (that map
+// is the component list — there is no .d.ts tree to derive it from).
+
+// ── Primitives: shadcn/ui + Radix (src/components/ui/) ──────────────────────
+export { AspectRatio } from "@/components/ui/aspect-ratio";
+export { Badge, badgeVariants } from "@/components/ui/badge";
+export { Button, buttonVariants } from "@/components/ui/button";
+export { Calendar } from "@/components/ui/calendar";
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+export {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+} from "@/components/ui/carousel";
+export { Checkbox } from "@/components/ui/checkbox";
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+} from "@/components/ui/drawer";
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+} from "@/components/ui/dropdown-menu";
+export {
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+} from "@/components/ui/form";
+export { Input } from "@/components/ui/input";
+export { Label } from "@/components/ui/label";
+export { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+} from "@/components/ui/select";
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+} from "@/components/ui/table";
+export { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+export { Textarea } from "@/components/ui/textarea";
+export {
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+} from "@/components/ui/toast";
+export {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "@/components/ui/tooltip";
+
+// ── Brand components (src/app/_components/) ─────────────────────────────────
+// These carry MusicNerd's identity; DESIGN.md: "brand identity is carried by the custom
+// components + global utilities, not the primitives."
+export { ThemeProvider, useTheme } from "@/app/_components/ThemeProvider";
+export { ThemeToggle } from "@/app/_components/ThemeToggle";
+export { EditModeContext, EditModeProvider } from "@/app/_components/EditModeContext";
+
+export { default as EditModeToggle } from "@/app/_components/EditModeToggle";
+export { default as BookmarkButton } from "@/app/_components/BookmarkButton";
+export { default as Footer } from "@/app/_components/Footer";
+export { default as LoadingPage } from "@/app/_components/LoadingPage";
+export { default as PleaseLoginPage } from "@/app/_components/PleaseLoginPage";
+export { default as SlidingText } from "@/app/_components/SlidingText";
+export { default as TypeWriter } from "@/app/_components/TypeWriter";
+
+// DELIBERATELY NOT EXPORTED: HomePageSplash.
+// It is the whole homepage — the "music nerd" wordmark PLUS ActivityFeed. ActivityFeed imports
+// next/link, whose module scope reads Next-internal `process.env.__NEXT_*` globals that only exist
+// because the Next compiler substitutes them at build time. In a plain browser bundle that is a
+// hard `ReferenceError: process is not defined` at IIFE init, which took down all 29 components,
+// not just this one. ActivityFeed also fetches /api/activity, which no design runtime can serve.
+// Shipping it would drag Next's router internals into every rendered design to display a
+// permanently-empty feed. The wordmark itself is pure inline-styled markup, so it is documented
+// as a copyable recipe in .design-sync/conventions.md instead.

--- a/.design-sync/groups/AspectRatio.md
+++ b/.design-sync/groups/AspectRatio.md
@@ -1,0 +1,3 @@
+---
+category: Layout
+---

--- a/.design-sync/groups/Badge.md
+++ b/.design-sync/groups/Badge.md
@@ -1,0 +1,3 @@
+---
+category: Content
+---

--- a/.design-sync/groups/BookmarkButton.md
+++ b/.design-sync/groups/BookmarkButton.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/.design-sync/groups/Button.md
+++ b/.design-sync/groups/Button.md
@@ -1,0 +1,3 @@
+---
+category: Actions
+---

--- a/.design-sync/groups/Calendar.md
+++ b/.design-sync/groups/Calendar.md
@@ -1,0 +1,3 @@
+---
+category: Content
+---

--- a/.design-sync/groups/Card.md
+++ b/.design-sync/groups/Card.md
@@ -1,0 +1,3 @@
+---
+category: Layout
+---

--- a/.design-sync/groups/Carousel.md
+++ b/.design-sync/groups/Carousel.md
@@ -1,0 +1,3 @@
+---
+category: Content
+---

--- a/.design-sync/groups/Checkbox.md
+++ b/.design-sync/groups/Checkbox.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/.design-sync/groups/Dialog.md
+++ b/.design-sync/groups/Dialog.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/.design-sync/groups/Drawer.md
+++ b/.design-sync/groups/Drawer.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/.design-sync/groups/DropdownMenu.md
+++ b/.design-sync/groups/DropdownMenu.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/.design-sync/groups/EditModeToggle.md
+++ b/.design-sync/groups/EditModeToggle.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/.design-sync/groups/Footer.md
+++ b/.design-sync/groups/Footer.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/.design-sync/groups/Form.md
+++ b/.design-sync/groups/Form.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/.design-sync/groups/Input.md
+++ b/.design-sync/groups/Input.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/.design-sync/groups/Label.md
+++ b/.design-sync/groups/Label.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/.design-sync/groups/LoadingPage.md
+++ b/.design-sync/groups/LoadingPage.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/.design-sync/groups/PleaseLoginPage.md
+++ b/.design-sync/groups/PleaseLoginPage.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/.design-sync/groups/Popover.md
+++ b/.design-sync/groups/Popover.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/.design-sync/groups/Select.md
+++ b/.design-sync/groups/Select.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/.design-sync/groups/SlidingText.md
+++ b/.design-sync/groups/SlidingText.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/.design-sync/groups/Table.md
+++ b/.design-sync/groups/Table.md
@@ -1,0 +1,3 @@
+---
+category: Layout
+---

--- a/.design-sync/groups/Tabs.md
+++ b/.design-sync/groups/Tabs.md
@@ -1,0 +1,3 @@
+---
+category: Navigation
+---

--- a/.design-sync/groups/Textarea.md
+++ b/.design-sync/groups/Textarea.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/.design-sync/groups/ThemeToggle.md
+++ b/.design-sync/groups/ThemeToggle.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/.design-sync/groups/Toast.md
+++ b/.design-sync/groups/Toast.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/.design-sync/groups/Tooltip.md
+++ b/.design-sync/groups/Tooltip.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/.design-sync/groups/TypeWriter.md
+++ b/.design-sync/groups/TypeWriter.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/.design-sync/overrides/dts.mjs
+++ b/.design-sync/overrides/dts.mjs
@@ -1,0 +1,580 @@
+// forked from design-sync lib/dts.mjs — MusicNerdWeb is a Next.js app with no shipped .d.ts tree,
+// so props are extracted from the .tsx sources instead of a declaration tree.
+//
+// The upstream adapter assumes a published package: it globs `<typesRoot>/**/*.d.ts` and reads the
+// export list from `pkgJson.types`. Neither exists here — typesRoot falls back to the repo root
+// (which globbed 2.4GB of .next/ and OOM'd v8), and every <Name>Props came out as
+// `{ [key: string]: unknown }`, which would have taught the design agent nothing about
+// Button's variant/size or any other real API.
+//
+// Only projectFor() is changed. It now:
+//   1. bounds the glob to src/ (no repo-wide .d.ts scan → no OOM)
+//   2. loads the component .tsx SOURCES into the ts-morph project, so propsBodyFor's primary
+//      lookup finds real declarations (e.g. `export interface ButtonProps extends
+//      React.ButtonHTMLAttributes<…>, VariantProps<typeof buttonVariants>`)
+//   3. points `entry` at the real source entry (.design-sync/ds-entry.ts) so the fallback path —
+//      used by components with no <Name>Props interface, like the forwardRef'd Card family —
+//      can resolve props from the component's call signature
+//   4. teaches the compiler the `@/*` → `src/*` path alias the sources import through
+//
+// Everything below projectFor is upstream, unmodified.
+//
+// .d.ts extraction via ts-morph (real TS checker). Resolves the apparent
+// structural type of each <Name>Props — unwraps Omit/Pick, follows extends
+// chains and intersections, resolves `(typeof X)[number]` / mapped types to
+// literal unions.
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { Project, Node, ts } from 'ts-morph';
+
+export function findTypesRoot(pkgDir, pkgJson) {
+  // Workspace/monorepo packages often point dev `types` at src/*.ts (no .d.ts
+  // tree there); publishConfig carries the published .d.ts entry — prefer it
+  // when it exists on disk.
+  const pubTypes = pkgJson.publishConfig?.types;
+  if (pubTypes && existsSync(join(pkgDir, pubTypes))) return dirname(join(pkgDir, pubTypes));
+  const t = pkgJson.types || pkgJson.typings;
+  if (t) return dirname(join(pkgDir, t));
+  const hasDts = (d) => { try { return readdirSync(d).some((f) => f.endsWith('.d.ts')); } catch { return false; } };
+  for (const c of ['build/ts', 'dist/types', 'types', 'lib', 'dist']) {
+    const p = join(pkgDir, c);
+    if (existsSync(p) && (c !== 'dist' || hasDts(p))) return p;
+  }
+  return pkgDir;
+}
+
+// *Props are prop interfaces; ALL-CAPS are object constants; *Manager /
+// *Placements / *Context are utility singletons; use* are hooks — none
+// renderable. (dts.nonComponents also catches React.Context by symbol kind;
+// the suffix check is belt-and-suspenders for DSes where that misses.)
+export const isComponentName = (n) => !n.endsWith('Props') && !/^[A-Z][A-Z0-9_]+$/.test(n)
+  && !/(?:Manager|Placements|Context)$/.test(n) && !/^use[A-Z]/.test(n);
+
+// Partition into roots and subcomponents. A name is a subcomponent ONLY when
+// another name is a PascalCase prefix of it AND the suffix is an actual
+// namespace member of that prefix per the `compounds` map (i.e. Table.Row
+// exists, so top-level TableRow is the same subpart). Name shape alone
+// can't distinguish TableRow (only renders inside Table) from ButtonGroup
+// (standalone) — the compounds membership is the reliable signal. For DSes
+// that export subparts top-level only (no `Table.Row` namespace), this
+// conservatively does nothing.
+export function partitionSubcomponents(names, compounds) {
+  const set = new Set(names);
+  const parentOf = new Map();
+  for (const n of names) {
+    const parts = n.match(/[A-Z][a-z0-9]*/g) ?? [];
+    // Try longest prefix first, keep trying shorter ones — `ListItemText`
+    // with compounds {List: ['ItemText']} must reach `List` even if
+    // `ListItem` is itself a top-level name.
+    for (let i = parts.length - 1; i >= 1; i--) {
+      const prefix = parts.slice(0, i).join('');
+      if (!set.has(prefix)) continue;
+      const suffix = parts.slice(i).join('');
+      if ((compounds?.get(prefix) ?? []).includes(suffix)) { parentOf.set(n, prefix); break; }
+    }
+  }
+  // Flatten transitively — TableRowCell → TableRow → Table becomes
+  // TableRowCell → Table, so the caller's per-root bucketing doesn't lose
+  // subs whose immediate parent is itself a sub. Terminates: each parent has
+  // strictly fewer PascalCase parts than its child.
+  for (const [n] of parentOf) {
+    let p = parentOf.get(n);
+    while (parentOf.has(p)) p = parentOf.get(p);
+    parentOf.set(n, p);
+  }
+  return { parentOf };
+}
+
+// One Project per package — loadDts/exportedNames share it.
+const projects = new Map();
+
+function projectFor(pkgDir, typesRoot) {
+  if (projects.has(pkgDir)) return projects.get(pkgDir);
+  // Derive node_modules for cross-package resolution (React, peer deps).
+  // Normalize separators — pkgDir may have backslashes on Windows.
+  const posix = pkgDir.split('\\').join('/');
+  const i = posix.lastIndexOf('/node_modules/');
+  let nodeModules = i >= 0 ? join(pkgDir.slice(0, i), 'node_modules') : join(pkgDir, '..');
+  // Workspace packages live outside node_modules — walk up to the hoisted
+  // root node_modules so @types/react resolves (otherwise React utility types
+  // collapse to `any` and inherited props drop out of the emitted bodies).
+  if (!existsSync(join(nodeModules, '@types', 'react'))) {
+    for (let d = pkgDir; ; d = dirname(d)) {
+      if (existsSync(join(d, 'node_modules', '@types', 'react'))) { nodeModules = join(d, 'node_modules'); break; }
+      if (dirname(d) === d) break;
+    }
+  }
+  const pj = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'));
+  // FORK: no `types` field and no declaration tree — the source entry IS the export list.
+  const SRC_ENTRY = join(pkgDir, '.design-sync', 'ds-entry.ts');
+  // Same publishConfig preference as findTypesRoot — keep the two in sync.
+  const pubEntry = pj.publishConfig?.types;
+  const dtsEntry = join(pkgDir, (pubEntry && existsSync(join(pkgDir, pubEntry)) ? pubEntry : null) || pj.types || pj.typings || 'index.d.ts');
+  const entry = existsSync(dtsEntry) ? dtsEntry : SRC_ENTRY;
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      jsx: ts.JsxEmit.ReactJSX,
+      skipLibCheck: true,
+      strict: false,
+      // FORK: the sources import through the app's `@/*` alias (tsconfig.json compilerOptions.paths).
+      // Without it every `@/components/ui/button` import is unresolved and props collapse to `any`.
+      baseUrl: pkgDir,
+      paths: { '@/*': ['./src/*'] },
+    },
+  });
+  // Add the package's own .d.ts tree plus @types/react (otherwise
+  // `ComponentPropsWithoutRef<…>` is `any` and intersection types collapse).
+  const reactTypes = join(nodeModules, '@types', 'react', 'index.d.ts');
+  // FORK: glob the .tsx SOURCES under src/, not a .d.ts tree. Bounded to src/ on purpose —
+  // the upstream repo-root glob walked .next/ (2.4GB) and blew the v8 heap.
+  const root = typesRoot ?? dirname(entry);
+  project.addSourceFilesAtPaths([`${pkgDir}/src/**/*.{ts,tsx}`, `!${pkgDir}/src/**/*.test.*`]);
+  project.addSourceFilesAtPaths([`${root}/src/types/**/*.d.ts`]);
+  console.error(`  [DTS] parsed ${project.getSourceFiles().length} source files from ${pkgDir}/src`);
+  // ts-morph StandardizedFilePath is always forward-slash; normalize pkgDir
+  // once so fp.startsWith(pkgDir) in isOwnProp/propsBodyFor works on Windows.
+  // Trailing slash so a sibling node_modules package whose name is a prefix of
+  // this one (foo vs foo-icons) isn't mis-classified as in-package.
+  const pkgDirStd = pkgDir.split('\\').join('/').replace(/\/?$/, '/');
+  if (existsSync(reactTypes)) project.addSourceFileAtPath(reactTypes);
+  else console.error(
+    '\n[DTS_REACT] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n' +
+    '[DTS_REACT] @types/react not found in node_modules. React utility types\n' +
+    '[DTS_REACT] (ComponentPropsWithoutRef, FC, …) will resolve to `any`, so\n' +
+    '[DTS_REACT] components whose props extend them will emit EMPTY bodies.\n' +
+    '[DTS_REACT] Fix: `npm i -D @types/react` then rebuild.\n' +
+    '[DTS_REACT] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n',
+  );
+  if (existsSync(entry)) project.addSourceFileAtPath(entry);
+  const ctx = { project, entry, pkgDir: pkgDirStd };
+  projects.set(pkgDir, ctx);
+  return ctx;
+}
+
+// Keep a prop unless its declaration lives in React/DOM types or a CSS-in-JS
+// style-system base (hundreds of token-typed style props from the component
+// library's styled-props layer). The small KEEP_PROP set passes regardless so
+// structural props survive when inherited from React. ts-morph's getFilePath()
+// returns StandardizedFilePath (forward-slash), so the substring checks are
+// cross-platform.
+const KEEP_PROP = /^(children|className|style|as|asChild|ref|id)$/;
+// Style-system bases are detected by SHAPE, two-tier (canonical contract —
+// the call sites point here):
+// - EXTERNAL packages: >STYLE_SYSTEM_THRESHOLD CSS/token-named props,
+//   counted per package directory (the node_modules/<pkg>/ boundary), so a
+//   style system split across small per-category .d.ts files still crosses
+//   the bar in aggregate. Paths with no node_modules/ segment fall back to
+//   per-file counting at the in-package bar.
+// - IN-PACKAGE files: >IN_PACKAGE_FILE_THRESHOLD CSS-named props in ONE
+//   file. Hand-written API layers (tens of CSS-named props) are the DS's
+//   own API and are never filtered; only a generated style system crosses
+//   this bar. Left unfiltered, printing hundreds of token-typed unions per
+//   component costs minutes of build time and tens of GB of retained
+//   checker cache, and bloats every emitted .d.ts.
+// All props declared in a flagged file/package are filtered (KEEP_PROP
+// passes regardless). ASSUMPTION: when inherited shorthands are real API,
+// override per component with cfg.dtsPropsFor.<Name>.
+const CSS_PROP_NAME =
+  /^(m[tblrxy]?$|p[tblrxy]?$|margin|padding|bg|background|color|border|width|height|flex|grid|gap|font|text|display|position|top|left|right|bottom|z|opacity|overflow|shadow|rounded|space)/;
+const STYLE_SYSTEM_THRESHOLD = 15;
+const IN_PACKAGE_FILE_THRESHOLD = 100;
+// The package that owns a path: its deepest node_modules/<pkg>/ boundary
+// (trailing slash), or null for workspace paths. Identity comparison against
+// ownerOf(pkgDir) is the single in-package/external discriminator.
+function ownerOf(p) {
+  const m = /^(.*\/node_modules\/(?:@[^/]+\/)?[^/]+)\//.exec(p);
+  return m ? m[1] + '/' : null;
+}
+function detectStyleSystemDirs(props, pkgDir, declFile) {
+  const pkgOwner = ownerOf(pkgDir);
+  const cssByDir = new Map();
+  for (const p of props) {
+    if (!CSS_PROP_NAME.test(p.getName())) continue;
+    const d = p.getDeclarations()[0];
+    if (!d) continue;
+    const fp = d.getSourceFile().getFilePath();
+    // Key shape encodes the tier (see the canonical contract above
+    // CSS_PROP_NAME): external packages → node_modules/<pkg>/ prefix key
+    // (trailing slash); in-package declarations → exact FILE key. The
+    // DEEPEST node_modules boundary decides: a dep nested under the
+    // package's own node_modules (un-hoisted version conflict) is external.
+    // One principle, no orientation cases: a declaration is IN-PACKAGE iff
+    // the package that OWNS its file is the package being synced.
+    // ownerOf() = deepest node_modules package boundary, null for
+    // workspace paths. This derives every layout — nested dep under the
+    // package's own node_modules (different owner → external), dual-publish
+    // nested manifest (same owner → in-package even though pkgDir sits
+    // below the boundary), DS synced from inside a host package's
+    // node_modules (host files have a shallower owner → external).
+    // In-package files key per-FILE; external files key per owning package.
+    // Ownerless externals (sibling workspace packages) key per-file at the
+    // in-package bar — the documented out-of-scope fallback in the
+    // canonical block above.
+    const owner = ownerOf(fp);
+    const inPackage = owner === pkgOwner && (owner !== null || fp.startsWith(pkgDir));
+    const key = inPackage ? fp : (owner ?? fp);
+    // Never flag the file that declares the component's own Props: in a
+    // rolled-up single-file .d.ts the generated style layer co-lives with
+    // the API interfaces, and a per-FILE flag would drop the component's
+    // own props. Separate generated files still filter; rollups fall back
+    // to unfiltered (slow but correct). External dir keys are unaffected.
+    if (key === declFile) continue;
+    cssByDir.set(key, (cssByDir.get(key) ?? 0) + 1);
+  }
+  // Per-tier bars — rationale in the canonical block above CSS_PROP_NAME.
+  const keys = [];
+  for (const [k, n] of cssByDir) {
+    const bar = k.endsWith('/') ? STYLE_SYSTEM_THRESHOLD : IN_PACKAGE_FILE_THRESHOLD;
+    if (n > bar) keys.push(k);
+  }
+  return keys;
+}
+function isOwnProp(p, pkgDir, styleSystemDirs) {
+  const name = p.getName();
+  if (KEEP_PROP.test(name)) return true;
+  const d = p.getDeclarations()[0];
+  if (!d) return true;
+  const fp = d.getSourceFile().getFilePath();
+  // FORK: upstream assumes pkgDir is `node_modules/<pkg>`, so node_modules is never INSIDE it.
+  // Here pkgDir is the app repo root, so every dependency's .d.ts sits under it and reads as
+  // "in-package" by path prefix. That let a GLOBAL JSX augmentation from Next's vendored satori
+  // (`tw?: string`, documented "Specify styles using Tailwind CSS classes") into every component
+  // contract — inviting the design agent to write tw= instead of className= and ship silently
+  // unstyled markup. Next's bundled vendor types are never this DS's API.
+  // Scoped deliberately to next/dist/compiled/ and NOT to all of node_modules: Radix declares
+  // genuine API there (Dialog.open, Checkbox.checked, Select.value) that must survive.
+  if (fp.includes('/next/dist/compiled/')) return false;
+  // Same owner-identity discriminator as detectStyleSystemDirs, same order
+  // of authority: a flagged in-package FILE drops first (exact match); then
+  // owner-equality keeps the DS's own API — checked BEFORE dir keys because
+  // a flagged dir key can be an ANCESTOR of pkgDir (DS synced from inside a
+  // host package's node_modules) and must not swallow in-package files;
+  // then flagged external packages drop by prefix.
+  if (styleSystemDirs.some((k) => !k.endsWith('/') && fp === k)) return false;
+  const owner = ownerOf(fp);
+  if (owner === ownerOf(pkgDir) && (owner !== null || fp.startsWith(pkgDir))) return true;
+  if (styleSystemDirs.some((k) => k.endsWith('/') && fp.startsWith(k))) return false;
+  if (fp.includes('/@types/react/') || fp.includes('/typescript/lib/')) return false;
+  // DOM-noise name filters apply only to props inherited from other packages.
+  if (/^(on[A-Z]|aria-)/.test(name)) return false;
+  return true;
+}
+
+// Keep well-known aliases as-written instead of expanding to their full union.
+const KEEP_ALIAS = /^(ReactNode|ReactElement|CSSProperties|JSX\.Element|Key|Ref|RefObject)$/;
+
+function typeText(t, at) {
+  const alias = t.getAliasSymbol()?.getName();
+  if (alias && KEEP_ALIAS.test(alias)) return `React.${alias}`;
+  if (t.isBoolean()) return 'boolean';
+  let s;
+  if (t.isUnion()) {
+    // Render each member so ReactNode/boolean collapse while literal unions
+    // stay expanded; dedup, drop `undefined` (optionality is the `?`).
+    const parts = t.getUnionTypes().map((u) => typeText(u, at)).filter((p) => p !== 'undefined');
+    let uniq = [...new Set(parts)];
+    if (uniq.length === 2 && uniq.includes('true') && uniq.includes('false')) return 'boolean';
+    // Collapse the structural expansion of React.ReactNode (string | number |
+    // ReactElement<…> | Iterable<ReactNode> | ReactPortal | Promise<…>) back to
+    // the alias — when the alias symbol is lost, the expansion blows past the
+    // length cap below and would truncate into invalid TS.
+    if (uniq.includes('ReactPortal') && uniq.some((u) => u.startsWith('Iterable<ReactNode>'))) {
+      const RN_MEMBER = /^(string|number|bigint|boolean|ReactPortal|Iterable<ReactNode>.*|ReactElement<.*|Promise<.*)$/;
+      uniq = [...new Set([...uniq.filter((u) => !RN_MEMBER.test(u)), 'React.ReactNode'])];
+    }
+    // Function-type members are invalid un-parenthesized inside a union
+    // (`string | (x) => void` doesn't parse) — wrap them.
+    if (uniq.length > 1) uniq = uniq.map((u) => (u.includes('=>') ? `(${u})` : u));
+    // Cap very wide unions (icon-name sets can be 600+ members).
+    if (uniq.length > 24) uniq = [...uniq.slice(0, 16), `(string & {}) /* +${uniq.length - 16} more */`];
+    s = uniq.join(' | ').replace(/\bfalse \| true\b/, 'boolean');
+  } else {
+    s = t.getText(at, ts.TypeFormatFlags.NoTruncation).replace(/import\("[^"]*"\)\./g, '');
+  }
+  // Never hard-slice an over-long type — a cut generic/object literal is
+  // invalid TS and fails the validator's [DTS_PARSE] check (and the app's
+  // API-contract parse). Fall back to a safe wide type instead; the JSDoc
+  // line above the prop carries the human-readable detail.
+  return s.length > 240 ? 'unknown' : s;
+}
+
+// PascalCase value exports from the entry module. The checker knows value vs
+// type, so type-only exports never enter the set.
+export function exportedNames(pkgDir, pkgJson) {
+  const { project, entry } = projectFor(pkgDir, findTypesRoot(pkgDir, pkgJson));
+  const sf = project.getSourceFile(entry);
+  const names = new Set();
+  if (!sf) return names;
+  for (const [name, decls] of sf.getExportedDeclarations()) {
+    if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) continue;
+    const hasValue = decls.some((d) =>
+      Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) ||
+      Node.isClassDeclaration(d) || Node.isSourceFile(d));
+    if (hasValue) names.add(name);
+  }
+  return names;
+}
+
+// Builds the context propsBodyFor/jsdocFor read from. `nonComponents` /
+// `compounds` are derived from the checker's symbol kinds.
+export function loadDts(typesRoot) {
+  // typesRoot is always under <nm>/<pkg>/… — walk up to the real package
+  // root: the nearest package.json with a `name` field, skipping stubs
+  // (`{"type":"module"}` in esm/ or dist/). dirname-fixed-point is the
+  // cross-platform root test (`/` vs `C:\`).
+  let walk = typesRoot;
+  for (; walk !== dirname(walk); walk = dirname(walk)) {
+    const pj = join(walk, 'package.json');
+    if (existsSync(pj)) {
+      try { if (JSON.parse(readFileSync(pj, 'utf8')).name) break; } catch {}
+    }
+  }
+  // projectFor normalizes pkgDir to forward-slashes (ts-morph's
+  // StandardizedFilePath) — use that for every fp.startsWith() downstream.
+  const { project, entry, pkgDir } = projectFor(walk, typesRoot);
+  const sf = project.getSourceFile(entry);
+  const nonComponents = new Set();
+  const compounds = new Map();
+  if (sf) for (const [name, decls] of sf.getExportedDeclarations()) {
+    if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) continue;
+    // Declaration-merged names (`interface Button {}` + `const Button: …`)
+    // return both decls — prefer the value decl so the merge isn't
+    // misclassified as type-only by whichever the checker listed first.
+    const d = decls.find((x) =>
+      Node.isVariableDeclaration(x) || Node.isFunctionDeclaration(x) ||
+      Node.isClassDeclaration(x) || Node.isSourceFile(x)) ?? decls[0];
+    // Namespace export (`export * as X`) → compound with its own value members.
+    if (Node.isSourceFile(d)) {
+      const members = [...d.getExportedDeclarations().entries()]
+        .filter(([n, ds]) => /^[A-Z][a-z]/.test(n) && ds.some((x) => !Node.isInterfaceDeclaration(x) && !Node.isTypeAliasDeclaration(x)))
+        .map(([n]) => n);
+      if (members.length) compounds.set(name, members);
+      else nonComponents.add(name);
+      continue;
+    }
+    // Type-only / enum / Context / abstract-class are not components.
+    if (Node.isInterfaceDeclaration(d) || Node.isTypeAliasDeclaration(d) || Node.isEnumDeclaration(d)) {
+      nonComponents.add(name);
+      continue;
+    }
+    if (Node.isClassDeclaration(d) && d.isAbstract()) { nonComponents.add(name); continue; }
+    if (Node.isClassDeclaration(d)) continue;  // always renderable; compounds via statics aren't handled here
+    if (!Node.isVariableDeclaration(d) && !Node.isFunctionDeclaration(d)) continue;
+    // `const X: FC<…> & { Sub: … }` (possibly through an alias/Omit) —
+    // PascalCase callable properties declared in-package are compound members
+    // (React.Component lifecycle names have underscores / fail the full match).
+    const t = d.getType();
+    const members = [];
+    // PascalCase props can't be style-system CSS-shorthands, so the empty
+    // list is correct here — detectStyleSystemDirs would contribute nothing.
+    const noStyle = [];
+    for (const p of t.getProperties()) {
+      const pn = p.getName();
+      if (!/^[A-Z][a-zA-Z0-9]*$/.test(pn) || !isOwnProp(p, pkgDir, noStyle)) continue;
+      if (p.getTypeAtLocation(d).getCallSignatures().length) members.push(pn);
+    }
+    if (members.length) compounds.set(name, members);
+    // Only provably-not-renderable consts are filtered: a plain object/record
+    // type whose every property is a primitive (token/enum
+    // objects like Colors or Sizes). Anything with a call signature, construct signature, or a
+    // non-primitive property stays — class components and forwardRef wrappers
+    // without call sigs on the instance type must not be dropped here.
+    if (t.isObject() && !t.getCallSignatures().length && !t.getConstructSignatures().length && !members.length && !t.isAny()) {
+      const props = t.getProperties();
+      if (props.length && props.every((p) => {
+        const pt = p.getTypeAtLocation(d);
+        return pt.isString() || pt.isNumber() || pt.isStringLiteral() || pt.isNumberLiteral();
+      })) nonComponents.add(name);
+    }
+  }
+  return { project, entry, pkgDir, nonComponents, compounds };
+}
+
+// Returns { body, generics, extendsClause, prelude } for emit.mjs. Types are
+// fully resolved into `body`, so extendsClause/prelude stay empty.
+export function propsBodyFor(name, ctx) {
+  if (ctx.dtsPropsFor?.[name]) {
+    return { body: ctx.dtsPropsFor[name], generics: '', extendsClause: '', prelude: '' };
+  }
+  const { project, entry, pkgDir } = ctx;
+  // Find <Name>Props across the package's own files (not @types/react).
+  // Skip deprecated/legacy/experimental dirs so a stale copy doesn't shadow
+  // the live one.
+  let decl = null;
+  for (const sf of project.getSourceFiles()) {
+    const fp = sf.getFilePath();
+    if (!fp.startsWith(pkgDir)) continue;
+    if (/\/(deprecated|legacy|experimental)\//i.test(fp)) continue;
+    decl = sf.getInterface(`${name}Props`) ?? sf.getTypeAlias(`${name}Props`);
+    if (decl) break;
+  }
+  // Fallback: derive from the component symbol's first call signature.
+  // Prefer the value decl (declaration-merging — see loadDts).
+  if (!decl) {
+    const decls = project.getSourceFile(entry)?.getExportedDeclarations().get(name) ?? [];
+    const exp = decls.find((d) =>
+      Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) || Node.isClassDeclaration(d)) ?? decls[0];
+    if (!exp || Node.isSourceFile(exp)) return null;
+    const sig = exp.getType().getCallSignatures()[0];
+    const p0 = sig?.getParameters()[0];
+    if (!p0) return null;
+    return emitBody(p0.getTypeAtLocation(exp), exp, '', pkgDir);
+  }
+  const generics = decl.getTypeParameters?.().length
+    ? `<${decl.getTypeParameters().map((p) => p.getText()).join(', ')}>`
+    : '';
+  return emitBody(decl.getType(), decl, generics, pkgDir);
+}
+
+let loggedStyleSystemDirs;
+function emitBody(type, at, generics, pkgDir) {
+  const lines = [];
+  const props = type.getApparentType().getProperties();
+  // `at` is the component's own Props declaration site — its file is exempt
+  // from per-FILE flagging (see detectStyleSystemDirs).
+  const styleSystemDirs = detectStyleSystemDirs(props, pkgDir, at.getSourceFile().getFilePath());
+  // Surface a one-shot [DTS_STYLE_SYSTEM] line per flagged package so the
+  // self-heal loop routes to cfg.dtsPropsFor when the heuristic guesses
+  // wrong. ASSUMPTION: props from the named packages are token-typed
+  // style shorthands; override a component's contract with cfg.dtsPropsFor.
+  loggedStyleSystemDirs ??= new Set();
+  for (const dir of styleSystemDirs) {
+    if (loggedStyleSystemDirs.has(dir)) continue;
+    loggedStyleSystemDirs.add(dir);
+    const isDirKey = dir.endsWith('/');
+    const pkg = /\/node_modules\/((?:@[^/]+\/)?[^/]+)\/$/.exec(dir)?.[1]
+      ?? (dir.startsWith(pkgDir) ? dir.slice(pkgDir.length) : dir);
+    const bar = isDirKey ? STYLE_SYSTEM_THRESHOLD : IN_PACKAGE_FILE_THRESHOLD;
+    console.error(
+      `[DTS_STYLE_SYSTEM] filtering ${pkg} props (>${bar} CSS-shorthand-named props) — override a component with cfg.dtsPropsFor.<Name> if these are real API`,
+    );
+  }
+  for (const p of props) {
+    if (!isOwnProp(p, pkgDir, styleSystemDirs)) continue;
+    const optional = p.hasFlags(ts.SymbolFlags.Optional) ? '?' : '';
+    const pt = p.getTypeAtLocation(at);
+    let tt = typeText(pt, at);
+    // Structural hint when the type text hides the shape (aliased functions /
+    // arrays) — smartDefaultProps reads these to pick the right required-stub.
+    const members = pt.isUnion() ? pt.getUnionTypes() : [pt];
+    if (members.some((u) => u.getCallSignatures().length)) tt += ' /* @fn */';
+    // Tuples are not @arr — `[]` has the wrong length and `[0]` access crashes
+    // either way; optional tuples are safer left unset.
+    else if (members.some((u) => u.isArray())) tt += ' /* @arr */';
+    // Leading JSDoc on the prop declaration, if any.
+    const d = p.getDeclarations()[0];
+    const doc = d?.getJsDocs?.()?.[0]?.getDescription()?.trim();
+    if (doc) lines.push(`  /** ${doc.replace(/\s+/g, ' ').slice(0, 120)} */`);
+    const pn = p.getName();
+    // Hyphenated/index-signature names (`data-*`, `aria-*`) must be quoted.
+    const key = /^[a-zA-Z_$][\w$]*$/.test(pn) ? pn : JSON.stringify(pn);
+    lines.push(`  ${key}${optional}: ${tt};`);
+  }
+  if (!lines.length) return null;
+  return { body: lines.join('\n'), generics, extendsClause: '', prelude: '' };
+}
+
+// Scaffold-preview defaults from the resolved props body. Conservative: fill
+// only what's needed for a meaningful first render (children + variant axis +
+// visibility toggles + required arrays). Optional string/number/Date props are
+// left unset — filling them with placeholder values crashes more than it
+// helps.
+//
+// Void-element-ish components — a string `children` would throw at render.
+const VOID_LIKE = /^(Text|Number|Search|Password|File|Masked)?Input$|^(TextField|TextArea|Textarea|Img|Image|Avatar|Hr|Br|Spacer|Divider|Separator|Slider|Progress|ProgressBar)$/;
+// Ordered preference for the variant axis — earlier wins. `type` is last so
+// the HTML `type` attr ("button"|"submit"|"reset") doesn't beat `variant`.
+const VARIANT_RANK = ['variant', 'intent', 'kind', 'appearance', 'tone', 'status', 'size', 'color', 'type'];
+export function smartDefaultProps(name, pb) {
+  const body = pb?.body ?? '';
+  const props = {};
+  let variants = null;
+  // Matches the 2-space indent emitBody writes — keep the two in sync.
+  // `.+` (not `[^;]+`) so object-param types with inner semicolons still match.
+  for (const m of body.matchAll(/^ {2}([a-zA-Z_$][\w$]*)(\??)\s*:\s*(.+);$/gm)) {
+    const [, prop, q, t] = m;
+    if (prop in props) continue;
+    const req = !q;
+    // Union of string literals, optionally with a `string & {}` escape-hatch
+    // member (the "autocomplete these, accept any string" TS pattern).
+    if (/^(?:(?:"[^"]*"|\(?string\s*&\s*\{\}\)?)\s*\|?\s*)+$/.test(t)) {
+      const lits = [...t.matchAll(/"([^"]*)"/g)].map((l) => l[1]).filter(Boolean);
+      if (lits.length >= 2) {
+        const rank = VARIANT_RANK.indexOf(prop.toLowerCase());
+        // Displace on strictly better rank (prop names are unique, so no ties).
+        if (!variants || (rank >= 0 && (variants.rank < 0 || rank < variants.rank))) {
+          variants = { prop, values: lits.slice(0, 4), rank };
+        }
+        if (req) props[prop] = lits[0];
+        continue;
+      }
+    }
+    // Structural hints (/* @fn */, /* @arr */) from emitBody are authoritative
+    // over the text regexes — `(() => void)[]` has @arr, so the `=>` in the
+    // element type must not flip it to isFn. The text regexes cover
+    // cfg.dtsPropsFor overrides with no hints.
+    const hasFn = t.includes('/* @fn */'), hasArr = t.includes('/* @arr */');
+    const isFn = hasFn || (!hasArr && /=>|\)\s*:/.test(t));
+    const isArr = !isFn && (hasArr || /\[\]|Array</.test(t));
+    if (prop === 'children' && /React\.ReactNode|ReactElement/.test(t) && !isFn && !VOID_LIKE.test(name)) props.children = name;
+    // Visibility toggles — an overlay/dialog with open=false renders nothing.
+    else if (/^(open|isOpen|visible|show|defaultOpen|expanded|checked|active|selected)$/.test(prop) && t === 'boolean') props[prop] = true;
+    // Callable (required or optional) — optional stays unset (DSes guard
+    // optional callbacks); required gets a noop.
+    else if (isFn) { if (req) props[prop] = { $raw: '()=>null' }; }
+    // Arrays (required or optional). `[]` is crash-safe but renders nothing.
+    // Props that look like data/option lists get a small sample so the
+    // preview has visible rows; element shape is best-effort from the type
+    // text (string[] → strings; otherwise {id,label,value}).
+    else if (isArr) {
+      const isList = /^(items|options|tabs|rows|columns|data|actions|fields|links|steps|choices|values)$/i.test(prop);
+      const elT = t.replace(/\/\*.*?\*\//g, '').trim();
+      const elIsString = /^(?:readonly\s+)?string\[\]|^ReadonlyArray<string>|^Array<string>/.test(elT);
+      // Over-provision keys — extra ones are ignored, and this covers the
+      // common {id|key} + {label|text|name|title} + value conventions.
+      props[prop] = isList
+        ? elIsString
+          ? ['Item 1', 'Item 2', 'Item 3']
+          : [1, 2, 3].map((i) => {
+            const s = String(i), l = `Item ${i}`;
+            return { id: s, key: s, value: s, label: l, text: l, name: l, title: l };
+          })
+        : [];
+    }
+    // Optional everything-else stays unset — the component's own defaults are
+    // safer than a placeholder.
+    else if (!req) continue;
+    // Required props get a type-appropriate stub so the render doesn't crash
+    // on `undefined.…` / `undefined()`. `$raw` values are emitted verbatim by
+    // scaffoldPropsExpr (not JSON-stringified).
+    else if (/\bDate\b/.test(t)) props[prop] = { $raw: 'new Date()' };
+    else if (/ElementType|ComponentType|JSXElementConstructor/.test(t)) props[prop] = 'div';
+    else if (/React\.ReactNode|ReactElement/.test(t)) props[prop] = name;
+    else if (/^string\b/.test(t)) props[prop] = name;
+    else if (/^number\b/.test(t)) props[prop] = 0;
+    else if (/^boolean\b/.test(t)) props[prop] = false;
+    else if (/^\{/.test(t) || /Record<|Partial<|Pick<|Omit</.test(t)) props[prop] = {};
+    // Fallback: required prop of unrecognized shape — `{}` is the least likely
+    // to crash `.foo` access.
+    else props[prop] = {};
+  }
+  return { props, variants };
+}
+
+// One-line JSDoc from the component's own declaration.
+export function jsdocFor(name, ctx) {
+  const decls = ctx.project?.getSourceFile(ctx.entry)?.getExportedDeclarations().get(name) ?? [];
+  const exp = decls.find((d) =>
+    Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) || Node.isClassDeclaration(d)) ?? decls[0];
+  if (!exp || Node.isSourceFile(exp)) return '';
+  const doc = exp.getJsDocs?.()?.[0]?.getDescription()
+    ?? exp.getSymbol?.()?.compilerSymbol.getDocumentationComment?.(undefined)?.[0]?.text;
+  if (!doc) return '';
+  return doc.split('\n').find((l) => l.trim() && !l.trim().startsWith('@'))
+    ?.trim().replace(/\s+/g, ' ').replace(/[^\w\s.,()'/:+-]/g, '').slice(0, 140) ?? '';
+}

--- a/.design-sync/overrides/source-kit.mjs
+++ b/.design-sync/overrides/source-kit.mjs
@@ -1,0 +1,187 @@
+// Non-storybook `package` adapter. Bundles dist/ when present (the authoritative
+// component list comes from shipped .d.ts; with no dist it synthesizes an
+// entry from src/ as a last resort) and opportunistically enriches each
+// component from src/ — JSDoc and dir-derived group. Every enrichment miss
+// degrades to the plain-dist behaviour.
+//
+// Discovery is heuristic-based; each heuristic has a `.design-sync/config.json`
+// override (ASSUMPTION comments below name them) so repos that don't match the
+// defaults write config, not code. `componentSrcMap` is the single override
+// knob for component inclusion: non-null value = add/pin src path, null =
+// exclude a .d.ts-exported internal.
+
+import { existsSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { Project, Node, ts } from 'ts-morph';
+// forked from design-sync lib/source-kit.mjs — Next.js App Router private-folder convention.
+//
+// Group derivation takes the last src/ path segment that isn't GENERIC_DIR. MusicNerd's brand
+// components live in `src/app/_components/`, and `_components` doesn't match the generic set
+// (which has `components`), so every brand component was forced into a group literally named
+// "components" — and because that group is non-generic, it also OUTRANKED the `category: Brand`
+// frontmatter in .design-sync/groups/*.md, so the regroup stubs silently did nothing.
+//
+// The leading underscore is Next.js's "private folder" marker (excluded from routing); it carries
+// no design meaning. Strip it before the generic-dir test so `_components` reads as `components`.
+//
+// Sibling imports are repointed at the staged lib (they don't exist under overrides/), EXCEPT
+// ./dts.mjs — that resolves to the forked dts.mjs alongside this file, so both forks share one
+// ts-morph project instead of building two.
+import { leadingJsdoc, readText, slash, walk } from '../../.ds-sync/lib/common.mjs';
+import { resolveDistEntry } from '../../.ds-sync/lib/bundle.mjs';
+import { exportedNames, isComponentName } from './dts.mjs';
+
+const NON_IMPL_RX = /\.(stories|test|spec)\./;
+const SRC_IMPL_RX = /\.(tsx|jsx)$/;
+// Dir names that don't usefully group components — skip so the emitted path
+// is `components/<group>/<Name>` not `components/components/<Name>`.
+const GENERIC_DIR = new Set(['components', 'component', 'src', 'lib', 'ui', 'packages', 'react']);
+const slug = (s) => s.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'general';
+
+// No .d.ts → scan src files for PascalCase value exports via ts-morph.
+function deriveComponentsFromSrc(srcFiles) {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    compilerOptions: { jsx: ts.JsxEmit.Preserve, allowJs: true, skipLibCheck: true },
+  });
+  const seen = new Set();
+  for (const p of srcFiles) {
+    if (NON_IMPL_RX.test(p) || !SRC_IMPL_RX.test(p)) continue;
+    const sf = project.addSourceFileAtPathIfExists(p);
+    if (!sf) continue;
+    for (const [name, decls] of sf.getExportedDeclarations()) {
+      // `export default function Button()` is keyed as 'default' — recover
+      // the declared name from the function/class node.
+      const real = name === 'default'
+        ? decls.map((d) => d.getName?.()).find((n) => n && n !== 'default')
+        : name;
+      if (!real || !/^[A-Z][A-Za-z0-9]*$/.test(real)) continue;
+      if (decls.some((d) => Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) || Node.isClassDeclaration(d))) {
+        seen.add(real);
+      }
+    }
+  }
+  return [...seen].sort().map((name) => ({ name, group: 'general' }));
+}
+
+export async function resolvePackage(ctx) {
+  const { PKG_DIR, pkgJson, ENTRY_OVERRIDE, PKG, OUT, cfg } = ctx;
+  const srcMap = cfg.componentSrcMap ?? {};
+
+  // ── 1. src/ discovery (best-effort; feeds enrichment + synth-entry fallback).
+  // ASSUMPTION: source root is first of src/ | lib/ | components/. Override: cfg.srcDir.
+  const srcRoot = [cfg.srcDir, 'src', 'lib', 'components']
+    .map((d) => d && resolve(PKG_DIR, d))
+    .find((d) => d && existsSync(d));
+  const srcFiles = srcRoot ? walk(srcRoot, (n) => /\.(tsx|jsx|mdx?)$/.test(n)) : [];
+
+  // ── 2. entry: dist if it exists, else synthesize from src/ (last resort).
+  let entry = resolveDistEntry({ pkgDir: PKG_DIR, pkgJson, override: ENTRY_OVERRIDE, pkgName: PKG, soft: true });
+  let synthEntry = false;
+  if (!entry) {
+    if (!srcRoot) {
+      console.error(`[NO_DIST] ${PKG} has no built entry and no src/ to synthesize from — run its build.`);
+      process.exit(1);
+    }
+    const comps = srcFiles.filter((p) => SRC_IMPL_RX.test(p) && !NON_IMPL_RX.test(p));
+    entry = join(OUT, '.pkg-entry.mjs');
+    writeFileSync(entry, comps.map((p) => `export * from ${JSON.stringify(p)};`).join('\n') + '\n');
+    synthEntry = true;
+    console.error(
+      `[NO_DIST] no built entry — synthesizing from ${comps.length} src files (run the package's build for best results)`,
+    );
+  }
+
+  // ── 3. component list: from shipped .d.ts (authoritative when dist exists).
+  // ASSUMPTION: components = PascalCase value exports in the .d.ts tree.
+  // Override: cfg.componentSrcMap (non-null adds/pins, null excludes).
+  const exported = exportedNames(PKG_DIR, pkgJson);
+  // FORK: componentSrcMap IS the component list here, not a set of tweaks to a discovered one.
+  // ds-entry.ts exports ~110 symbols, but ~77 of those are compound sub-parts (CardHeader,
+  // DialogFooter, SelectItem…) and 2 are context providers. Auto-discovering them would mint a
+  // card and a near-empty contract for each — dozens of duplicate previews and a pane no human
+  // can browse. They all still SHIP in the bundle (window.MusicNerd.CardHeader works) and each
+  // compound's authored preview demonstrates its sub-parts in a real composition; they just
+  // don't get their own cards. Seeding from srcMap keeps that curation stable even though this
+  // repo's export list is fully resolvable.
+  const curated = Object.values(srcMap).some((v) => v !== null);
+  const names = new Set(curated ? [] : [...exported].filter(isComponentName));
+  for (const [k, v] of Object.entries(srcMap)) {
+    if (v === null) { names.delete(k); continue; }
+    // Names reach `<script>` blocks in the emitted HTML — reject anything
+    // that isn't a plain PascalCase identifier.
+    if (!/^[A-Z][A-Za-z0-9]*$/.test(k)) {
+      console.error(`[CONFIG] componentSrcMap: "${k}" is not a valid component name (PascalCase identifiers only)`);
+      continue;
+    }
+    names.add(k);
+  }
+  let components = [...names].sort().map((name) => ({ name, group: 'general' }));
+  if (!components.length && synthEntry) {
+    components = deriveComponentsFromSrc(srcFiles).filter((c) => srcMap[c.name] !== null);
+  }
+  if (!components.length) {
+    if (cfg.cssEntry || existsSync(join(PKG_DIR, 'styles.css'))) {
+      console.error('[ZERO_MATCH] no component exports — treating as tokens-only DS');
+      return { shape: 'package', entry, components: [], tokensOnly: true };
+    }
+    console.error(`[ZERO_MATCH] no PascalCase exports in ${PKG} and no styles — nothing to sync`);
+    process.exit(1);
+  }
+
+  // ── 4. src/ enrichment per component. Every miss degrades to plain-dist.
+  if (srcRoot) {
+    for (const c of components) {
+      // Pinned via config → skip fuzzy-find entirely.
+      let hit = typeof srcMap[c.name] === 'string' ? slash(resolve(PKG_DIR, srcMap[c.name])) : null;
+      if (!hit) {
+        // ASSUMPTION: <Name>.tsx | <name>/<name>.tsx | <Name>/index.tsx |
+        // <kebab-name>.tsx, case-insensitive; dir-match ranks above
+        // bare-file match, then prefer one that actually exports `c.name`.
+        // Override: cfg.componentSrcMap.
+        const kebab = c.name.replace(/([a-z0-9])([A-Z])/g, '$1-$2');
+        const nameRx = new RegExp(
+          `(?:^|/)(?:${c.name}/(?:index|${c.name})\\.(tsx|jsx)|(?:${c.name}|${kebab})\\.(tsx|jsx))$`,
+          'i',
+        );
+        const hits = srcFiles
+          .filter((p) => nameRx.test(p) && !NON_IMPL_RX.test(p))
+          .sort(
+            (a, b) =>
+              (b.toLowerCase().includes(`/${c.name.toLowerCase()}/`) ? 1 : 0) -
+              (a.toLowerCase().includes(`/${c.name.toLowerCase()}/`) ? 1 : 0),
+          );
+        const exportRx = new RegExp(`export\\s+(?:default\\s+)?(?:const|let|var|function|class)\\s+${c.name}\\b`);
+        hit = hits.find((p) => exportRx.test(readText(p))) ?? hits[0];
+      }
+      if (!hit || !existsSync(hit)) continue;
+      c.srcPath = hit;
+      c.doc = leadingJsdoc(readText(hit), c.name) || undefined;
+      // group = last src/ path segment that isn't the component's own dir or
+      // a generic container name — else JSDoc @category — else 'general'.
+      c.group = slug(
+        slash(relative(srcRoot, dirname(hit)))
+          .split('/')
+          // FORK: strip Next.js's leading-underscore private-folder marker before the generic
+          // test, so `_components` is recognized as the generic `components`. `app` and `pages`
+          // are Next.js router roots — structural, not design categories — so they're generic too.
+          // With every segment of `app/_components` filtered, the group falls through to the
+          // `category:` frontmatter in .design-sync/groups/*.md, which is what we want it to use.
+          .filter((s) => {
+            const seg = s.toLowerCase().replace(/^_+/, '');
+            return s && seg !== c.name.toLowerCase()
+              && !GENERIC_DIR.has(seg) && seg !== 'app' && seg !== 'pages';
+          })
+          .at(-1)
+        || (c.doc && /@category\s+(\S+)/.exec(c.doc)?.[1])
+        || 'general',
+      );
+    }
+  }
+
+  console.error(
+    `  package: ${components.length} components` +
+      (srcRoot ? ` (${components.filter((c) => c.srcPath).length} src-matched)` : ' (no src/ — dist-only)'),
+  );
+  return { shape: 'package', entry, components, synthEntry, exported };
+}

--- a/.design-sync/previews/AspectRatio.tsx
+++ b/.design-sync/previews/AspectRatio.tsx
@@ -1,0 +1,75 @@
+import { AspectRatio, Badge } from "musicnerdweb";
+
+/**
+ * A 1:1 artist artwork tile — the shape Spotify images arrive in. AspectRatio is a bare
+ * Radix re-export with no styling of its own: it only reserves the box (padding-bottom
+ * trick), so it renders as nothing unless the parent has a width AND it has a child.
+ * Here the parent is `w-64` and the child is an absolutely-filled brand gradient standing
+ * in for the artwork.
+ */
+export const Square = () => (
+  <div className="w-64">
+    <AspectRatio ratio={1}>
+      <div className="flex h-full w-full items-end rounded-lg bg-gradient-to-br from-pastypink via-[#7c3aed] to-pastyblue p-3">
+        <span className="rounded bg-black/40 px-2 py-1 text-sm font-medium text-white">
+          Floating Points
+        </span>
+      </div>
+    </AspectRatio>
+  </div>
+);
+
+/**
+ * 16:9 — the ratio the Spotify/YouTube embeds on the artist page need. Same component,
+ * only `ratio` changes; the wrapper width is identical to the 1:1 story above, so the
+ * height difference is entirely the ratio doing its job.
+ */
+export const Video = () => (
+  <div className="w-80">
+    <AspectRatio ratio={16 / 9}>
+      <div className="flex h-full w-full items-center justify-center rounded-lg border bg-muted">
+        <span className="text-sm text-muted-foreground">Spotify embed · 16:9</span>
+      </div>
+    </AspectRatio>
+  </div>
+);
+
+/**
+ * The ratio axis in one row: 1:1 (artwork), 4:3, 16:9 (embed), 3:4 (portrait press shot).
+ * Equal-width columns, so each box's height is a direct readout of its ratio.
+ */
+export const RatioScale = () => (
+  <div className="grid w-[520px] grid-cols-4 items-start gap-3">
+    {[
+      ["1:1", 1, "from-pastypink to-[#7c3aed]"],
+      ["4:3", 4 / 3, "from-pastyblue to-jellygreen"],
+      ["16:9", 16 / 9, "from-jellygreen to-pastyblue"],
+      ["3:4", 3 / 4, "from-[#7c3aed] to-pastypink"],
+    ].map(([label, ratio, grad]) => (
+      <div key={label as string} className="space-y-1.5">
+        <AspectRatio ratio={ratio as number}>
+          <div className={`h-full w-full rounded-md bg-gradient-to-br ${grad}`} />
+        </AspectRatio>
+        <p className="text-center text-xs text-muted-foreground">{label as string}</p>
+      </div>
+    ))}
+  </div>
+);
+
+/**
+ * In situ: an artwork tile inside a card, with the genre badge below. This is the whole
+ * point of the component in a music directory — the grid stays on a rigid baseline even
+ * before any image has loaded, so a slow Spotify CDN never reflows the page.
+ */
+export const InArtistCard = () => (
+  <div className="w-56 overflow-hidden rounded-lg border bg-card shadow-sm">
+    <AspectRatio ratio={1}>
+      <div className="h-full w-full bg-gradient-to-br from-[#ff9ce3] via-pastypink to-pastyblue" />
+    </AspectRatio>
+    <div className="space-y-2 p-3">
+      <p className="font-medium leading-none">Yaeji</p>
+      <p className="text-xs text-muted-foreground">9 platform links</p>
+      <Badge variant="secondary">house</Badge>
+    </div>
+  </div>
+);

--- a/.design-sync/previews/Badge.tsx
+++ b/.design-sync/previews/Badge.tsx
@@ -1,0 +1,73 @@
+import { Badge } from "musicnerdweb";
+
+/**
+ * The four stock variants, side by side. Base is always
+ * `rounded-full border px-2.5 py-0.5 text-xs font-semibold` — only the fill changes.
+ * `outline` is the only variant with a visible border (the other three set
+ * `border-transparent`), so it reads as the quietest of the set.
+ */
+export const Variants = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Badge>default</Badge>
+    <Badge variant="secondary">secondary</Badge>
+    <Badge variant="destructive">destructive</Badge>
+    <Badge variant="outline">outline</Badge>
+  </div>
+);
+
+/**
+ * Genre pills on an artist record — the densest real use. `secondary` is the house style
+ * for taxonomy; `outline` demotes a low-confidence tag the community hasn't confirmed.
+ */
+export const GenrePills = () => (
+  <div className="max-w-sm space-y-3">
+    <p className="text-sm font-medium">Jamie xx</p>
+    <div className="flex flex-wrap gap-2">
+      <Badge variant="secondary">electronic</Badge>
+      <Badge variant="secondary">uk garage</Badge>
+      <Badge variant="secondary">house</Badge>
+      <Badge variant="secondary">downtempo</Badge>
+      <Badge variant="outline">+ unverified: trip hop</Badge>
+    </div>
+  </div>
+);
+
+/**
+ * Status pills in the moderation and agent queues — the semantic axis. `default` (primary
+ * fill) = approved, `outline` = pending, `destructive` = rejected, `secondary` = the
+ * neutral machine-written state. Note DESIGN.md's warning: nothing in the component
+ * enforces this mapping, so it lives entirely in convention at the call site.
+ */
+export const StatusPills = () => (
+  <div className="max-w-md space-y-2 text-sm">
+    {[
+      ["Yaeji → Bandcamp", <Badge key="a">Approved</Badge>],
+      ["Overmono → Deezer", <Badge key="b" variant="outline">Pending review</Badge>],
+      ["Kelela → Tidal", <Badge key="c" variant="destructive">Rejected</Badge>],
+      ["Four Tet → MusicBrainz", <Badge key="d" variant="secondary">Auto-mapped</Badge>],
+    ].map(([label, badge], i) => (
+      <div
+        key={i}
+        className="flex items-center justify-between rounded-md border bg-card px-3 py-2"
+      >
+        <span className="text-muted-foreground">{label}</span>
+        {badge}
+      </div>
+    ))}
+  </div>
+);
+
+/**
+ * Brand-tinted badges via `className` overrides — how confidence levels are colored in
+ * the agent-work view. The pink here is the raw `#ff9ce3` literal users actually see,
+ * not the `pastypink` token (#ef95ff); DESIGN.md flags the two as a real fragmentation.
+ * Shown against `maroon` text, the brand's ink color.
+ */
+export const BrandTinted = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Badge className="bg-jellygreen text-maroon hover:bg-jellygreen">high confidence</Badge>
+    <Badge className="bg-pastyblue text-maroon hover:bg-pastyblue">medium</Badge>
+    <Badge className="bg-[#ff9ce3] text-maroon hover:bg-[#ff9ce3]">low</Badge>
+    <Badge className="bg-pastypink text-maroon hover:bg-pastypink">manual</Badge>
+  </div>
+);

--- a/.design-sync/previews/BookmarkButton.tsx
+++ b/.design-sync/previews/BookmarkButton.tsx
@@ -1,0 +1,66 @@
+import { BookmarkButton } from "musicnerdweb";
+
+/**
+ * BookmarkButton is localStorage-backed: it reads `bookmarks_<userId>` on mount and
+ * derives its own `bookmarked` state from it. There is no controlled prop, so the only
+ * honest way to show the *filled* state is to seed the store the component actually reads.
+ * Two distinct userIds keep the two cells independent.
+ */
+const SEEDED_USER = "user-seeded-bookmarks";
+const EMPTY_USER = "user-no-bookmarks";
+
+if (typeof window !== "undefined") {
+  window.localStorage.setItem(
+    `bookmarks_${SEEDED_USER}`,
+    JSON.stringify([{ artistId: "artist-arca", artistName: "Arca" }]),
+  );
+  window.localStorage.removeItem(`bookmarks_${EMPTY_USER}`);
+}
+
+/**
+ * The two states side by side. Un-bookmarked is a white pill with a `pastypink` 2px border
+ * and pink label + icon; bookmarked inverts to a solid `pastypink` fill with white content.
+ * Both are locked to `w-[120px]` so the label swap ("Bookmark" → "Bookmarked") never
+ * reflows the row it sits in — that fixed width is the whole reason the component exists
+ * as a wrapper instead of a bare Button.
+ */
+export const States = () => (
+  <div className="flex flex-wrap items-center gap-3">
+    <BookmarkButton
+      userId={EMPTY_USER}
+      artistId="artist-jpegmafia"
+      artistName="JPEGMAFIA"
+    />
+    <BookmarkButton
+      userId={SEEDED_USER}
+      artistId="artist-arca"
+      artistName="Arca"
+    />
+  </div>
+);
+
+/**
+ * In the app this button sits on the artist header, to the right of the name and next to
+ * the other row actions. The fixed 120px width plus `flex-shrink-0` is what stops it from
+ * being squeezed by a long artist name.
+ */
+export const OnArtistHeader = () => (
+  <div className="w-full max-w-md rounded-xl border border-border bg-card p-4">
+    <div className="flex items-center gap-3">
+      <div className="h-14 w-14 flex-shrink-0 rounded-full bg-gradient-to-br from-pastypink to-pastyblue" />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-lg font-bold text-maroon">
+          Yaeji
+        </div>
+        <div className="truncate text-sm text-muted-foreground">
+          house · korean-american · added by @cxy
+        </div>
+      </div>
+      <BookmarkButton
+        userId={SEEDED_USER}
+        artistId="artist-arca"
+        artistName="Yaeji"
+      />
+    </div>
+  </div>
+);

--- a/.design-sync/previews/Button.tsx
+++ b/.design-sync/previews/Button.tsx
@@ -1,0 +1,68 @@
+import { Button } from "musicnerdweb";
+
+/**
+ * The full cva variant axis. Copy from the repo's own call sites: `outline` is the
+ * workhorse (admin tables, leaderboard range pickers), `destructive` is reserved for
+ * revoke/delete, `ghost` for low-emphasis row actions.
+ *
+ * Note the `default` variant has NO hover state — stock shadcn ships `hover:bg-primary/90`
+ * and it was removed here (DESIGN.md, known inconsistency #9). That is the shipped
+ * behavior, so the preview shows it truthfully rather than patching it.
+ */
+export const Variants = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Button>Add artist</Button>
+    <Button variant="secondary">Save draft</Button>
+    <Button variant="outline">Edit links</Button>
+    <Button variant="ghost">Dismiss</Button>
+    <Button variant="destructive">Revoke key</Button>
+    <Button variant="link">View on Spotify</Button>
+  </div>
+);
+
+/** Every size token. `icon` is a square 40px tap target used across the artist page. */
+export const Sizes = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Button size="sm">Small</Button>
+    <Button size="default">Default</Button>
+    <Button size="lg">Large</Button>
+    <Button size="icon" aria-label="Bookmark">★</Button>
+  </div>
+);
+
+/** Disabled is the one interactive state that renders statically. */
+export const Disabled = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Button disabled>Adding…</Button>
+    <Button variant="outline" disabled>
+      Searching…
+    </Button>
+    <Button variant="destructive" disabled>
+      Revoke key
+    </Button>
+  </div>
+);
+
+/**
+ * The brand move: shadcn Button restyled with the pastypink token via className.
+ * This is exactly how EditModeToggle and BookmarkButton apply brand color — DESIGN.md is
+ * explicit that identity lives at the custom-component layer, never by forking the primitive.
+ */
+export const BrandAccent = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Button
+      variant="outline"
+      size="sm"
+      className="border-pastypink/50 text-pastypink hover:bg-pastypink hover:text-white"
+    >
+      Edit mode
+    </Button>
+    <Button
+      variant="outline"
+      size="sm"
+      className="border-pastypink bg-pastypink text-white hover:bg-pastypink/90"
+    >
+      Bookmarked
+    </Button>
+  </div>
+);

--- a/.design-sync/previews/Calendar.tsx
+++ b/.design-sync/previews/Calendar.tsx
@@ -1,0 +1,49 @@
+import { Calendar } from "musicnerdweb";
+
+/**
+ * Single-month, single-day select — the base shape. Every day cell is a ghost Button
+ * (`buttonVariants({ variant: "ghost" })` at h-9 w-9), so the calendar inherits the
+ * button system rather than defining its own hit targets. The selected day flips to
+ * `bg-primary text-primary-foreground`; today gets `bg-accent`.
+ */
+export const Default = () => (
+  <Calendar
+    mode="single"
+    defaultMonth={new Date(2026, 6, 1)}
+    selected={new Date(2026, 6, 9)}
+    className="rounded-lg border bg-card"
+  />
+);
+
+/**
+ * The real in-app usage: the profile leaderboard date-range filter
+ * (`src/app/profile/DatePicker.tsx` — `mode="range"`, `numberOfMonths={2}`), which
+ * normally lives inside a Popover. Range middles are `bg-accent`, the two endpoints are
+ * `bg-primary`, and `showOutsideDays` leaves the neighbouring month's days visible in
+ * muted-foreground.
+ */
+export const ContributionRange = () => (
+  <Calendar
+    mode="range"
+    numberOfMonths={2}
+    defaultMonth={new Date(2026, 5, 1)}
+    selected={{ from: new Date(2026, 5, 14), to: new Date(2026, 6, 2) }}
+    className="rounded-lg border bg-card"
+  />
+);
+
+/**
+ * Disabled days — future dates can't be filtered on, since no submissions exist yet.
+ * `day_disabled` is `text-muted-foreground opacity-50`, which is a *very* light touch:
+ * on white it reads only barely differently from an outside-month day. Worth knowing
+ * before relying on it as the sole affordance.
+ */
+export const WithDisabledDays = () => (
+  <Calendar
+    mode="single"
+    defaultMonth={new Date(2026, 6, 1)}
+    selected={new Date(2026, 6, 6)}
+    disabled={{ after: new Date(2026, 6, 13) }}
+    className="rounded-lg border bg-card"
+  />
+);

--- a/.design-sync/previews/Card.tsx
+++ b/.design-sync/previews/Card.tsx
@@ -1,0 +1,103 @@
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Badge,
+} from "musicnerdweb";
+
+/**
+ * The canonical compound: Header (Title + Description) → Content → Footer.
+ * Card is stock shadcn — `rounded-lg border bg-card shadow-sm`, every section on `p-6`.
+ */
+export const Default = () => (
+  <Card className="max-w-sm">
+    <CardHeader>
+      <CardTitle>Jamie xx</CardTitle>
+      <CardDescription>
+        Electronic producer and DJ. 14 platform links collected by the community.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <div className="flex flex-wrap gap-2">
+        <Badge variant="secondary">electronic</Badge>
+        <Badge variant="secondary">house</Badge>
+        <Badge variant="outline">uk</Badge>
+      </div>
+    </CardContent>
+    <CardFooter className="gap-2">
+      <Button size="sm">Open artist</Button>
+      <Button size="sm" variant="outline">
+        Edit links
+      </Button>
+    </CardFooter>
+  </Card>
+);
+
+/**
+ * Header + Content only — the shape the leaderboard and admin tables use.
+ * Note the mauve title color (`#9b83a0`), applied as a literal at the call site;
+ * DESIGN.md flags this micro-palette as un-tokenized design debt.
+ */
+export const Sectioned = () => (
+  <Card className="max-w-md shadow-2xl">
+    <CardHeader className="text-center">
+      <CardTitle className="text-[#9b83a0]">Leaderboard</CardTitle>
+      <CardDescription>Top contributors this week</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <ol className="space-y-2 text-sm">
+        {[
+          ["1", "vinylwitch", "142"],
+          ["2", "bpmhunter", "118"],
+          ["3", "crate.digger", "97"],
+        ].map(([rank, name, points]) => (
+          <li
+            key={rank}
+            className="flex items-center justify-between border-b pb-2 last:border-b-0"
+          >
+            <span className="flex items-center gap-3">
+              <span className="text-muted-foreground">{rank}</span>
+              <span className="font-medium">{name}</span>
+            </span>
+            <span className="text-muted-foreground">{points} pts</span>
+          </li>
+        ))}
+      </ol>
+    </CardContent>
+  </Card>
+);
+
+/**
+ * The competing surface language. DESIGN.md: the codebase mostly uses the custom
+ * `.glass` panel (`glass p-4 sm:p-5 space-y-3`, 16px radius) rather than Card for primary
+ * layout — two padding conventions coexist. Shown side by side so the difference is a
+ * deliberate choice, not an accident.
+ */
+export const CardVsGlassPanel = () => (
+  // The brand wash is load-bearing here, not decoration: `.glass` is rgba(255,255,255,0.55)
+  // with a backdrop-filter, so on a plain white page it is literally invisible. It only reads
+  // as glass over color — which is how it always appears in the app (over the hero gradient
+  // and artist imagery). Card, being opaque `bg-card`, looks identical on any backdrop.
+  <div className="rounded-2xl bg-gradient-to-br from-pastypink via-[#7c3aed] to-pastyblue p-6">
+    <div className="flex flex-wrap items-start gap-4">
+      <Card className="w-64">
+        <CardHeader>
+          <CardTitle className="text-lg">shadcn Card</CardTitle>
+          <CardDescription>Opaque bg-card, rounded-lg (8px), p-6</CardDescription>
+        </CardHeader>
+      </Card>
+      <div className="glass w-64 space-y-3 p-4 sm:p-5">
+        <h3 className="text-lg font-semibold leading-none tracking-tight text-maroon">
+          .glass panel
+        </h3>
+        <p className="text-sm text-maroon/80">
+          Translucent, blur(20px) saturate(180%), 16px radius — the primary surface.
+        </p>
+      </div>
+    </div>
+  </div>
+);

--- a/.design-sync/previews/Carousel.tsx
+++ b/.design-sync/previews/Carousel.tsx
@@ -1,0 +1,112 @@
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+  AspectRatio,
+  Badge,
+} from "musicnerdweb";
+
+const ARTISTS = [
+  ["Jamie xx", "electronic", "from-pastypink to-[#7c3aed]"],
+  ["Floating Points", "modal jazz", "from-pastyblue to-jellygreen"],
+  ["Yaeji", "house", "from-[#ff9ce3] to-pastyblue"],
+  ["Overmono", "breakbeat", "from-jellygreen to-pastypink"],
+  ["Kelela", "r&b", "from-[#7c3aed] to-pastyblue"],
+  ["Four Tet", "idm", "from-pastypink to-jellygreen"],
+];
+
+/**
+ * Featured-artists rail — three cards per view (`basis-1/3`). CarouselItem defaults to
+ * `basis-full` (one slide fills the viewport), so a multi-up rail is entirely a call-site
+ * decision: without an explicit basis you get a one-at-a-time hero, not a rail.
+ *
+ * The arrows are absolutely positioned OUTSIDE the track (`-left-12` / `-right-12`), so
+ * the Carousel needs horizontal room around it — hence `px-12` on the wrapper. Drop that
+ * padding and both buttons clip off the edge of the card.
+ */
+export const FeaturedArtists = () => (
+  <div className="w-[560px] px-12">
+    <Carousel className="w-full">
+      <CarouselContent>
+        {ARTISTS.map(([name, genre, grad]) => (
+          <CarouselItem key={name} className="basis-1/3">
+            <div className="overflow-hidden rounded-lg border bg-card shadow-sm">
+              <AspectRatio ratio={1}>
+                <div className={`h-full w-full bg-gradient-to-br ${grad}`} />
+              </AspectRatio>
+              <div className="space-y-1.5 p-3">
+                <p className="truncate text-sm font-medium leading-none">{name}</p>
+                <Badge variant="secondary">{genre}</Badge>
+              </div>
+            </div>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  </div>
+);
+
+/**
+ * The default `basis-full` shape: one slide at a time, a full-bleed hero for the
+ * homepage's featured artist. Because this Carousel hardcodes `loop: true` (a repo
+ * modification — stock shadcn leaves loop off), both arrows are always enabled; you never
+ * see the disabled end-of-track state that stock gives you for free.
+ */
+export const SingleSlideHero = () => (
+  <div className="w-[520px] px-12">
+    <Carousel className="w-full">
+      <CarouselContent>
+        {ARTISTS.slice(0, 3).map(([name, genre, grad]) => (
+          <CarouselItem key={name}>
+            <div
+              className={`flex h-40 items-end rounded-xl bg-gradient-to-br ${grad} p-4`}
+            >
+              <div>
+                <p className="text-xl font-semibold text-white drop-shadow">{name}</p>
+                <p className="text-sm text-white/80">Featured this week · {genre}</p>
+              </div>
+            </div>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  </div>
+);
+
+/**
+ * A text-only rail — the "recently added" activity strip. Same `basis-1/3` sizing as the
+ * artwork rail, so the gutter that CarouselContent's `-ml-4` / CarouselItem's `pl-4` create
+ * is legible without artwork carrying it. Note `basis-1/2` renders unevenly here: with
+ * `loop: true` embla can settle mid-snap, so odd slide counts per view are safer.
+ */
+export const CompactRail = () => (
+  <div className="w-[560px] px-12">
+    <Carousel className="w-full">
+      <CarouselContent>
+        {[
+          ["Overmono", "Deezer + Tidal added"],
+          ["Kelela", "MusicBrainz ID resolved"],
+          ["Four Tet", "Bandcamp link approved"],
+          ["Yaeji", "Apple Music mapped"],
+          ["Jamie xx", "Beatport link approved"],
+          ["Floating Points", "Wikidata ID resolved"],
+        ].map(([name, note]) => (
+          <CarouselItem key={name} className="basis-1/3">
+            <div className="rounded-lg border bg-card p-4">
+              <p className="font-medium leading-none">{name}</p>
+              <p className="mt-1.5 truncate text-xs text-muted-foreground">{note}</p>
+            </div>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  </div>
+);

--- a/.design-sync/previews/Checkbox.tsx
+++ b/.design-sync/previews/Checkbox.tsx
@@ -1,0 +1,102 @@
+import { Checkbox, Label } from "musicnerdweb";
+
+/**
+ * Every state the primitive encodes. 16px square, `border-primary`, and on check it fills
+ * with `bg-primary` — which in this app resolves to the brand pink, so Checkbox is one of
+ * the few primitives where brand color reaches the semantic token layer unaided.
+ *
+ * BUG VISIBLE HERE: `indeterminate` renders the Check icon but NO fill. The Radix Indicator
+ * is shown for both `checked` and `indeterminate`, while the background is gated on
+ * `data-[state=checked]` only — so indeterminate paints a checkmark on a white square, which
+ * reads as "checked, unstyled" rather than "partially selected". Stock shadcn shows a dash.
+ * The admin select-all header hits this on every partial page selection.
+ */
+export const States = () => (
+  <div className="flex flex-col gap-3">
+    <div className="flex items-center gap-2">
+      <Checkbox id="cb-unchecked" />
+      <Label htmlFor="cb-unchecked">Unchecked</Label>
+    </div>
+    <div className="flex items-center gap-2">
+      <Checkbox id="cb-checked" defaultChecked />
+      <Label htmlFor="cb-checked">Checked</Label>
+    </div>
+    <div className="flex items-center gap-2">
+      <Checkbox id="cb-ind" checked="indeterminate" />
+      <Label htmlFor="cb-ind">Indeterminate (select-all, page partially selected)</Label>
+    </div>
+    <div className="flex items-center gap-2">
+      <Checkbox id="cb-dis" className="peer" disabled />
+      <Label htmlFor="cb-dis">Disabled</Label>
+    </div>
+    <div className="flex items-center gap-2">
+      <Checkbox id="cb-dis-checked" className="peer" disabled defaultChecked />
+      <Label htmlFor="cb-dis-checked">Disabled + checked</Label>
+    </div>
+  </div>
+);
+
+/**
+ * The canonical call site: the row-selection column of the admin UGC table (columns.tsx).
+ * Header checkbox is `indeterminate` when some-but-not-all page rows are selected; each row
+ * gets an `aria-label`-only checkbox with no visible Label. Note the header reads as an
+ * unfilled checkmark rather than a dash — see the `States` cell for why.
+ */
+export const TableSelection = () => (
+  <div className="w-full max-w-2xl overflow-hidden rounded-md border border-input">
+    <table className="w-full text-sm">
+      <thead className="border-b border-input bg-muted/50">
+        <tr className="text-left">
+          <th className="w-10 px-3 py-2">
+            <Checkbox checked="indeterminate" aria-label="Select all" />
+          </th>
+          <th className="px-3 py-2 font-medium">Artist</th>
+          <th className="px-3 py-2 font-medium">Platform</th>
+          <th className="px-3 py-2 font-medium">Contributor</th>
+        </tr>
+      </thead>
+      <tbody>
+        {[
+          { a: "Yaeji", p: "Bandcamp", u: "0xkim.eth", sel: true },
+          { a: "Arca", p: "SoundCloud", u: "nerdvana", sel: true },
+          { a: "Floating Points", p: "Deezer", u: "sam.b", sel: false },
+          { a: "Jamie xx", p: "Apple Music", u: "0xkim.eth", sel: false },
+        ].map((r) => (
+          <tr key={r.a} className="border-b border-input/60 last:border-0">
+            <td className="px-3 py-2">
+              <Checkbox defaultChecked={r.sel} aria-label={`Select ${r.a}`} />
+            </td>
+            <td className="px-3 py-2">{r.a}</td>
+            <td className="px-3 py-2 text-muted-foreground">{r.p}</td>
+            <td className="px-3 py-2 text-muted-foreground">{r.u}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+/**
+ * A checklist of platforms — the shape a "which links to sync" filter takes. Worth looking at
+ * for density: at 16px with `bg-primary` pink fill and a hairline unchecked border, the
+ * checked and unchecked rows carry very different visual weight in a stacked list.
+ */
+export const PlatformFilter = () => (
+  <div className="w-full max-w-xs space-y-3 rounded-lg border border-input p-4">
+    <p className="text-sm font-semibold">Sync ID mappings for</p>
+    {[
+      { id: "deezer", label: "Deezer", on: true },
+      { id: "apple", label: "Apple Music", on: true },
+      { id: "musicbrainz", label: "MusicBrainz", on: true },
+      { id: "tidal", label: "Tidal", on: false },
+      { id: "ytm", label: "YouTube Music", on: false },
+    ].map((p) => (
+      <div key={p.id} className="flex items-center gap-2">
+        <Checkbox id={`pf-${p.id}`} defaultChecked={p.on} />
+        <Label htmlFor={`pf-${p.id}`} className="font-normal">
+          {p.label}
+        </Label>
+      </div>
+    ))}
+  </div>
+);

--- a/.design-sync/previews/Dialog.tsx
+++ b/.design-sync/previews/Dialog.tsx
@@ -1,0 +1,70 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from "musicnerdweb";
+
+/**
+ * Rendered `open` so the open state is what the card actually shows — a closed Dialog
+ * renders nothing. Ported from the admin "Create MCP API Key" modal, which is the
+ * canonical Dialog composition in this repo.
+ *
+ * `modal={false}` keeps Radix from marking the rest of the page inert and locking scroll
+ * inside the preview frame; it does not change how the content itself renders.
+ *
+ * Note DialogContent hardcodes `dark:bg-gray-900` instead of the `bg-background` token
+ * (DESIGN.md known inconsistency #12) — shipped behavior, shown as-is.
+ */
+export const Open = () => (
+  <Dialog open modal={false}>
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Create MCP API Key</DialogTitle>
+        <DialogDescription>
+          Enter a label to identify this key (e.g. agent name or purpose).
+        </DialogDescription>
+      </DialogHeader>
+      <div className="space-y-2">
+        <Label htmlFor="key-label">Label</Label>
+        <Input
+          id="key-label"
+          placeholder="id-mapping-agent"
+          defaultValue="id-mapping-agent"
+          className="h-10 rounded-md border border-input px-3 py-2"
+        />
+      </div>
+      <DialogFooter className="gap-2">
+        <Button variant="outline">Cancel</Button>
+        <Button>Create key</Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+);
+
+/**
+ * A destructive confirmation — the other shape Dialog is used for in admin
+ * (revoke key, delete submission).
+ */
+export const Destructive = () => (
+  <Dialog open modal={false}>
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Revoke this key?</DialogTitle>
+        <DialogDescription>
+          `id-mapping-agent` will immediately lose write access to the MCP server. This
+          cannot be undone.
+        </DialogDescription>
+      </DialogHeader>
+      <DialogFooter className="gap-2">
+        <Button variant="outline">Cancel</Button>
+        <Button variant="destructive">Revoke key</Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+);

--- a/.design-sync/previews/Drawer.tsx
+++ b/.design-sync/previews/Drawer.tsx
@@ -1,0 +1,95 @@
+import {
+  Button,
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  Badge,
+} from "musicnerdweb";
+
+/**
+ * Drawer is vaul, not Radix: it portals to document.body and its content is `fixed inset-x-0
+ * bottom-0`. It renders nothing closed, so `open` is forced. `modal={false}` keeps vaul from
+ * marking the page inert / locking scroll inside the preview frame — it does not change how the
+ * content itself renders. Positioning classes are left alone; the card viewport is sized to fit
+ * the sheet plus its overlay.
+ *
+ * No Drawer consumer exists in the repo yet, so this composes the mobile counterpart of the
+ * artist-page "add artist data" flow.
+ */
+export const Open = () => (
+  <Drawer open modal={false}>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>Add a link for Four Tet</DrawerTitle>
+          <DrawerDescription>
+            Pick a platform. Your submission is reviewed before it goes live.
+          </DrawerDescription>
+        </DrawerHeader>
+        <div className="grid grid-cols-2 gap-2 px-4">
+          <Button variant="outline" className="justify-start">
+            Spotify
+          </Button>
+          <Button variant="outline" className="justify-start">
+            Bandcamp
+          </Button>
+          <Button variant="outline" className="justify-start">
+            SoundCloud
+          </Button>
+          <Button variant="outline" className="justify-start">
+            Deezer
+          </Button>
+        </div>
+        <DrawerFooter>
+          <Button>Continue</Button>
+          <DrawerClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+  </Drawer>
+);
+
+/**
+ * A denser sheet: the mobile moderation queue for a UGC submission. Exercises DrawerHeader with
+ * secondary metadata and a two-action footer (approve / reject).
+ */
+export const ModerationSheet = () => (
+  <Drawer open modal={false}>
+      <DrawerContent>
+        <DrawerHeader>
+          <div className="flex items-center gap-2">
+            <DrawerTitle>Review submission</DrawerTitle>
+            <Badge>listen</Badge>
+          </div>
+          <DrawerDescription>
+            Submitted by @vinylghost, 2 hours ago.
+          </DrawerDescription>
+        </DrawerHeader>
+        <div className="space-y-2 px-4 text-sm">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Artist</span>
+            <span className="font-medium">Jamie xx</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Platform</span>
+            <span className="font-medium">Bandcamp</span>
+          </div>
+          <p className="break-all rounded-md bg-muted px-2 py-1.5 font-mono text-xs">
+            bandcamp.com/jamiexx
+          </p>
+        </div>
+        <DrawerFooter className="flex-row gap-2">
+          <Button className="flex-1">Approve</Button>
+          <DrawerClose asChild>
+            <Button variant="outline" className="flex-1">
+              Reject
+            </Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+  </Drawer>
+);

--- a/.design-sync/previews/DropdownMenu.tsx
+++ b/.design-sync/previews/DropdownMenu.tsx
@@ -1,0 +1,99 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  DropdownMenuCheckboxItem,
+} from "musicnerdweb";
+
+/**
+ * A closed DropdownMenu renders nothing (content is portaled + `fixed`), so `defaultOpen` is
+ * required for the card to show anything. Positioning classes are untouched — the card's
+ * viewport is sized around the floating panel instead.
+ *
+ * Composition mirrors the nav account menu in PrivyLogin.tsx (Leaderboard / User Profile /
+ * theme / Log Out).
+ */
+export const Open = () => (
+  <div className="flex min-h-[400px] items-start justify-center pt-6">
+    <DropdownMenu defaultOpen modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">@vinylghost</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="center" sideOffset={8} className="w-44">
+        <DropdownMenuLabel>My account</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>Leaderboard</DropdownMenuItem>
+        <DropdownMenuItem>User Profile</DropdownMenuItem>
+        <DropdownMenuItem>Dark mode</DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>Log Out</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  </div>
+);
+
+/**
+ * The artist-page "add artist data" picker (AddArtistDataOptions.tsx): a scrollable list of
+ * platform link examples, with the pink focus tint the repo applies to those items.
+ */
+export const PlatformPicker = () => (
+  <div className="flex min-h-[400px] items-start justify-center pt-6">
+    <DropdownMenu defaultOpen modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="h-11">
+          Add artist data
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="center"
+        sideOffset={8}
+        className="max-h-52 w-56 overflow-auto"
+      >
+        <DropdownMenuItem className="cursor-pointer text-xs">
+          bandcamp.com/artist-name
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer text-xs">
+          deezer.com/artist/12345
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer text-xs">
+          instagram.com/artist-name
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer text-xs">
+          soundcloud.com/artist-name
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer text-xs">
+          open.spotify.com/artist/1a2b3c
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer text-xs" disabled>
+          x.com/artist-name
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  </div>
+);
+
+/**
+ * Checkbox items — the coverage filter on the Agent Work tab. Sweeps the checked indicator
+ * and the `pl-8` indent variant of the item.
+ */
+export const WithCheckboxes = () => (
+  <div className="flex min-h-[400px] items-start justify-center pt-6">
+    <DropdownMenu defaultOpen modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">Platforms</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="center" sideOffset={8} className="w-52">
+        <DropdownMenuLabel>Show mappings for</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuCheckboxItem checked>Deezer</DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem checked>Apple Music</DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem>MusicBrainz</DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem>Tidal</DropdownMenuCheckboxItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  </div>
+);

--- a/.design-sync/previews/EditModeToggle.tsx
+++ b/.design-sync/previews/EditModeToggle.tsx
@@ -1,0 +1,39 @@
+import { EditModeToggle } from "musicnerdweb";
+
+/**
+ * EditModeToggle reads `EditModeContext` and returns `null` unless `canEdit` is true —
+ * so it only ever renders for whitelisted contributors and admins. The design-sync
+ * provider stack already supplies `EditModeProvider canEdit`, which is why it appears
+ * here at all.
+ *
+ * Resting state: an outline Button restyled with the brand token —
+ * `border-pastypink/50 text-pastypink`, pencil icon, "Edit". The hover inversion
+ * (solid pink fill, white text) does not fire in a static capture, so this shows the
+ * resting state truthfully rather than faking it.
+ */
+export const Default = () => (
+  <div className="flex items-center gap-2">
+    <EditModeToggle />
+  </div>
+);
+
+/**
+ * Its real home: pinned to the right of an artist-page section heading, where it flips
+ * the surrounding link grid between read and write. Shown at the same scale it appears
+ * in the app — deliberately small, low-emphasis, and the only pink thing in the row.
+ */
+export const OnSectionHeader = () => (
+  <div className="w-full max-w-md rounded-xl border border-border bg-card p-4">
+    <div className="mb-3 flex items-center justify-between">
+      <h3 className="text-sm font-bold uppercase tracking-wide text-maroon">
+        Listen
+      </h3>
+      <EditModeToggle />
+    </div>
+    <ul className="space-y-1.5 text-sm text-muted-foreground">
+      <li>Spotify · open.spotify.com/artist/2nvl0N9GwyX69RRBMEZ4OD</li>
+      <li>Bandcamp · yaeji.bandcamp.com</li>
+      <li>SoundCloud · soundcloud.com/yaeji</li>
+    </ul>
+  </div>
+);

--- a/.design-sync/previews/Footer.tsx
+++ b/.design-sync/previews/Footer.tsx
@@ -1,0 +1,23 @@
+import { Footer } from "musicnerdweb";
+
+/**
+ * The whole component is one line of copy — "Made in Seattle by @cxy @clt and friends" —
+ * in `text-maroon`, bold, `text-[14px]` on mobile stepping up to `text-[25px]` at `sm`.
+ * The handles are underlined anchors. There is no border, no background, no nav: the
+ * footer is intentionally a signature, not a sitemap.
+ *
+ * It ships `mt-auto`, which only does anything inside a flex column — so the wrapper here
+ * is a min-height flex column that pins it to the bottom, exactly as `layout.tsx` does.
+ * Without that wrapper the `mt-auto` is a no-op and the component reads as floating text.
+ */
+export const Default = () => (
+  <div className="flex h-[220px] w-full max-w-2xl flex-col rounded-xl border border-border bg-background">
+    <div className="flex-1 px-6 py-6">
+      <p className="text-sm text-muted-foreground">
+        …end of the artist grid. Page content ends here; the footer is pushed to the
+        bottom of the viewport by <code className="text-foreground">mt-auto</code>.
+      </p>
+    </div>
+    <Footer />
+  </div>
+);

--- a/.design-sync/previews/Form.tsx
+++ b/.design-sync/previews/Form.tsx
@@ -1,0 +1,189 @@
+import * as React from "react";
+import { useForm } from "react-hook-form";
+import {
+  Button,
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  Textarea,
+} from "musicnerdweb";
+
+/**
+ * `Form` is just react-hook-form's `FormProvider` re-exported — it renders no DOM. What the
+ * design system actually owns is the FormItem / FormLabel / FormControl / FormDescription /
+ * FormMessage stack: `space-y-2` between parts, `text-sm text-muted-foreground` for the
+ * description, `text-sm font-medium text-destructive` for the message, and FormLabel
+ * flipping to `text-destructive` when the field has an error.
+ *
+ * NOTE the Input here carries hand-added chrome (`h-10 rounded-md border border-input`).
+ * FormControl does not supply any — and the base Input has no border or height — so a
+ * literal port of AddArtist.tsx (`<Input {...field} />`) renders an invisible field.
+ */
+export const Default = () => {
+  const form = useForm({
+    defaultValues: { artistUrl: "https://open.spotify.com/artist/2VZNmg3v9nbVMnRkZadyi5" },
+  });
+
+  return (
+    <Form {...form}>
+      <form className="w-full max-w-lg space-y-6">
+        <FormField
+          control={form.control}
+          name="artistUrl"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Artist URL</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="Paste a Spotify or Deezer artist URL"
+                  className="h-10 rounded-md border border-input px-3 py-2"
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription>
+                Copy the URL from the artist&apos;s Spotify or Deezer page.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="button" className="bg-pastypink text-white hover:bg-pastypink/90">
+          Add artist
+        </Button>
+      </form>
+    </Form>
+  );
+};
+
+/**
+ * The error state — the whole reason FormMessage exists. FormLabel turns `text-destructive`,
+ * FormMessage prints the resolver message, and FormControl sets `aria-invalid`.
+ *
+ * The error is injected with `setError` in an effect because a static render never runs a
+ * submit; this is exactly the state a failed urlmap regex check produces.
+ */
+export const WithError = () => {
+  const form = useForm({ defaultValues: { artistUrl: "sondcloud.com/arca1000000" } });
+
+  React.useEffect(() => {
+    form.setError("artistUrl", {
+      type: "manual",
+      message: "That host doesn't match any platform in urlmap.",
+    });
+  }, [form]);
+
+  const error = form.formState.errors.artistUrl;
+
+  return (
+    <Form {...form}>
+      <form className="w-full max-w-lg space-y-6">
+        <FormField
+          control={form.control}
+          name="artistUrl"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Artist URL</FormLabel>
+              <FormControl>
+                <Input
+                  className={`h-10 rounded-md border px-3 py-2 ${
+                    error ? "border-destructive" : "border-input"
+                  }`}
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription>
+                Supported: Spotify, Deezer, Bandcamp, SoundCloud, Apple Music.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="button" className="bg-pastypink text-white hover:bg-pastypink/90">
+          Add artist
+        </Button>
+      </form>
+    </Form>
+  );
+};
+
+/**
+ * A multi-field form, which is where the `space-y-2` inside FormItem and the outer field
+ * rhythm actually get tested. Mixes Input and Textarea controls through FormControl's Slot.
+ */
+export const MultiField = () => {
+  const form = useForm({
+    defaultValues: {
+      label: "id-mapping-agent",
+      spotifyUrl: "https://open.spotify.com/artist/6UBAOAqvpz7GwxLIleJm3O",
+      notes: "",
+    },
+  });
+
+  return (
+    <Form {...form}>
+      <form className="w-full max-w-lg space-y-5">
+        <FormField
+          control={form.control}
+          name="label"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Key label</FormLabel>
+              <FormControl>
+                <Input
+                  className="h-10 rounded-md border border-input px-3 py-2"
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription>Shown in the MCP audit log for every write.</FormDescription>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="spotifyUrl"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Spotify artist URL</FormLabel>
+              <FormControl>
+                <Input
+                  className="h-10 rounded-md border border-input px-3 py-2"
+                  {...field}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="notes"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Reviewer notes</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="Why is this mapping high-confidence?"
+                  className="min-h-[80px]"
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription>Optional — attached to the UGC submission.</FormDescription>
+            </FormItem>
+          )}
+        />
+        <div className="flex gap-2">
+          <Button type="button" variant="outline">
+            Cancel
+          </Button>
+          <Button type="button" className="bg-pastypink text-white hover:bg-pastypink/90">
+            Submit
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+};

--- a/.design-sync/previews/Input.tsx
+++ b/.design-sync/previews/Input.tsx
@@ -1,0 +1,132 @@
+import { Input, Label } from "musicnerdweb";
+
+/**
+ * THE MOST IMPORTANT FACT ABOUT THIS COMPONENT.
+ *
+ * `Input` was stripped of its chrome: the base class list has NO border, NO fixed height
+ * (`h-10`), and NO focus ring — only `rounded-md bg-background px-3 py-2`. On a light
+ * background it renders as an invisible rectangle. Stock shadcn ships
+ * `h-10 border border-input focus-visible:ring-2`; all three were removed here.
+ *
+ * The left cell is the shipped default. The right cell is what every real form in the app
+ * has to re-add by hand via className. That re-adding is the actual convention.
+ */
+export const BareVsStyled = () => (
+  <div className="grid w-full max-w-xl gap-6 sm:grid-cols-2">
+    <div className="space-y-2">
+      <Label className="text-muted-foreground">Shipped default (no border)</Label>
+      <Input placeholder="Search for an artist…" />
+      <p className="text-xs text-muted-foreground">
+        `&lt;Input /&gt;` with no className. There is a real input here.
+      </p>
+    </div>
+    <div className="space-y-2">
+      <Label>What call sites actually write</Label>
+      <Input
+        placeholder="Search for an artist…"
+        className="h-10 rounded-md border border-input px-3 py-2"
+      />
+      <p className="text-xs text-muted-foreground">
+        `h-10 rounded-md border border-input` bolted on at the call site.
+      </p>
+    </div>
+  </div>
+);
+
+/**
+ * The nav SearchBar composition: a leading Lucide magnifier absolutely positioned over a
+ * `pl-10` Input. Ported from SearchBar.tsx, with the border added so the field is visible.
+ */
+export const WithLeadingIcon = () => (
+  <div className="relative w-full max-w-[400px]">
+    <Input
+      type="text"
+      placeholder="Search for an artist..."
+      defaultValue="Arca"
+      className="h-10 rounded-md border border-input pl-10 pr-3 py-2"
+    />
+    <svg
+      className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  </div>
+);
+
+/** The static states an Input can be captured in: empty, filled, disabled, read-only. */
+export const States = () => {
+  const chrome = "h-10 rounded-md border border-input px-3 py-2";
+  return (
+    <div className="grid w-full max-w-md gap-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="in-empty">Artist name</Label>
+        <Input id="in-empty" placeholder="e.g. Yaeji" className={chrome} />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="in-filled">Spotify URL</Label>
+        <Input
+          id="in-filled"
+          defaultValue="https://open.spotify.com/artist/2VZNmg3v9nbVMnRkZadyi5"
+          className={chrome}
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="in-disabled">Wallet address</Label>
+        <Input
+          id="in-disabled"
+          disabled
+          defaultValue="0x4a1e…9c02 (linked via Privy)"
+          className={chrome}
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="in-invalid">Bandcamp URL</Label>
+        <Input
+          id="in-invalid"
+          defaultValue="bandcamp/notarealartist"
+          aria-invalid
+          className="h-10 rounded-md border border-destructive px-3 py-2"
+        />
+        <p className="text-sm font-medium text-destructive">
+          Doesn&apos;t match the Bandcamp URL pattern in urlmap.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * The `glass-subtle` wrapper pattern from AddArtistData: the Input keeps its borderless
+ * default and the surrounding glass pill supplies the chrome. This is the one place the
+ * stripped-bare default is actually load-bearing rather than a bug.
+ *
+ * `.glass-subtle` is a translucent white — it needs a saturated backdrop to be visible at
+ * all, so the card sits on the brand gradient the artist page uses.
+ */
+export const GlassWrapper = () => (
+  <div className="w-full rounded-xl bg-gradient-to-br from-pastypink via-[#7c3aed] to-pastyblue p-8">
+    <div className="flex max-w-md gap-2">
+      <div className="glass-subtle flex h-11 flex-grow items-center rounded-lg px-3">
+        <Input
+          placeholder="Paste a profile link…"
+          defaultValue="https://soundcloud.com/jamie-xx"
+          className="w-full border-0 bg-transparent p-0 text-sm text-black outline-none placeholder:text-muted-foreground"
+        />
+      </div>
+      <button
+        type="button"
+        className="h-11 shrink-0 rounded-lg bg-pastypink px-4 text-sm font-medium text-white"
+      >
+        Submit
+      </button>
+    </div>
+  </div>
+);

--- a/.design-sync/previews/Label.tsx
+++ b/.design-sync/previews/Label.tsx
@@ -1,0 +1,77 @@
+import { Checkbox, Input, Label } from "musicnerdweb";
+
+/**
+ * Label is the thinnest wrapper in the kit: a Radix Label with a single, variant-less cva
+ * — `text-sm font-medium leading-none` plus the `peer-disabled:` pair. There is no size or
+ * tone axis to show, so the axis worth showing is *what it labels*.
+ */
+export const Default = () => (
+  <div className="w-full max-w-sm space-y-1.5">
+    <Label htmlFor="lb-artist">Artist name</Label>
+    <Input
+      id="lb-artist"
+      defaultValue="Floating Points"
+      className="h-10 rounded-md border border-input px-3 py-2"
+    />
+  </div>
+);
+
+/**
+ * `peer-disabled:opacity-70` is the only state the cva encodes, and it is a footgun: it fires
+ * off the SIBLING control's `peer` marker, so a disabled control that forgot `className="peer"`
+ * leaves its label at full strength — indistinguishable from an enabled field.
+ *
+ * The two rows below are the whole axis: enabled at full strength, and a disabled control
+ * whose Label has dimmed itself to 70%. The footgun is that this ONLY happens if the control
+ * carries `className="peer"` — a disabled control that forgot the marker leaves its label at
+ * full strength, indistinguishable from row 1. Worth noting that 70% opacity is a very quiet
+ * disabled signal to begin with.
+ */
+export const PeerDisabled = () => (
+  <div className="flex w-full max-w-lg flex-col gap-4">
+    <div className="flex items-center gap-2">
+      <Checkbox id="lb-enabled" className="peer" defaultChecked />
+      <Label htmlFor="lb-enabled" className="text-base">
+        Whitelisted contributor — enabled
+      </Label>
+    </div>
+    <div className="flex items-center gap-2">
+      <Checkbox id="lb-peer" className="peer" disabled />
+      <Label htmlFor="lb-peer" className="text-base">
+        Admin role — disabled, label dimmed via peer
+      </Label>
+    </div>
+  </div>
+);
+
+/**
+ * The repo leans on Label for two things it wasn't really designed for: an inline error
+ * string (AddArtistData renders rejection text as a red `<Label>`), and admin field
+ * captions. Both are just className overrides on the same primitive — shown as shipped.
+ */
+export const AsErrorText = () => (
+  <div className="w-full max-w-md space-y-3">
+    <div className="space-y-1.5">
+      <Label htmlFor="lb-url">Platform link</Label>
+      <Input
+        id="lb-url"
+        defaultValue="https://sondcloud.com/arca1000000"
+        className="h-10 rounded-md border border-destructive px-3 py-2"
+      />
+      <Label className="text-xs leading-relaxed text-red-600">
+        We couldn&apos;t match that host to any platform in urlmap. Supported: Spotify,
+        Deezer, Bandcamp, SoundCloud, Apple Music.
+      </Label>
+    </div>
+    <div className="space-y-1.5">
+      <Label htmlFor="lb-key" className="uppercase tracking-wide text-muted-foreground">
+        MCP key label
+      </Label>
+      <Input
+        id="lb-key"
+        defaultValue="id-mapping-agent"
+        className="h-10 rounded-md border border-input px-3 py-2"
+      />
+    </div>
+  </div>
+);

--- a/.design-sync/previews/LoadingPage.tsx
+++ b/.design-sync/previews/LoadingPage.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from "react";
+import { LoadingPage } from "musicnerdweb";
+
+/**
+ * Two capture-harness facts drive this file:
+ *
+ * 1. LoadingPage is a `fixed inset-0 z-[9999]` full-viewport scrim. Dropped straight into a
+ *    preview grid it blankets the whole sheet. The wrapper below carries an inline
+ *    `transform: translateZ(0)`, which makes it the containing block for `position: fixed`
+ *    descendants, bounding the overlay to this card. (Inline style, not a Tailwind arbitrary
+ *    property — the DS stylesheet does not emit those.)
+ *
+ * 2. The spinner is `<img src="/spinner.svg">`. The preview server serves only the bundle dir
+ *    and its MIME table has no `.svg` entry, so the request 404s / mis-types and the browser
+ *    paints a broken-image glyph. `useRealSpinner` re-points that exact <img> at the REAL
+ *    public/spinner.svg, inlined as a data URI — so the card shows the shipped asset, not a
+ *    substitute. Remove this shim once the harness serves public/ with an svg MIME type.
+ */
+const SPINNER_DATA_URI = "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiBzdHlsZT0ibWFyZ2luOiBhdXRvOyBiYWNrZ3JvdW5kOiBub25lOyBkaXNwbGF5OiBibG9jazsgc2hhcGUtcmVuZGVyaW5nOiBhdXRvOyIgd2lkdGg9IjIwMHB4IiBoZWlnaHQ9IjIwMHB4IiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQiPgo8ZyB0cmFuc2Zvcm09InJvdGF0ZSgwIDUwIDUwKSI+CiAgPHJlY3QgeD0iMjkuNSIgeT0iOS41IiByeD0iMjAuNSIgcnk9IjIwLjUiIHdpZHRoPSI0MSIgaGVpZ2h0PSI0MSIgZmlsbD0iI2ZmOWFlMSI+CiAgICA8YW5pbWF0ZSBhdHRyaWJ1dGVOYW1lPSJvcGFjaXR5IiB2YWx1ZXM9IjE7MCIga2V5VGltZXM9IjA7MSIgZHVyPSIwLjYyNXMiIGJlZ2luPSItMC41NDY4NzVzIiByZXBlYXRDb3VudD0iaW5kZWZpbml0ZSI+PC9hbmltYXRlPgogIDwvcmVjdD4KPC9nPjxnIHRyYW5zZm9ybT0icm90YXRlKDQ1IDUwIDUwKSI+CiAgPHJlY3QgeD0iMjkuNSIgeT0iOS41IiByeD0iMjAuNSIgcnk9IjIwLjUiIHdpZHRoPSI0MSIgaGVpZ2h0PSI0MSIgZmlsbD0iI2ZmOWFlMSI+CiAgICA8YW5pbWF0ZSBhdHRyaWJ1dGVOYW1lPSJvcGFjaXR5IiB2YWx1ZXM9IjE7MCIga2V5VGltZXM9IjA7MSIgZHVyPSIwLjYyNXMiIGJlZ2luPSItMC40Njg3NXMiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIj48L2FuaW1hdGU+CiAgPC9yZWN0Pgo8L2c+PGcgdHJhbnNmb3JtPSJyb3RhdGUoOTAgNTAgNTApIj4KICA8cmVjdCB4PSIyOS41IiB5PSI5LjUiIHJ4PSIyMC41IiByeT0iMjAuNSIgd2lkdGg9IjQxIiBoZWlnaHQ9IjQxIiBmaWxsPSIjZmY5YWUxIj4KICAgIDxhbmltYXRlIGF0dHJpYnV0ZU5hbWU9Im9wYWNpdHkiIHZhbHVlcz0iMTswIiBrZXlUaW1lcz0iMDsxIiBkdXI9IjAuNjI1cyIgYmVnaW49Ii0wLjM5MDYyNXMiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIj48L2FuaW1hdGU+CiAgPC9yZWN0Pgo8L2c+PGcgdHJhbnNmb3JtPSJyb3RhdGUoMTM1IDUwIDUwKSI+CiAgPHJlY3QgeD0iMjkuNSIgeT0iOS41IiByeD0iMjAuNSIgcnk9IjIwLjUiIHdpZHRoPSI0MSIgaGVpZ2h0PSI0MSIgZmlsbD0iI2ZmOWFlMSI+CiAgICA8YW5pbWF0ZSBhdHRyaWJ1dGVOYW1lPSJvcGFjaXR5IiB2YWx1ZXM9IjE7MCIga2V5VGltZXM9IjA7MSIgZHVyPSIwLjYyNXMiIGJlZ2luPSItMC4zMTI1cyIgcmVwZWF0Q291bnQ9ImluZGVmaW5pdGUiPjwvYW5pbWF0ZT4KICA8L3JlY3Q+CjwvZz48ZyB0cmFuc2Zvcm09InJvdGF0ZSgxODAgNTAgNTApIj4KICA8cmVjdCB4PSIyOS41IiB5PSI5LjUiIHJ4PSIyMC41IiByeT0iMjAuNSIgd2lkdGg9IjQxIiBoZWlnaHQ9IjQxIiBmaWxsPSIjZmY5YWUxIj4KICAgIDxhbmltYXRlIGF0dHJpYnV0ZU5hbWU9Im9wYWNpdHkiIHZhbHVlcz0iMTswIiBrZXlUaW1lcz0iMDsxIiBkdXI9IjAuNjI1cyIgYmVnaW49Ii0wLjIzNDM3NXMiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIj48L2FuaW1hdGU+CiAgPC9yZWN0Pgo8L2c+PGcgdHJhbnNmb3JtPSJyb3RhdGUoMjI1IDUwIDUwKSI+CiAgPHJlY3QgeD0iMjkuNSIgeT0iOS41IiByeD0iMjAuNSIgcnk9IjIwLjUiIHdpZHRoPSI0MSIgaGVpZ2h0PSI0MSIgZmlsbD0iI2ZmOWFlMSI+CiAgICA8YW5pbWF0ZSBhdHRyaWJ1dGVOYW1lPSJvcGFjaXR5IiB2YWx1ZXM9IjE7MCIga2V5VGltZXM9IjA7MSIgZHVyPSIwLjYyNXMiIGJlZ2luPSItMC4xNTYyNXMiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIj48L2FuaW1hdGU+CiAgPC9yZWN0Pgo8L2c+PGcgdHJhbnNmb3JtPSJyb3RhdGUoMjcwIDUwIDUwKSI+CiAgPHJlY3QgeD0iMjkuNSIgeT0iOS41IiByeD0iMjAuNSIgcnk9IjIwLjUiIHdpZHRoPSI0MSIgaGVpZ2h0PSI0MSIgZmlsbD0iI2ZmOWFlMSI+CiAgICA8YW5pbWF0ZSBhdHRyaWJ1dGVOYW1lPSJvcGFjaXR5IiB2YWx1ZXM9IjE7MCIga2V5VGltZXM9IjA7MSIgZHVyPSIwLjYyNXMiIGJlZ2luPSItMC4wNzgxMjVzIiByZXBlYXRDb3VudD0iaW5kZWZpbml0ZSI+PC9hbmltYXRlPgogIDwvcmVjdD4KPC9nPjxnIHRyYW5zZm9ybT0icm90YXRlKDMxNSA1MCA1MCkiPgogIDxyZWN0IHg9IjI5LjUiIHk9IjkuNSIgcng9IjIwLjUiIHJ5PSIyMC41IiB3aWR0aD0iNDEiIGhlaWdodD0iNDEiIGZpbGw9IiNmZjlhZTEiPgogICAgPGFuaW1hdGUgYXR0cmlidXRlTmFtZT0ib3BhY2l0eSIgdmFsdWVzPSIxOzAiIGtleVRpbWVzPSIwOzEiIGR1cj0iMC42MjVzIiBiZWdpbj0iMHMiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIj48L2FuaW1hdGU+CiAgPC9yZWN0Pgo8L2c+CjwhLS0gW2xkaW9dIGdlbmVyYXRlZCBieSBodHRwczovL2xvYWRpbmcuaW8vIC0tPjwvc3ZnPg==";
+
+function useRealSpinner(ref: React.RefObject<HTMLDivElement>) {
+  useEffect(() => {
+    const img = ref.current?.querySelector<HTMLImageElement>('img[alt="Loading"]');
+    if (img) img.src = SPINNER_DATA_URI;
+  });
+}
+
+const Frame = ({ children }: { children: React.ReactNode }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useRealSpinner(ref as React.RefObject<HTMLDivElement>);
+  return (
+    <div
+      ref={ref}
+      className="relative h-64 w-full max-w-md overflow-hidden rounded-xl border border-border bg-card"
+      style={{ transform: "translateZ(0)" }}
+    >
+      {/* Real page content, so the scrim has something to veil. On a blank white card the
+          bg-white/80 + backdrop-blur-sm treatment would be completely invisible. */}
+      <div className="space-y-3 p-5">
+        <div className="text-xl font-bold text-maroon">Sudan Archives</div>
+        <div className="h-4 w-full rounded bg-muted" />
+        <div className="h-4 w-5/6 rounded bg-muted" />
+        <div className="h-28 w-full rounded-lg bg-gradient-to-br from-pastypink via-purple-600 to-pastyblue" />
+      </div>
+      {children}
+    </div>
+  );
+};
+
+/**
+ * Default state: an 80%-white blurred scrim over the page, with a white `rounded-xl shadow-lg`
+ * card holding the 48px spinner and the message. It also locks `body` scroll while mounted.
+ */
+export const Default = () => (
+  <Frame>
+    <LoadingPage />
+  </Frame>
+);
+
+/**
+ * `message` is the only prop. Call sites use it to name the operation being awaited — the
+ * add-artist flow names the artist being written, so the wait is attributable rather than generic.
+ */
+export const WithMessage = () => (
+  <Frame>
+    <LoadingPage message="Adding Yaeji…" />
+  </Frame>
+);

--- a/.design-sync/previews/PleaseLoginPage.tsx
+++ b/.design-sync/previews/PleaseLoginPage.tsx
@@ -1,0 +1,33 @@
+import { PleaseLoginPage } from "musicnerdweb";
+
+/**
+ * The gate shown in place of any authenticated route. It is deliberately spare: a centered
+ * `text-2xl` bold heading and one `pastypink` Button whose click proxies to the real nav
+ * login button (`#login-btn`). Wrapped in a bounded, page-like frame so the centering is
+ * legible instead of collapsing to a bare stack of two elements.
+ *
+ * Note the button's hover is `hover:bg-gray-200` — a grey, not a pink tint. That is the
+ * shipped styling (DESIGN.md flags it as an inconsistency); the preview shows it as-is.
+ */
+const Page = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex h-[220px] w-full max-w-md items-center justify-center rounded-xl border border-border bg-background">
+    {children}
+  </div>
+);
+
+/** Default copy — the generic route guard. */
+export const Default = () => (
+  <Page>
+    <PleaseLoginPage />
+  </Page>
+);
+
+/**
+ * `text` is the only prop, and every real call site overrides it to name the thing being
+ * gated (profile, bookmarks, the add-artist flow) rather than leaving the generic string.
+ */
+export const CustomCopy = () => (
+  <Page>
+    <PleaseLoginPage text="Log in to add an artist to MusicNerd" />
+  </Page>
+);

--- a/.design-sync/previews/Popover.tsx
+++ b/.design-sync/previews/Popover.tsx
@@ -1,0 +1,87 @@
+import {
+  Button,
+  Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Badge,
+} from "musicnerdweb";
+
+/**
+ * Popover portals to document.body and positions itself `fixed` against its trigger, so it
+ * only renders when forced open — hence `defaultOpen`. Positioning classes are left alone;
+ * the card viewport is sized to fit the floating panel.
+ *
+ * Composition follows the profile DatePicker (the repo's only Popover), generalized to the
+ * artist-page "link details" affordance.
+ */
+export const Open = () => (
+  <div className="flex min-h-[360px] items-start justify-center pt-6">
+    <Popover defaultOpen>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Spotify link details</Button>
+      </PopoverTrigger>
+      <PopoverContent align="center" sideOffset={8}>
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <h4 className="text-sm font-semibold leading-none">Spotify</h4>
+            <p className="text-sm text-muted-foreground">
+              Added by @vinylghost on Mar 4, 2025.
+            </p>
+          </div>
+          <p className="break-all rounded-md bg-muted px-2 py-1.5 font-mono text-xs">
+            open.spotify.com/artist/4tZwfgrHOc3mvqYlEYSvVi
+          </p>
+          <div className="flex items-center gap-2">
+            <Badge>listen</Badge>
+            <span className="text-xs text-muted-foreground">Verified link</span>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  </div>
+);
+
+/**
+ * Wider panel with a form-ish body: the "add a platform link" flow. Shows that PopoverContent's
+ * default `w-72` is overridable and that padding survives a denser layout.
+ */
+export const WithActions = () => (
+  <div className="flex min-h-[360px] items-start justify-center pt-6">
+    <Popover defaultOpen>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Add link</Button>
+      </PopoverTrigger>
+      {/* Radix autofocuses the first field on open, which paints a native focus ring in the
+          capture; suppressed so the card shows the resting state. */}
+      <PopoverContent
+        align="center"
+        sideOffset={8}
+        className="w-80"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <h4 className="text-sm font-semibold leading-none">
+              Suggest a link for Jamie xx
+            </h4>
+            <p className="text-sm text-muted-foreground">
+              Submissions are reviewed by a moderator before they go live.
+            </p>
+          </div>
+          {/* Input ships with no border/height of its own — styled here so it reads as a field. */}
+          <Input
+            defaultValue="bandcamp.com/jamiexx"
+            className="h-10 w-full rounded-md border border-input px-3 py-2 text-sm"
+          />
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" size="sm">
+              Cancel
+            </Button>
+            <Button size="sm">Submit</Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  </div>
+);

--- a/.design-sync/previews/Select.tsx
+++ b/.design-sync/previews/Select.tsx
@@ -1,0 +1,96 @@
+import {
+  Label,
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "musicnerdweb";
+
+/**
+ * Rendered `open` — a closed Select shows only its trigger, and the listbox is the part
+ * worth reviewing. `modal={false}` stops Radix from marking the rest of the frame inert.
+ *
+ * SelectContent is PORTALED to document.body and positioned `fixed` by Radix. Do not try to
+ * re-anchor it inside the card with `className="relative"`: `cn()` is tailwind-merge, so
+ * `relative` REPLACES Radix's `fixed` and the -50% transform yanks the panel off-screen.
+ * Positioning is left alone here on purpose.
+ *
+ * Composition ported from the admin user-role filter (whitelisted-data-table.tsx), extended
+ * with a SelectLabel/SelectSeparator group so the full part inventory is on screen. Note the
+ * trigger DOES carry `h-10 border border-input` — unlike Input, Select was not stripped.
+ */
+export const Open = () => (
+  <div className="w-[220px] space-y-1.5">
+    <Label htmlFor="sel-role">Filter role</Label>
+    <Select open modal={false} defaultValue="Whitelisted">
+      <SelectTrigger id="sel-role" className="w-[220px]">
+        <SelectValue placeholder="Filter Role" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>Roles</SelectLabel>
+          <SelectItem value="All">All Users</SelectItem>
+          <SelectItem value="Admin">Admins</SelectItem>
+          <SelectItem value="Whitelisted">Whitelisted Users</SelectItem>
+          <SelectItem value="User">Users</SelectItem>
+        </SelectGroup>
+        <SelectSeparator />
+        <SelectGroup>
+          <SelectLabel>Moderation</SelectLabel>
+          <SelectItem value="Hidden">Hidden Users</SelectItem>
+          <SelectItem value="Banned" disabled>
+            Banned Users (coming soon)
+          </SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  </div>
+);
+
+/**
+ * Closed triggers — the only Select surface that renders inline. Left is the standard admin
+ * filter; right is the SourceCard "type" pill, which squashes the trigger down to a
+ * rounded-full 10px badge (`h-auto py-0.5 px-2 text-[10px]`) and colors it per source type.
+ * That badge-shaped trigger is a real, load-bearing override in this repo.
+ */
+export const Triggers = () => (
+  <div className="flex flex-wrap items-end gap-6">
+    <div className="space-y-1.5">
+      <Label>Placeholder (no value)</Label>
+      <Select>
+        <SelectTrigger className="w-[180px]">
+          <SelectValue placeholder="Filter Role" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="All">All Users</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+    <div className="space-y-1.5">
+      <Label>Disabled</Label>
+      <Select disabled defaultValue="Deezer">
+        <SelectTrigger className="w-[180px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="Deezer">Deezer</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+    <div className="space-y-1.5">
+      <Label>SourceCard type pill</Label>
+      <Select defaultValue="interview">
+        <SelectTrigger className="h-auto w-auto min-w-0 gap-1 rounded-full border border-purple-200 bg-purple-50 px-2 py-0.5 text-[10px] capitalize text-purple-700">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="interview">interview</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  </div>
+);

--- a/.design-sync/previews/SlidingText.tsx
+++ b/.design-sync/previews/SlidingText.tsx
@@ -1,0 +1,77 @@
+import { SlidingText } from "musicnerdweb";
+
+/**
+ * A vertical word carousel: it takes `ReactNode[]`, stacks them, and translates the stack
+ * up by one slot every `interval` ms until it reaches the last item — then it resets to 0
+ * and "expands" (stops animating). Each slot is clamped to the `.home-text-height` global
+ * (36px → 70px, fluid) and the outer div is `overflow-hidden`, so exactly one item shows.
+ *
+ * Because it animates on a timer, a static capture freezes one frame. That is the honest
+ * artifact — the interval here is stretched so the captured frame is a stable one.
+ *
+ * Two traps, both learned the hard way:
+ *  • Do NOT typeset slots with the `.home-text-h2` global. It looks like a pure type class
+ *    but globals.css also attaches `color: … !important` to it (`:first-child` → #ff9ce3,
+ *    everything else → #9b83a0), which silently overrides any `text-*` utility on the node.
+ *    Size the slots with plain Tailwind and keep colour under your own control.
+ *  • The source declares `transition-max-height`, which is not a real Tailwind utility, so
+ *    the collapse is instant rather than eased. Left as-is; that's the shipped behavior.
+ */
+
+/**
+ * Sizing rule for slots: the component wraps each node in a div whose `max-height` is the
+ * `.home-text-height` clamp (36→70px, fluid), but it never sets a `height`. So a node
+ * SHORTER than the clamp leaves the slot short of the window and the NEXT word peeks in
+ * underneath. Every node therefore gets a fixed `h-16` box — taller than the clamp at any
+ * viewport, so each slot fills the window exactly and only one word is ever visible.
+ */
+const SLOT = "flex h-16 items-center text-4xl font-bold";
+
+/**
+ * The homepage hero pattern this exists for: a fixed lead-in on the left, the rotating noun
+ * on the right. Slots are ReactNode, so each carries its own brand colour — the frame you
+ * catch is whichever word is up.
+ */
+export const HeroRotator = () => (
+  <div className="flex w-full max-w-xl items-center justify-center gap-3 rounded-xl border border-border bg-card px-6 py-6">
+    <span className="text-4xl font-bold text-maroon">Discover</span>
+    <SlidingText
+      interval={9000}
+      items={[
+        <span key="a" className={SLOT} style={{ color: "#ff9ce3" }}>
+          artists
+        </span>,
+        <span key="b" className={`${SLOT} text-pastyblue`}>
+          labels
+        </span>,
+        <span key="c" className={`${SLOT} text-jellygreen`}>
+          collectors
+        </span>,
+      ]}
+    />
+  </div>
+);
+
+/**
+ * The same machine over a saturated backdrop — the only context where the brand's glass and
+ * gradient surfaces actually read (`.glass` is white-on-white and invisible otherwise).
+ * Slots here are composites, not bare strings, which is the point of the `ReactNode[]` API.
+ */
+export const OnGradient = () => (
+  <div className="flex w-full max-w-xl items-center justify-center rounded-xl bg-gradient-to-br from-pastypink via-purple-600 to-pastyblue px-6 py-8">
+    <SlidingText
+      interval={9000}
+      items={[
+        <span key="a" className={`${SLOT} text-white`}>
+          Sudan Archives
+        </span>,
+        <span key="b" className={`${SLOT} text-white`}>
+          JPEGMAFIA
+        </span>,
+        <span key="c" className={`${SLOT} text-white`}>
+          Yaeji
+        </span>,
+      ]}
+    />
+  </div>
+);

--- a/.design-sync/previews/Table.tsx
+++ b/.design-sync/previews/Table.tsx
@@ -1,0 +1,136 @@
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Badge,
+} from "musicnerdweb";
+
+/**
+ * The profile "My entries" table (`src/app/profile/UserEntriesTable.tsx`): one row per
+ * UGC submission — date, artist, platform, submitted URL, status.
+ *
+ * Note this Table is NOT stock shadcn: `TableCell` carries
+ * `whitespace-nowrap overflow-hidden text-ellipsis` and tighter `p-2` padding
+ * (stock is `p-4`, wrapping). Every cell truncates rather than wraps.
+ */
+export const Default = () => (
+  <Table>
+    <TableHeader>
+      <TableRow>
+        <TableHead className="w-[110px]">Date</TableHead>
+        <TableHead>Artist</TableHead>
+        <TableHead>Platform</TableHead>
+        <TableHead>Submitted URL</TableHead>
+        <TableHead className="text-right">Status</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {[
+        ["Jul 09, 2026", "Jamie xx", "Spotify", "https://open.spotify.com/artist/2SBRfBHOwGKA8fdQrRAtc4", "Approved"],
+        ["Jul 08, 2026", "Floating Points", "Bandcamp", "https://floatingpoints.bandcamp.com/album/cascade", "Approved"],
+        ["Jul 08, 2026", "Yaeji", "SoundCloud", "https://soundcloud.com/kraeji", "Pending"],
+        ["Jul 06, 2026", "Overmono", "Apple Music", "https://music.apple.com/us/artist/overmono/1113641144", "Approved"],
+      ].map(([date, artist, platform, url, status]) => (
+        <TableRow key={url}>
+          <TableCell className="text-muted-foreground">{date}</TableCell>
+          <TableCell className="font-medium">{artist}</TableCell>
+          <TableCell>{platform}</TableCell>
+          <TableCell className="text-muted-foreground">{url}</TableCell>
+          <TableCell className="text-right">
+            <Badge variant={status === "Approved" ? "secondary" : "outline"}>{status}</Badge>
+          </TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+);
+
+/**
+ * Truncation, on purpose. The same MusicBrainz/Deezer URL in three columns of decreasing
+ * width: it silently loses its tail rather than wrapping to a second line. This is the most
+ * consequential deviation from stock shadcn Table — and it only bites under `table-fixed`,
+ * since in the default auto layout the table just widens to fit and no cell ever clips.
+ */
+export const TruncatingCells = () => (
+  <Table style={{ tableLayout: "fixed" }}>
+    <TableHeader>
+      <TableRow>
+        <TableHead style={{ width: 100 }}>Artist</TableHead>
+        <TableHead style={{ width: 130 }}>narrow</TableHead>
+        <TableHead style={{ width: 210 }}>medium</TableHead>
+        <TableHead>wide</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {[
+        ["Kelela", "https://musicbrainz.org/artist/9e4b8d5f-9c15-4b31-a2f6-72d0e4e19b21"],
+        ["Four Tet", "https://www.deezer.com/en/artist/1147?utm_source=musicnerd"],
+      ].map(([artist, url]) => (
+        <TableRow key={artist}>
+          <TableCell className="font-medium">{artist}</TableCell>
+          <TableCell className="text-muted-foreground">{url}</TableCell>
+          <TableCell className="text-muted-foreground">{url}</TableCell>
+          <TableCell className="text-muted-foreground">{url}</TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+);
+
+/**
+ * The full compound: Caption + Header + Body + Footer, with a selected row
+ * (`data-[state=selected]:bg-muted`) — the admin moderation queue pattern. Footer is
+ * `bg-muted/50 font-medium` and is the only place a total belongs.
+ */
+export const WithFooterAndSelection = () => (
+  <Table>
+    <TableCaption>Cross-platform ID mapping coverage — agent run #48</TableCaption>
+    <TableHeader>
+      <TableRow>
+        <TableHead>Platform</TableHead>
+        <TableHead className="text-right">Mapped</TableHead>
+        <TableHead className="text-right">Excluded</TableHead>
+        <TableHead className="text-right">Coverage</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      <TableRow>
+        <TableCell className="font-medium">Deezer</TableCell>
+        <TableCell className="text-right">12,480</TableCell>
+        <TableCell className="text-right">312</TableCell>
+        <TableCell className="text-right">86%</TableCell>
+      </TableRow>
+      <TableRow data-state="selected">
+        <TableCell className="font-medium">Apple Music</TableCell>
+        <TableCell className="text-right">9,104</TableCell>
+        <TableCell className="text-right">844</TableCell>
+        <TableCell className="text-right">63%</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell className="font-medium">MusicBrainz</TableCell>
+        <TableCell className="text-right">13,902</TableCell>
+        <TableCell className="text-right">96</TableCell>
+        <TableCell className="text-right">95%</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell className="font-medium">Tidal</TableCell>
+        <TableCell className="text-right">4,331</TableCell>
+        <TableCell className="text-right">1,207</TableCell>
+        <TableCell className="text-right">30%</TableCell>
+      </TableRow>
+    </TableBody>
+    <TableFooter>
+      <TableRow>
+        <TableCell>Total</TableCell>
+        <TableCell className="text-right">39,817</TableCell>
+        <TableCell className="text-right">2,459</TableCell>
+        <TableCell className="text-right">68%</TableCell>
+      </TableRow>
+    </TableFooter>
+  </Table>
+);

--- a/.design-sync/previews/Tabs.tsx
+++ b/.design-sync/previews/Tabs.tsx
@@ -1,0 +1,121 @@
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  Badge,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "musicnerdweb";
+
+/**
+ * The admin dashboard nav (`src/app/admin/AdminTabs.tsx`) — six sections, pending counts
+ * baked into the trigger labels. `defaultValue` is required or no panel renders.
+ * Stock shadcn/Radix: `bg-muted` rail, active trigger lifts to `bg-background` + shadow-sm.
+ */
+export const Default = () => (
+  <Tabs defaultValue="ugc" className="w-[620px]">
+    <TabsList>
+      <TabsTrigger value="ugc">UGC (14)</TabsTrigger>
+      <TabsTrigger value="claims">Claims (3)</TabsTrigger>
+      <TabsTrigger value="artist-data">Artist Data</TabsTrigger>
+      <TabsTrigger value="users">Users</TabsTrigger>
+      <TabsTrigger value="mcp-keys">MCP Keys</TabsTrigger>
+      <TabsTrigger value="agent-work">Agent Work</TabsTrigger>
+    </TabsList>
+    <TabsContent value="ugc">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Artist</TableHead>
+            <TableHead>Platform</TableHead>
+            <TableHead>Contributor</TableHead>
+            <TableHead className="text-right">Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {[
+            ["Yaeji", "Bandcamp", "vinylwitch"],
+            ["Overmono", "Deezer", "bpmhunter"],
+            ["Kelela", "SoundCloud", "crate.digger"],
+          ].map(([artist, platform, who]) => (
+            <TableRow key={artist}>
+              <TableCell className="font-medium">{artist}</TableCell>
+              <TableCell>{platform}</TableCell>
+              <TableCell className="text-muted-foreground">@{who}</TableCell>
+              <TableCell className="text-right">
+                <Badge variant="outline">Pending</Badge>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TabsContent>
+    <TabsContent value="claims">Claims queue</TabsContent>
+    <TabsContent value="artist-data">Artist data tools</TabsContent>
+    <TabsContent value="users">User directory</TabsContent>
+    <TabsContent value="mcp-keys">MCP API keys</TabsContent>
+    <TabsContent value="agent-work">Agent activity</TabsContent>
+  </Tabs>
+);
+
+/**
+ * A different tab selected (`defaultValue="agent-work"`, the last trigger), proving the
+ * active-state axis: only the selected trigger gets `bg-background text-foreground shadow-sm`;
+ * the rest stay `text-muted-foreground` on the muted rail.
+ */
+export const SecondPanelActive = () => (
+  <Tabs defaultValue="agent-work" className="w-[620px]">
+    <TabsList>
+      <TabsTrigger value="ugc">UGC (14)</TabsTrigger>
+      <TabsTrigger value="claims">Claims (3)</TabsTrigger>
+      <TabsTrigger value="artist-data">Artist Data</TabsTrigger>
+      <TabsTrigger value="users">Users</TabsTrigger>
+      <TabsTrigger value="mcp-keys">MCP Keys</TabsTrigger>
+      <TabsTrigger value="agent-work">Agent Work</TabsTrigger>
+    </TabsList>
+    <TabsContent value="ugc">UGC queue</TabsContent>
+    <TabsContent value="agent-work">
+      <div className="grid grid-cols-3 gap-3">
+        {[
+          ["Deezer", "12,480", "86% coverage"],
+          ["Apple Music", "9,104", "63% coverage"],
+          ["MusicBrainz", "13,902", "95% coverage"],
+        ].map(([platform, mapped, note]) => (
+          <div key={platform} className="rounded-lg border bg-card p-4">
+            <p className="text-sm text-muted-foreground">{platform}</p>
+            <p className="text-2xl font-semibold">{mapped}</p>
+            <p className="text-xs text-muted-foreground">{note}</p>
+          </div>
+        ))}
+      </div>
+    </TabsContent>
+  </Tabs>
+);
+
+/**
+ * Two triggers, one disabled (`disabled:opacity-50`) — the artist page's Bio / Fun Facts
+ * split before the AI content has generated. Also the narrow, non-admin shape of the
+ * component: a short rail rather than a six-way one.
+ */
+export const TwoUpWithDisabled = () => (
+  <Tabs defaultValue="bio" className="w-[420px]">
+    <TabsList>
+      <TabsTrigger value="bio">Bio</TabsTrigger>
+      <TabsTrigger value="fun-facts" disabled>
+        Fun Facts
+      </TabsTrigger>
+    </TabsList>
+    <TabsContent value="bio">
+      <div className="rounded-lg border bg-card p-4 text-sm leading-relaxed text-muted-foreground">
+        Floating Points is the project of Sam Shepherd — a London producer whose work moves
+        between modal jazz, broken house, and orchestral composition.
+      </div>
+    </TabsContent>
+    <TabsContent value="fun-facts">Not generated yet.</TabsContent>
+  </Tabs>
+);

--- a/.design-sync/previews/Textarea.tsx
+++ b/.design-sync/previews/Textarea.tsx
@@ -1,0 +1,73 @@
+import { Label, Textarea } from "musicnerdweb";
+
+/**
+ * The shipped default. Two deliberate-looking deviations from stock shadcn are visible here:
+ *
+ * 1. `min-h-[50px]` instead of stock `min-h-[80px]` — the empty field is noticeably squatter
+ *    than a shadcn Textarea anywhere else.
+ * 2. The focus ring is BROKEN: the class list has `focus-visible:ring-ring` and
+ *    `focus-visible:ring-offset-2` but no `focus-visible:ring-2`, so ring width stays 0 and
+ *    nothing paints on focus. Unlike Input, the border IS present.
+ */
+export const Default = () => (
+  <div className="w-full max-w-md space-y-1.5">
+    <Label htmlFor="ta-default">Artist bio</Label>
+    <Textarea
+      id="ta-default"
+      placeholder="Tell us about this artist…"
+    />
+    <p className="text-sm text-muted-foreground">
+      Empty height is 50px — stock shadcn is 80px.
+    </p>
+  </div>
+);
+
+/**
+ * Realistic content at the height an editor actually uses. The AI-bio review surface passes
+ * `rows` / a min-height override rather than living with the 50px default.
+ */
+export const Filled = () => (
+  <div className="w-full max-w-lg space-y-1.5">
+    <Label htmlFor="ta-bio">AI-generated bio (editable before publish)</Label>
+    <Textarea
+      id="ta-bio"
+      rows={6}
+      className="min-h-[140px]"
+      defaultValue={
+        "Yaeji is a Korean-American producer and vocalist whose work folds house, hip-hop and Korean-language pop into something quietly euphoric. Since 'Raingurl' broke out in 2017 she has released on Godmode and XL Recordings, and her 2023 album 'With A Hammer' pushed further into live instrumentation."
+      }
+    />
+    <p className="text-sm text-muted-foreground">
+      Regenerated automatically whenever a platform link changes.
+    </p>
+  </div>
+);
+
+/** The two non-default static states: disabled and error. */
+export const States = () => (
+  <div className="grid w-full max-w-lg gap-5">
+    <div className="space-y-1.5">
+      <Label htmlFor="ta-disabled">Fun fact (regenerating…)</Label>
+      <Textarea
+        id="ta-disabled"
+        disabled
+        className="min-h-[70px]"
+        defaultValue="Arca scored the runway music for Björk's Cornucopia tour."
+      />
+    </div>
+    <div className="space-y-1.5">
+      <Label htmlFor="ta-error" className="text-destructive">
+        Moderation note
+      </Label>
+      <Textarea
+        id="ta-error"
+        aria-invalid
+        className="min-h-[70px] border-destructive"
+        defaultValue="dupe"
+      />
+      <p className="text-sm font-medium text-destructive">
+        Rejection notes must be at least 20 characters — reviewers see this text.
+      </p>
+    </div>
+  </div>
+);

--- a/.design-sync/previews/ThemeToggle.tsx
+++ b/.design-sync/previews/ThemeToggle.tsx
@@ -1,0 +1,37 @@
+import { ThemeToggle } from "musicnerdweb";
+
+/**
+ * A hand-rolled pill switch — NOT a Radix Switch. It renders two buttons and lets the
+ * `sm:` breakpoint pick one: a 48px circle below `sm`, and this 112×32 pill at and above
+ * it. The knob is an absolutely-positioned 24px white circle that slides left↔right, and
+ * the "Light Mode" / "Dark Mode" labels cross-fade on opacity so the pill never resizes.
+ *
+ * Previews capture light mode, so this is the resting light state: knob left, purple Sun,
+ * "Light Mode" label pushed to the right edge (`justify-end pr-2`). The dark state swaps
+ * to a `#2d3748` track, a black knob and a `pastyblue` Moon.
+ */
+export const Default = () => (
+  <div className="flex items-center gap-4">
+    <ThemeToggle />
+  </div>
+);
+
+/**
+ * Where it actually lives: far right of the nav bar, next to the wordmark and search.
+ * Placed on a plain surface because the toggle carries its own `#f3f4f6` track — it has
+ * no border, so it needs a lighter or darker surface behind it to read as a control.
+ */
+export const InNavBar = () => (
+  <div className="flex w-full max-w-xl items-center gap-4 rounded-xl border border-border bg-card px-4 py-3">
+    <span
+      className="text-lg font-extrabold tracking-tight"
+      style={{ color: "#ff9ce3" }}
+    >
+      MusicNerd
+    </span>
+    <div className="h-9 flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm text-muted-foreground">
+      Search artists…
+    </div>
+    <ThemeToggle />
+  </div>
+);

--- a/.design-sync/previews/Toast.tsx
+++ b/.design-sync/previews/Toast.tsx
@@ -1,0 +1,83 @@
+import {
+  Toast,
+  ToastAction,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "musicnerdweb";
+
+/**
+ * Toast needs ToastProvider + ToastViewport (the viewport is itself `fixed`), and each Toast
+ * must be forced `open` — nothing renders otherwise. ToastClose is `opacity-0` until
+ * group-hover, which never fires in a headless capture, so `opacity-100` is passed to make the
+ * dismiss affordance visible. The capture also takes no animation settle, so
+ * `animation: none` pins the toast at its resting position instead of mid `slide-in`.
+ *
+ * The wrapper + `absolute` viewport is a HARNESS workaround, not a DS pattern: the card's
+ * `.ds-single` root carries a `transform`, which makes it the containing block for anything
+ * `position: fixed`. ToastViewport is rendered inline (Radix does not portal it), so its
+ * `fixed bottom-0` resolved against that box and stranded the toast at the frame edge in a sea
+ * of whitespace. Merging `absolute` over its `fixed` (ToastViewport uses cn()/tailwind-merge)
+ * anchors it inside a bounded relative box. The toast's own appearance is untouched.
+ *
+ * Copy comes from EditablePlatformLink.tsx ("<Platform> link has been removed") and the
+ * admin claims table.
+ */
+export const Default = () => (
+  <div className="relative h-40 w-full">
+    <ToastProvider duration={Infinity}>
+    <Toast open style={{ animation: "none" }}>
+      <div className="grid gap-1">
+        <ToastTitle>Spotify link has been removed</ToastTitle>
+        <ToastDescription>
+          The change is live on Four Tet&apos;s profile.
+        </ToastDescription>
+      </div>
+      <ToastAction altText="Undo removing the Spotify link">Undo</ToastAction>
+      <ToastClose className="opacity-100" />
+    </Toast>
+      <ToastViewport className="absolute inset-x-0 top-0 max-w-full p-3" />
+    </ToastProvider>
+  </div>
+);
+
+/**
+ * The destructive variant, as fired by SearchBar.tsx when adding an artist fails.
+ */
+export const Destructive = () => (
+  <div className="relative h-40 w-full">
+    <ToastProvider duration={Infinity}>
+    <Toast open variant="destructive" style={{ animation: "none" }}>
+      <div className="grid gap-1">
+        <ToastTitle>Error</ToastTitle>
+        <ToastDescription>
+          Failed to add artist — please try again.
+        </ToastDescription>
+      </div>
+      <ToastAction altText="Retry adding the artist">Retry</ToastAction>
+      <ToastClose className="opacity-100" />
+    </Toast>
+      <ToastViewport className="absolute inset-x-0 top-0 max-w-full p-3" />
+    </ToastProvider>
+  </div>
+);
+
+/**
+ * Title-only toast (no description, no action) — the shape most `toast({ title })` calls in the
+ * repo actually produce, e.g. the admin claims table's `Claim Approved`.
+ */
+export const TitleOnly = () => (
+  <div className="relative h-40 w-full">
+    <ToastProvider duration={Infinity}>
+    <Toast open style={{ animation: "none" }}>
+      <div className="grid gap-1">
+        <ToastTitle>Claim approved</ToastTitle>
+      </div>
+      <ToastClose className="opacity-100" />
+    </Toast>
+      <ToastViewport className="absolute inset-x-0 top-0 max-w-full p-3" />
+    </ToastProvider>
+  </div>
+);

--- a/.design-sync/previews/Tooltip.tsx
+++ b/.design-sync/previews/Tooltip.tsx
@@ -1,0 +1,53 @@
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "musicnerdweb";
+
+/**
+ * TooltipContent is portaled and `fixed`, and hover never happens in a headless capture — so
+ * the Tooltip is forced `open` and wrapped in the required TooltipProvider. Positioning is
+ * left to Radix; the card viewport is what makes it fit.
+ *
+ * Content copied in spirit from the artist-page fun-facts buttons, which are the repo's only
+ * Tooltip consumers (a one-line description under each prompt button).
+ */
+export const Open = () => (
+  <TooltipProvider>
+    <div className="flex min-h-[240px] items-start justify-center pt-6">
+      <Tooltip open>
+        <TooltipTrigger asChild>
+          <Button variant="outline" size="sm">
+            Surprise me
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={8} className="whitespace-nowrap">
+          <p>An unexpected fact about this artist</p>
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  </TooltipProvider>
+);
+
+/**
+ * Tooltip anchored to the side, on an icon-only trigger — the pattern used for the small
+ * platform-link icons on the artist page, where the label has nowhere else to live.
+ */
+export const OnIconTrigger = () => (
+  <TooltipProvider>
+    <div className="flex min-h-[240px] items-center justify-center">
+      <Tooltip open>
+        <TooltipTrigger asChild>
+          <Button variant="outline" size="icon" aria-label="Bandcamp">
+            <span className="text-sm font-semibold">B</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="right" sideOffset={10}>
+          <p>Open on Bandcamp</p>
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  </TooltipProvider>
+);

--- a/.design-sync/previews/TypeWriter.tsx
+++ b/.design-sync/previews/TypeWriter.tsx
@@ -1,0 +1,48 @@
+import { TypeWriter } from "musicnerdweb";
+
+/**
+ * Types `text` out one character at a time. Two timers gate it: `startDelay` (default
+ * 1000ms) before the first character, then `typingDelay` (default 80ms) per character.
+ *
+ * Three things a preview author must know:
+ *  1. At the shipped defaults a static capture lands INSIDE the 1000ms start delay and
+ *     photographs an empty string. Both cells below collapse `startDelay` to 0 and
+ *     `typingDelay` to 1ms so the capture catches the settled, fully-typed frame — which
+ *     is the frame a user spends ~all of their time looking at anyway.
+ *  2. It accepts a `className` prop and then never applies it — the render is a bare
+ *     `<span>{displayText}</span>`. So ALL typography must come from the PARENT element.
+ *     That is not a workaround; it is the only way to style this component today.
+ *  3. Do not reach for the `.home-text-h2` global to typeset it: that class also carries
+ *     `color: … !important` in globals.css and will hijack whatever colour you set.
+ */
+
+/** The settled frame at hero scale, with the parent supplying size, weight and colour. */
+export const HeroHeadline = () => (
+  <div className="w-full max-w-xl rounded-xl border border-border bg-card px-6 py-6">
+    <h2 className="text-4xl font-bold text-maroon">
+      <TypeWriter text="who made this?" startDelay={0} typingDelay={1} />
+    </h2>
+  </div>
+);
+
+/**
+ * Inline inside body copy, with the parent supplying the brand pink users actually SEE —
+ * `#ff9ce3`, a raw literal that lives in no palette (wordmark, highlight glows). It is
+ * applied by inline style, exactly as the app applies it. A blinking caret is composed
+ * alongside, since the component ships none of its own.
+ */
+export const InlineAccent = () => (
+  <div className="w-full max-w-md rounded-xl border border-border bg-card px-6 py-6">
+    <p className="text-lg text-muted-foreground">
+      Now indexing{" "}
+      <span className="font-bold" style={{ color: "#ff9ce3" }}>
+        <TypeWriter text="Sudan Archives" startDelay={0} typingDelay={1} />
+        <span
+          className="ml-0.5 inline-block h-4 w-0.5 align-middle"
+          style={{ backgroundColor: "#ff9ce3" }}
+        />
+      </span>{" "}
+      across 40+ platforms.
+    </p>
+  </div>
+);

--- a/.design-sync/tailwind.ds.config.ts
+++ b/.design-sync/tailwind.ds.config.ts
@@ -1,0 +1,171 @@
+// Tailwind config used ONLY to compile the design-sync stylesheet (.design-sync/.cache/ds-tailwind.css).
+//
+// Why this exists: the app's tailwind.config.ts JIT-compiles only the classes that appear in src/.
+// The claude.ai/design agent writes NEW markup with utilities the app never happened to use, and a
+// rendered design receives nothing but styles.css — so any class missing from this stylesheet is
+// silently unstyled. We therefore extend the app config with:
+//   1. content globs that also cover the authored preview cards
+//   2. a safelist covering the general Tailwind utility surface + the MusicNerd brand palette
+//
+// Theme, plugins, and brand colors are inherited verbatim from the app config — this file adds
+// coverage, it never redefines design values.
+import type { Config } from "tailwindcss";
+import appConfig from "../tailwind.config";
+
+// Tailwind's default numeric scales, spelled out so safelist regexes stay readable.
+const SPACE = "0|px|0\\.5|1|1\\.5|2|2\\.5|3|3\\.5|4|5|6|7|8|9|10|11|12|14|16|20|24|28|32|36|40|48|56|64|72|80|96";
+const FRACTION = "1/2|1/3|2/3|1/4|3/4|1/5|2/5|3/5|4/5|1/6|5/6|1/12|5/12|7/12|11/12";
+const SIZE = `${SPACE}|${FRACTION}|auto|full|screen|min|max|fit|svh|dvh|lvh`;
+const TEXT = "xs|sm|base|lg|xl|2xl|3xl|4xl|5xl|6xl|7xl|8xl|9xl";
+const WEIGHT = "thin|extralight|light|normal|medium|semibold|bold|extrabold|black";
+const RADIUS = "none|sm|DEFAULT|md|lg|xl|2xl|3xl|full";
+const SHADOW = "sm|DEFAULT|md|lg|xl|2xl|inner|none";
+const SCALE_1_100 = "0|5|10|20|25|30|40|50|60|70|75|80|90|95|100";
+
+// Palette. Deliberately NOT the full 22-hue Tailwind rainbow: DESIGN.md's standing rule is
+// "don't introduce a fourth pink or a new blue", so we ship the brand trio, the shadcn semantic
+// tokens, the neutrals, and only the accent hues the app actually reaches for (counted from src/).
+// A curated palette both keeps the stylesheet small and steers the design agent on-brand.
+const HUE =
+  "slate|gray|zinc|neutral|red|orange|amber|yellow|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose";
+const SHADE = "50|100|200|300|400|500|600|700|800|900|950";
+const BRAND = "maroon|pastyblue|pastypink|jellygreen";
+const SEMANTIC =
+  "border|input|ring|background|foreground|primary|secondary|destructive|muted|accent|popover|card|primary-foreground|secondary-foreground|destructive-foreground|muted-foreground|accent-foreground|popover-foreground|card-foreground";
+const COLOR = `(?:${HUE})-(?:${SHADE})|(?:${BRAND})|(?:${SEMANTIC})|white|black|transparent|current|inherit`;
+// Tailwind slash-opacity (bg-white/70, border-white/40) is the backbone of the .glass language.
+const ALPHA = "(?:/(?:5|10|20|30|40|50|60|70|80|90))?";
+
+/** Interaction + responsive variants worth generating for a given family. */
+const V_STATE = ["hover", "focus", "focus-visible", "active", "disabled", "group-hover"];
+const V_RESPONSIVE = ["sm", "md", "lg", "xl"];
+const V_THEME = ["dark"];
+const V_ALL = [...V_STATE, ...V_RESPONSIVE, ...V_THEME];
+// Colors are the combinatorial hot spot (palette x alpha x variant). Responsive color variants are
+// vanishingly rare in real markup, so colors get state+theme variants only — this is what keeps the
+// stylesheet at a couple of MB instead of ~30.
+const V_COLOR = ["hover", "focus", "dark", "group-hover"];
+
+const safelist: Config["safelist"] = [
+  // ---- Brand identity arbitrary values ----
+  // Tailwind only emits an arbitrary value it literally finds in scanned source. The pink users
+  // actually SEE — #ff9ce3, the wordmark/glow pink — is applied via inline style in the app, so
+  // `text-[#ff9ce3]` was never generated and would have been silently dead for anyone writing new
+  // markup. These are listed literally (patterns cannot match arbitrary values).
+  "text-[#ff9ce3]",
+  "bg-[#ff9ce3]",
+  "border-[#ff9ce3]",
+  "shadow-[0_0_40px_rgba(255,156,227,0.25)]",
+  "shadow-[0_0_20px_rgba(255,156,227,0.3)]",
+  // The signature "pink-glow lift" hover (and its blue listen-platform variant).
+  "group-hover:shadow-[0_0_15px_rgba(239,149,255,0.45)]",
+  "group-hover:shadow-[0_0_15px_rgba(0,199,242,0.45)]",
+  "hover:shadow-[0_0_25px_rgba(239,149,255,0.5)]",
+  "hover:shadow-[0_0_30px_rgba(239,149,255,0.35)]",
+  // The hero's pink→violet wash. `#7c3aed` (violet-600) is the app's gradient partner for pink.
+  "from-[#ef95ff]",
+  "to-[#7c3aed]",
+  "via-[#7c3aed]",
+  "from-[#ff9ce3]",
+
+  // ---- Layout ----
+  // basis-* is what carousel/flex slides size on — its absence collapsed every Carousel slide.
+  { pattern: /^basis-(0|1|2|3|4|5|6|8|10|12|auto|full|1\/2|1\/3|2\/3|1\/4|3\/4|1\/5|1\/6)$/, variants: V_RESPONSIVE },
+  { pattern: /^table-(auto|fixed)$/ },
+  { pattern: /^(flex-)?(nowrap|wrap)$/ },
+  { pattern: /^(block|inline-block|inline|flex|inline-flex|grid|inline-grid|hidden|contents|table)$/, variants: V_RESPONSIVE },
+  { pattern: /^flex-(row|row-reverse|col|col-reverse|wrap|nowrap|wrap-reverse|1|auto|initial|none)$/, variants: V_RESPONSIVE },
+  { pattern: /^(grow|shrink)(-0)?$/, variants: V_RESPONSIVE },
+  { pattern: /^items-(start|end|center|baseline|stretch)$/, variants: V_RESPONSIVE },
+  { pattern: /^justify-(start|end|center|between|around|evenly)$/, variants: V_RESPONSIVE },
+  { pattern: /^self-(auto|start|end|center|stretch)$/, variants: V_RESPONSIVE },
+  { pattern: /^content-(start|end|center|between|around|evenly)$/, variants: V_RESPONSIVE },
+  { pattern: /^grid-cols-(1|2|3|4|5|6|7|8|9|10|11|12|none)$/, variants: V_RESPONSIVE },
+  { pattern: /^grid-rows-(1|2|3|4|5|6|none)$/, variants: V_RESPONSIVE },
+  { pattern: /^col-span-(1|2|3|4|5|6|7|8|9|10|11|12|full)$/, variants: V_RESPONSIVE },
+  { pattern: /^row-span-(1|2|3|4|5|6|full)$/, variants: V_RESPONSIVE },
+  { pattern: /^order-(1|2|3|4|5|6|first|last|none)$/, variants: V_RESPONSIVE },
+
+  // ---- Spacing ----
+  { pattern: new RegExp(`^-?(p|px|py|pt|pr|pb|pl)-(${SPACE})$`), variants: V_RESPONSIVE },
+  { pattern: new RegExp(`^-?(m|mx|my|mt|mr|mb|ml)-(${SPACE}|auto)$`), variants: V_RESPONSIVE },
+  { pattern: new RegExp(`^(gap|gap-x|gap-y)-(${SPACE})$`), variants: V_RESPONSIVE },
+  { pattern: new RegExp(`^-?(space-x|space-y)-(${SPACE})$`), variants: V_RESPONSIVE },
+
+  // ---- Sizing ----
+  { pattern: new RegExp(`^w-(${SIZE})$`), variants: V_RESPONSIVE },
+  { pattern: new RegExp(`^h-(${SIZE})$`), variants: V_RESPONSIVE },
+  { pattern: new RegExp(`^(min-w|min-h)-(0|full|screen|min|max|fit)$`), variants: V_RESPONSIVE },
+  { pattern: /^max-w-(0|none|xs|sm|md|lg|xl|2xl|3xl|4xl|5xl|6xl|7xl|full|min|max|fit|prose|screen-sm|screen-md|screen-lg|screen-xl|screen-2xl)$/, variants: V_RESPONSIVE },
+  { pattern: /^max-h-(none|full|screen|min|max|fit)$/, variants: V_RESPONSIVE },
+  { pattern: /^aspect-(auto|square|video)$/, variants: V_RESPONSIVE },
+
+  // ---- Typography ----
+  { pattern: new RegExp(`^text-(${TEXT})$`), variants: V_RESPONSIVE },
+  { pattern: new RegExp(`^font-(${WEIGHT})$`), variants: V_RESPONSIVE },
+  { pattern: /^font-(sans|serif|mono)$/ },
+  { pattern: /^leading-(none|tight|snug|normal|relaxed|loose|3|4|5|6|7|8|9|10)$/, variants: V_RESPONSIVE },
+  { pattern: /^tracking-(tighter|tight|normal|wide|wider|widest)$/, variants: V_RESPONSIVE },
+  { pattern: /^text-(left|center|right|justify)$/, variants: V_RESPONSIVE },
+  { pattern: /^(uppercase|lowercase|capitalize|normal-case|truncate|italic|not-italic|underline|line-through|no-underline)$/, variants: V_ALL },
+  { pattern: /^line-clamp-(1|2|3|4|5|6|none)$/, variants: V_RESPONSIVE },
+  { pattern: /^(whitespace|break)-(normal|nowrap|pre|pre-line|pre-wrap|words|all)$/, variants: V_RESPONSIVE },
+  { pattern: /^align-(baseline|top|middle|bottom)$/ },
+
+  // ---- Color (text / bg / border / ring / divide / gradient stops) ----
+  { pattern: new RegExp(`^text-(${COLOR})$`), variants: V_COLOR },
+  { pattern: new RegExp(`^bg-(${COLOR})${ALPHA}$`), variants: V_COLOR },
+  { pattern: new RegExp(`^border-(${COLOR})${ALPHA}$`), variants: V_COLOR },
+  { pattern: new RegExp(`^ring-(${COLOR})$`), variants: ["focus", "focus-visible", "dark"] },
+  { pattern: new RegExp(`^divide-(${COLOR})$`), variants: V_THEME },
+  { pattern: new RegExp(`^(from|via|to)-(${COLOR})${ALPHA}$`), variants: V_THEME },
+  { pattern: /^bg-gradient-to-(t|tr|r|br|b|bl|l|tl)$/, variants: V_THEME },
+
+  // ---- Borders & radius ----
+  { pattern: /^border(-(0|2|4|8))?$/, variants: V_ALL },
+  { pattern: /^border-(x|y|t|r|b|l)(-(0|2|4|8))?$/, variants: V_RESPONSIVE },
+  { pattern: /^border-(solid|dashed|dotted|double|none)$/ },
+  { pattern: new RegExp(`^rounded(-(${RADIUS}))?$`), variants: V_RESPONSIVE },
+  { pattern: new RegExp(`^rounded-(t|r|b|l|tl|tr|br|bl)(-(${RADIUS}))?$`), variants: V_RESPONSIVE },
+  { pattern: /^divide-(x|y)(-(0|2|4|8))?$/ },
+
+  // ---- Effects ----
+  { pattern: new RegExp(`^shadow(-(${SHADOW}))?$`), variants: V_ALL },
+  { pattern: new RegExp(`^opacity-(${SCALE_1_100})$`), variants: V_ALL },
+  { pattern: /^(backdrop-)?blur(-(none|sm|md|lg|xl|2xl|3xl))?$/, variants: V_THEME },
+  { pattern: /^backdrop-saturate-(0|50|100|150|200)$/ },
+  { pattern: /^(overflow|overflow-x|overflow-y)-(auto|hidden|clip|visible|scroll)$/, variants: V_RESPONSIVE },
+  { pattern: /^ring(-(0|1|2|4|8|inset))?$/, variants: V_ALL },
+  { pattern: /^ring-offset-(0|1|2|4|8)$/, variants: V_ALL },
+  { pattern: /^object-(contain|cover|fill|none|scale-down|center|top|bottom|left|right)$/ },
+
+  // ---- Position ----
+  { pattern: /^(static|fixed|absolute|relative|sticky)$/, variants: V_RESPONSIVE },
+  { pattern: new RegExp(`^-?(inset|inset-x|inset-y|top|right|bottom|left)-(${SPACE}|${FRACTION}|auto|full)$`), variants: V_RESPONSIVE },
+  { pattern: /^z-(0|10|20|30|40|50|auto)$/, variants: V_RESPONSIVE },
+
+  // ---- Transform & motion (the "pink-glow lift" language) ----
+  { pattern: new RegExp(`^scale(-(x|y))?-(${SCALE_1_100}|105|110|125|150)$`), variants: V_ALL },
+  { pattern: /^-?rotate-(0|1|2|3|6|12|45|90|180)$/, variants: V_ALL },
+  { pattern: new RegExp(`^-?(translate-x|translate-y)-(${SPACE}|${FRACTION}|full)$`), variants: V_ALL },
+  { pattern: /^transition(-(none|all|colors|opacity|shadow|transform))?$/, variants: V_ALL },
+  { pattern: /^duration-(0|75|100|150|200|300|500|700|1000)$/ },
+  { pattern: /^ease-(linear|in|out|in-out)$/ },
+  { pattern: /^delay-(0|75|100|150|200|300|500|700|1000)$/ },
+  { pattern: /^animate-(none|spin|ping|pulse|bounce|fadeSlideIn|accordion-down|accordion-up)$/ },
+  { pattern: /^(cursor|select|pointer-events)-(auto|none|pointer|default|text|not-allowed|all)$/, variants: V_STATE },
+  { pattern: /^(origin)-(center|top|bottom|left|right)$/ },
+  { pattern: /^(sr-only|not-sr-only)$/ },
+];
+
+const config = {
+  ...appConfig,
+  content: [
+    "./src/**/*.{ts,tsx}",
+    // authored preview cards — their layout glue must compile too
+    "./.design-sync/previews/**/*.{ts,tsx}",
+  ],
+  safelist,
+} satisfies Config;
+
+export default config;

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,8 @@ wikidata_query.py
 
 # Claude Code runtime lock (machine-specific)
 .claude/scheduled_tasks.lock
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules


### PR DESCRIPTION
Imports MusicNerdWeb's component library into a [Claude Design project](https://claude.ai/design/p/5c842a8e-3d59-454b-8153-4249ee34a66f) so the design agent builds screens with **our real components**, not generic shadcn.

**No app source is touched.** Everything lives under `.design-sync/`, which is invisible to CI (TypeScript's wildcard includes skip dot-directories). Full CI is green: type-check, lint, 1082 tests, build.

## What shipped

- **28 components** in 7 groups (actions, forms, layout, navigation, overlays, content, brand)
- **74 preview cells, all authored and verified — zero floor cards**
- `package-validate` exits clean: 28/28 render, 0 blank, 0 grid-overflow
- 109 working exports on `window.MusicNerd` (sub-parts like `CardHeader`/`SelectItem` stay importable)
- `DESIGN.md` ships as the design guideline; `conventions.md` is inlined into the design agent's system prompt

## Why this needed a custom setup

This repo is an **app**, not a published component library — no `dist/`, no `.d.ts` tree. So:

- **`ds-entry.ts` is the library boundary.** Hand-written and committed. A synthesized entry would `export * from` every source file and pull Drizzle/postgres/next-auth into a browser bundle.
- **Tailwind is compiled before the converter runs.** A rendered design receives only `styles.css` — there is no Tailwind JIT at the other end — so any class the agent writes that isn't in the sheet is silently dead. The stylesheet therefore carries a safelisted utility surface. The palette is curated to the brand trio + shadcn semantic tokens + the ~20 hues the app actually uses: that keeps it at ~7MB (464KB gzipped) instead of 29MB, *and* steers generated designs on-brand (DESIGN.md: "don't introduce a fourth pink or a new blue").
- **Two forked lib adapters** (`overrides/`), both because the upstream converter assumes `pkgDir == node_modules/<pkg>` — false for an app repo:
  - `dts.mjs` — extracts props from the `.tsx` sources. Without it every contract was `{ [key: string]: unknown }` and the design agent would never learn `Button` has `variant`/`size`. Also drops Next's vendored satori `tw?: string` JSX augmentation, which is documented as *"Specify styles using Tailwind CSS classes"* and would have invited the agent to write `tw=` instead of `className=`.
  - `source-kit.mjs` — App Router's `_components` private-folder prefix defeated the group heuristic.

## Deliberate exclusions

- **`HomePageSplash`** — mounts `ActivityFeed` → `next/link`, whose module scope reads `process.env.__NEXT_*` globals that only exist under the Next compiler. In a plain browser bundle that's a hard `ReferenceError` at IIFE init, which took down **all 28 components**. It also fetches `/api/activity`, unservable in a design runtime. The wordmark ships as a copyable recipe in `conventions.md` instead.
- **KoHo** — declared in `globals.css` (`.koho-*`, `.pink-btn`) but loaded nowhere in the app, so it silently falls back to system sans in production today (DESIGN.md #7). Not shipping it keeps the DS faithful to the live site.
- Server/DB-bound components (`ArtistLinks`, `ArtistLinksGrid`, `ActivityFeed`, `nav/*`) can't render in a design runtime. `ArtistLinksGrid`'s glass-tile look is captured as a documented pattern instead.

## Two real app bugs this surfaced (not fixed here)

1. **`Checkbox` indeterminate is broken.** The Indicator renders for both `checked` and `indeterminate`, but the fill is gated on `data-[state=checked]` only — so indeterminate paints a checkmark on an *unfilled* square. Stock shadcn shows a dash. The admin select-all header hits this on every partial page selection.
2. **`[data-state="checked"] { background: #ff9ce3 !important }` is unscoped.** It isn't limited to Checkbox — it also hits the selected `SelectItem` and `DropdownMenuCheckboxItem`, which both go brand pink. Possibly intentional, but it's global.

🤖 Generated with [Claude Code](https://claude.com/claude-code)