### PR TITLE
release: promote staging to main

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,171 @@
+# design-sync notes — MusicNerdWeb
+
+Repo-specific gotchas for future syncs. Read this before re-running the converter.
+
+## The big one: this is an app, not a component library
+
+There is no `dist/`, no published package, no `.d.ts` tree. Three consequences drive most of the
+config:
+
+- **`.design-sync/ds-entry.ts` IS the library boundary.** It is hand-written and committed, and the
+  converter runs with `--entry ./.design-sync/ds-entry.ts`. Do NOT let the converter synthesize an
+  entry from `src/` — a synth entry does `export * from` every source file, which drags the async
+  server components (`ArtistLinks`, `ArtistLinksGrid`) and through them Drizzle/postgres/next-auth
+  into a browser bundle.
+- **`componentSrcMap` IS the component list**, not a set of tweaks to a discovered one. Anything you
+  add to `ds-entry.ts` must also be added there or it ships in the bundle without getting a card.
+- **Never `ln -s` the repo into `node_modules/musicnerdweb`.** It looks like the obvious way to make
+  the converter's `PKG_DIR` resolve, but it creates a symlink cycle
+  (`node_modules/musicnerdweb/node_modules/musicnerdweb/…`) that OOM'd the v8 heap during the
+  ts-morph glob. `--entry` is what makes `PKG_DIR` resolve; no symlink needed.
+
+## Tailwind must be COMPILED before the converter runs
+
+`src/app/globals.css` is raw `@tailwind` directives. Pointing `cssEntry` at it ships a stylesheet
+with no utilities in it and every component renders unstyled. `cfg.buildCmd` compiles
+`.design-sync/tailwind.ds.config.ts` → `.design-sync/.cache/ds-tailwind.css` first. **Re-run
+`buildCmd` before every converter run.**
+
+`tailwind.ds.config.ts` extends the app's real config (never redefines design values) and adds:
+1. content globs covering `.design-sync/previews/**` so authored-preview classes compile;
+2. a **safelist** of the general utility surface.
+
+The safelist is not optional. A rendered design receives only `styles.css` — there is no Tailwind
+JIT at the other end — so any class the design agent writes that isn't already in the sheet is
+silently dead. Curating the palette (brand + shadcn semantic + the ~20 hues the app actually uses,
+rather than all 22 Tailwind hues) is what keeps this at ~7MB / 464KB gzipped instead of 29MB.
+If you widen the safelist, re-check the size.
+
+## Two forked lib adapters (`.design-sync/overrides/`)
+
+Both exist because the upstream converter assumes `pkgDir == node_modules/<pkg>`, which is false here.
+
+- **`dts.mjs`** — props are extracted from the `.tsx` SOURCES, not a `.d.ts` tree. Without it every
+  contract was `{ [key: string]: unknown }` (the agent would never learn `Button` has `variant`).
+  Also bounds the ts-morph glob to `src/` (the repo-root glob walked `.next/`, 2.4GB, and OOM'd) and
+  drops props declared in `next/dist/compiled/` — Next's vendored satori injects a global
+  `tw?: string` JSX prop into every element, documented as "Specify styles using Tailwind CSS
+  classes", which would invite the agent to write `tw=` instead of `className=`. The node_modules
+  filter is deliberately scoped to that one path: Radix declares real API under node_modules
+  (`Dialog.open`, `Checkbox.checked`) and must survive.
+- **`source-kit.mjs`** — Next's App Router `_components` private-folder prefix and the `app/` router
+  root aren't in the generic-dir set, so brand components were forced into a group literally named
+  "components", which then OUTRANKED the `category:` frontmatter and made the regroup stubs no-ops.
+  Also seeds the component list from `componentSrcMap` (see above).
+
+`.design-sync/node_modules` is a gitignored symlink → `.ds-sync/node_modules`, needed so the forks
+can resolve their bare `ts-morph` import. **Recreate it on a fresh clone:**
+`ln -sfn ../.ds-sync/node_modules .design-sync/node_modules`
+
+## Component-set decisions
+
+- **`HomePageSplash` is deliberately NOT synced.** It mounts `ActivityFeed`, which imports
+  `next/link`, whose module scope reads `process.env.__NEXT_*` — Next-compiler-substituted globals
+  that don't exist in a plain browser bundle. That was a hard `ReferenceError: process is not
+  defined` at IIFE init which took down **all 28 components**, not just this one. ActivityFeed also
+  fetches `/api/activity`, which no design runtime can serve. The wordmark is documented as a
+  copyable recipe in `conventions.md` instead. **If you ever re-add it, check for `process.env` in
+  `_ds_bundle.js` — a single Next import re-breaks the whole bundle.**
+- **Sub-parts get no cards.** `ds-entry.ts` exports ~109 symbols; only 28 get cards. `CardHeader`,
+  `DialogFooter`, `SelectItem` etc. all still ship and are importable — they just don't each get a
+  duplicate preview and a near-empty contract. Each compound's authored preview demonstrates its
+  sub-parts in a real composition instead.
+- Excluded as unrenderable (DB/session/fetch-bound): `ArtistLinks`, `ArtistLinksGrid`,
+  `EditablePlatformLink`, `EditableLinkIcon`, `ActivityFeed`, `Providers`, `PrivyProviderWrapper`,
+  `nav/*`. `ArtistLinksGrid`'s glass-tile look is brand-defining, so it's captured as a documented
+  pattern in `conventions.md` rather than shipped as a component that can't render.
+
+## Authoring previews — what was learned the hard way
+
+- Import from `"musicnerdweb"` (shimmed to `window.MusicNerd`). `@/` aliases resolve too.
+- **Overlays portal to `document.body` and are viewport-`fixed`** (Dialog, Drawer, DropdownMenu,
+  Popover, Tooltip, Select, Toast). They escape their cell and get clipped. Fix with
+  `cfg.overrides.<Name> = {cardMode:"single", primaryStory:"…", viewport:"WxH"}`.
+  **Do NOT pass `className="relative"` to fight it** — `cn()` is tailwind-merge, so `relative`
+  *replaces* `fixed`, and the `-translate-50%` then yanks the content off the top edge. It renders
+  worse, not better. Pass `open` (and `modal={false}` to avoid inert/scroll-lock).
+- **`.glass` is invisible on white.** It's `rgba(255,255,255,0.55)` + a white border. It only reads
+  over color. Any preview showing a glass surface needs a saturated backdrop — the app always has
+  one (hero gradient, artist photography).
+- **`Input` ships with no border, no height, and no focus ring** (DESIGN.md #10 — it's stripped
+  bare). A bare `<Input/>` renders as an invisible blank and trips `[RENDER_BLANK]`. Form previews
+  must add `h-10 rounded-md border border-input px-3 py-2` — which is what every real form in the
+  app does. Same story for `Textarea`'s missing ring width (#11).
+- Use MusicNerd-real content (artists, platforms, contributors, MCP keys) — never foo/bar.
+
+## Findings from the preview-authoring wave
+
+Two claims came back from the parallel agents that were WRONG. Both are recorded here because they
+are exactly the mistakes a future run would repeat.
+
+- **"`bg-primary` is brand pink."** It is NOT. `--primary` is stock slate navy
+  (`222.2 47.4% 11.2%`) and the default Button renders navy. What the agent actually saw was
+  `globals.css:485` — an **unscoped** `[data-state="checked"] { background-color: #ff9ce3
+  !important }`. That selector isn't limited to Checkbox: it hits ANY Radix element in the checked
+  state, so a selected `SelectItem` and a checked `DropdownMenuCheckboxItem` also go pink. It is the
+  one place brand color reaches the primitives without a call-site class.
+- **"`text-[#ff9ce3]` renders black / arbitrary utilities don't apply."** They DO. Verified by
+  computed style in headless chromium: `text-[#ff9ce3]` → `rgb(255, 156, 227)`. The agent observed
+  truthfully but the cause was a moving stylesheet — the orchestrator recompiled and swapped
+  `_ds_bundle.css` **mid-wave**, so early captures ran against a sheet that genuinely lacked the
+  class. **Lesson: never swap the shared stylesheet while agents are capturing.** Recompile before
+  dispatch, or after the wave — never during.
+
+Real findings worth keeping:
+
+- **`.home-text-h2` is a colour trap, not a type class.** It looks like pure fluid-type
+  (font-size/letter-spacing clamps) but `globals.css:186-260` also pins `color: … !important`
+  (`:first-child` → `#ff9ce3`, otherwise → `#9b83a0`), silently overriding any `text-*` utility on
+  it. Don't use it for hero markup.
+- **`TableCell`'s truncation is conditional.** `whitespace-nowrap overflow-hidden text-ellipsis` on
+  a `<td>` does nothing under the default `table-layout: auto` (the wrapper scrolls instead). It
+  only ellipsizes under `table-fixed`, which `UserEntriesTable` never sets.
+- **`Checkbox` indeterminate is genuinely broken.** The Indicator renders for both `checked` and
+  `indeterminate`, but the fill is gated on `data-[state=checked]` only — so indeterminate paints a
+  checkmark on an *unfilled* square. Stock shadcn shows a dash. The admin select-all header hits
+  this on every partial page selection. A real fix candidate in the app.
+- **`LoadingPage` is `fixed inset-0 z-[9999]`** — it blankets anything it's dropped into unless an
+  ancestor establishes a containing block (an inline `transform` does it).
+- **The capture server can't serve SVG.** `.ds-sync/storybook/http-serve.mjs`'s MIME table has no
+  `.svg`, and it doesn't serve Next's `public/`. `previews/LoadingPage.tsx` inlines the real
+  `public/spinner.svg` as a data URI to work around it (the shipped asset, not a substitute).
+- **The safelist had real gaps** the app's own source never exercised: `basis-*` (Carousel slides
+  collapsed without it), `table-fixed`, and arbitrary gradient stops. Added. Expect more gaps in
+  this shape — the design agent writes classes the app never did.
+- `react-hook-form` resolves inside previews, and hooks run during capture — so validation error
+  states can be injected with `form.setError` in a `useEffect` (no submit needed).
+- A preview cell whose only axis is a sub-30% opacity delta will not read on a downscaled review
+  sheet. Pair it with a full-strength baseline.
+
+## Known render warns (expected — not new findings)
+
+Check new warns against this list; anything not here is genuinely new.
+
+- `[FONT_MISSING] "KoHo"` — **expected, and correct.** KoHo is declared in `globals.css`
+  (`.koho-extralight`, `.koho-light`, `.pink-btn`) but is loaded NOWHERE in the app: no `next/font`,
+  no `<link>`, no `@font-face`. It silently falls back to system sans in production today (DESIGN.md
+  headline typography finding; design-debt #7 is still open). **The user explicitly chose to match
+  production and NOT ship KoHo** — shipping it would make every design render in a typeface the real
+  site doesn't have. The warn is a truthful signal; leave it firing.
+- `[FONT_MISSING] "Cambria"` — false alarm. It's just a member of Tailwind's default `font-serif`
+  fallback stack (`ui-serif, Georgia, Cambria, …`). No `@font-face` is wanted.
+- `[TOKENS_MISSING]` (9 vars) — all set at runtime, never by a stylesheet:
+  `--radix-accordion-content-height` (Radix measures it), `--tw-shadow-color` (Tailwind internal),
+  `--scrollbar-*` (the `tailwind-scrollbar` plugin emits them per-utility).
+- `[RENDER_BLANK]` on a bare `Input`/`Textarea`/`Checkbox` floor card — a true statement about a
+  borderless primitive, resolved by authoring the preview (see above).
+
+## Re-sync risks
+
+- **`buildCmd` (the Tailwind compile) is a hard prerequisite.** Skip it and `cssEntry` points at a
+  stale or missing file. The driver does not know to run it for you.
+- **The safelist can silently rot.** It's a hand-maintained approximation of "what the design agent
+  might write". If the app adopts a new hue or a plugin, add it — a missing class doesn't error, it
+  just renders unstyled.
+- **The two lib forks are pinned to upstream internals** (`projectFor`, `isOwnProp`, the group
+  derivation, the component-list seed). On re-sync, diff them against `.ds-sync/lib/*.mjs` and merge
+  upstream changes; if the converter's shape changed, the forks may need rework rather than a merge.
+- **`.next/` size is load-bearing for build time.** The dts fork bounds its glob to `src/`, so a big
+  `.next/` is fine now — but any change that re-widens a glob to the repo root will OOM again.
+- `HomePageSplash`/`ActivityFeed` are the tripwire for Next imports leaking into the bundle. Grep
+  `_ds_bundle.js` for `process.env` after any change to `ds-entry.ts`.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,146 @@
+{
+  "projectId": "5c842a8e-3d59-454b-8153-4249ee34a66f",
+  "shape": "package",
+  "pkg": "musicnerdweb",
+  "globalName": "MusicNerd",
+  "srcDir": "src",
+  "tsconfig": "tsconfig.json",
+  "buildCmd": "npx tailwindcss -c .design-sync/tailwind.ds.config.ts -i src/app/globals.css -o .design-sync/.cache/ds-tailwind.css",
+  "cssEntry": ".design-sync/.cache/ds-tailwind.css",
+  "libOverrides": {
+    "dts.mjs": "app repo has no shipped .d.ts tree \u2014 extract props from the .tsx sources (and bound the glob to src/, since the repo-root scan OOM'd on .next/)",
+    "source-kit.mjs": "Next.js App Router `_components` private-folder prefix defeated the generic-dir test, forcing a group named \"components\" that outranked the category frontmatter"
+  },
+  "provider": {
+    "component": "ThemeProvider",
+    "inner": {
+      "component": "EditModeProvider",
+      "props": {
+        "canEdit": true
+      }
+    }
+  },
+  "componentSrcMap": {
+    "AspectRatio": "src/components/ui/aspect-ratio.tsx",
+    "Badge": "src/components/ui/badge.tsx",
+    "Button": "src/components/ui/button.tsx",
+    "Calendar": "src/components/ui/calendar.tsx",
+    "Card": "src/components/ui/card.tsx",
+    "Carousel": "src/components/ui/carousel.tsx",
+    "Checkbox": "src/components/ui/checkbox.tsx",
+    "Dialog": "src/components/ui/dialog.tsx",
+    "Drawer": "src/components/ui/drawer.tsx",
+    "DropdownMenu": "src/components/ui/dropdown-menu.tsx",
+    "Form": "src/components/ui/form.tsx",
+    "Input": "src/components/ui/input.tsx",
+    "Label": "src/components/ui/label.tsx",
+    "Popover": "src/components/ui/popover.tsx",
+    "Select": "src/components/ui/select.tsx",
+    "Table": "src/components/ui/table.tsx",
+    "Tabs": "src/components/ui/tabs.tsx",
+    "Textarea": "src/components/ui/textarea.tsx",
+    "Toast": "src/components/ui/toast.tsx",
+    "Tooltip": "src/components/ui/tooltip.tsx",
+    "BookmarkButton": "src/app/_components/BookmarkButton.tsx",
+    "EditModeToggle": "src/app/_components/EditModeToggle.tsx",
+    "Footer": "src/app/_components/Footer.tsx",
+    "LoadingPage": "src/app/_components/LoadingPage.tsx",
+    "PleaseLoginPage": "src/app/_components/PleaseLoginPage.tsx",
+    "SlidingText": "src/app/_components/SlidingText.tsx",
+    "ThemeToggle": "src/app/_components/ThemeToggle.tsx",
+    "TypeWriter": "src/app/_components/TypeWriter.tsx"
+  },
+  "guidelinesGlob": [
+    "DESIGN.md"
+  ],
+  "docsMap": {
+    "AspectRatio": ".design-sync/groups/AspectRatio.md",
+    "Badge": ".design-sync/groups/Badge.md",
+    "BookmarkButton": ".design-sync/groups/BookmarkButton.md",
+    "Button": ".design-sync/groups/Button.md",
+    "Calendar": ".design-sync/groups/Calendar.md",
+    "Card": ".design-sync/groups/Card.md",
+    "Carousel": ".design-sync/groups/Carousel.md",
+    "Checkbox": ".design-sync/groups/Checkbox.md",
+    "Dialog": ".design-sync/groups/Dialog.md",
+    "Drawer": ".design-sync/groups/Drawer.md",
+    "DropdownMenu": ".design-sync/groups/DropdownMenu.md",
+    "EditModeToggle": ".design-sync/groups/EditModeToggle.md",
+    "Footer": ".design-sync/groups/Footer.md",
+    "Form": ".design-sync/groups/Form.md",
+    "Input": ".design-sync/groups/Input.md",
+    "Label": ".design-sync/groups/Label.md",
+    "LoadingPage": ".design-sync/groups/LoadingPage.md",
+    "PleaseLoginPage": ".design-sync/groups/PleaseLoginPage.md",
+    "Popover": ".design-sync/groups/Popover.md",
+    "Select": ".design-sync/groups/Select.md",
+    "SlidingText": ".design-sync/groups/SlidingText.md",
+    "Table": ".design-sync/groups/Table.md",
+    "Tabs": ".design-sync/groups/Tabs.md",
+    "Textarea": ".design-sync/groups/Textarea.md",
+    "ThemeToggle": ".design-sync/groups/ThemeToggle.md",
+    "Toast": ".design-sync/groups/Toast.md",
+    "Tooltip": ".design-sync/groups/Tooltip.md",
+    "TypeWriter": ".design-sync/groups/TypeWriter.md"
+  },
+  "overrides": {
+    "Dialog": {
+      "cardMode": "single",
+      "primaryStory": "Open",
+      "viewport": "680x460"
+    },
+    "Drawer": {
+      "cardMode": "single",
+      "primaryStory": "Open",
+      "viewport": "680x540"
+    },
+    "DropdownMenu": {
+      "cardMode": "single",
+      "primaryStory": "Open",
+      "viewport": "560x440"
+    },
+    "Popover": {
+      "cardMode": "single",
+      "primaryStory": "Open",
+      "viewport": "560x400"
+    },
+    "Tooltip": {
+      "cardMode": "single",
+      "primaryStory": "Open",
+      "viewport": "480x280"
+    },
+    "Select": {
+      "cardMode": "single",
+      "primaryStory": "Open",
+      "viewport": "560x440"
+    },
+    "Toast": {
+      "cardMode": "single",
+      "primaryStory": "Default",
+      "viewport": "640x340"
+    },
+    "Table": {
+      "cardMode": "column"
+    },
+    "Calendar": {
+      "cardMode": "column"
+    },
+    "EditModeToggle": {
+      "cardMode": "column"
+    },
+    "Carousel": {
+      "cardMode": "column"
+    },
+    "AspectRatio": {
+      "cardMode": "column"
+    },
+    "Tabs": {
+      "cardMode": "column"
+    },
+    "LoadingPage": {
+      "cardMode": "single",
+      "primaryStory": "Default"
+    }
+  },
+  "readmeHeader": ".design-sync/conventions.md"
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,130 @@
+# Building with the MusicNerd design system
+
+MusicNerd is a **playful, indie, candy-neon music directory dressed in Apple-style frosted glass.**
+Neon accents on quiet chrome; glass surfaces; round everything; calm ambient motion; a lowercase,
+friendly voice. When in doubt, the `music nerd` wordmark and the `.glass` panel are the templates.
+
+## Setup: wrap the tree in ThemeProvider
+
+`ThemeProvider` owns the light/dark class on the root and is what `ThemeToggle` reads through
+`useTheme()`. Without it, `ThemeToggle` throws. `EditModeProvider` gates the artist-page edit
+affordances (`EditModeToggle` renders inert unless `canEdit` is true).
+
+```jsx
+<ThemeProvider>
+  <EditModeProvider canEdit={false}>
+    <YourScreen />
+  </EditModeProvider>
+</ThemeProvider>
+```
+
+Dark mode is **class-based** (`.dark` on `<html>`), driven by this custom provider — *not*
+`next-themes`. Don't reach for `next-themes` APIs.
+
+## The styling idiom: Tailwind utilities
+
+Everything is styled with **Tailwind utility classes** — there are no CSS modules and no style props.
+Compose layout with utilities; use components for the controls.
+
+**Brand palette** (real Tailwind classes — `bg-`, `text-`, `border-`):
+
+| Class | Value | Use |
+|---|---|---|
+| `pastypink` | `#ef95ff` | the brand token — accents, borders, glows |
+| `pastyblue` | `#2ad4fc` | cyan accent; takes over from pink in dark mode |
+| `jellygreen` | `#19ffb8` | mint accent (live/success) |
+| `maroon` | `#422b46` | deep-aubergine ink for body/footer text |
+
+**Semantic tokens** (shadcn slate, consumed as `bg-*`/`text-*`): `background`, `foreground`, `card`,
+`popover`, `primary`, `secondary`, `muted`, `accent`, `destructive`, `border`, `input`, `ring`, each
+with a `-foreground` counterpart. Radius derives from `--radius` (8px): `rounded-lg` 8, `rounded-md`
+6, `rounded-sm` 4.
+
+⚠️ **The semantic layer is stock shadcn slate and carries NO brand color.** `bg-primary` is navy,
+not pink. To put brand color on a component, add a brand class at the call site — never fork the
+primitive. This is exactly what the real app does:
+
+```jsx
+<Button variant="outline" size="sm"
+  className="border-pastypink/50 text-pastypink hover:bg-pastypink hover:text-white">
+  Edit mode
+</Button>
+```
+
+**The pink users actually see is `#ff9ce3`** — the wordmark, highlight glows, focus rings. It is in
+no palette. `text-[#ff9ce3]`, `bg-[#ff9ce3]` and `border-[#ff9ce3]` are available. Three pinks exist
+(`#ef95ff`, `#ff9ce3`, `#EDADF8`); prefer `pastypink` for chrome and `#ff9ce3` for the identity
+glow. **Do not invent a fourth pink or a new blue.**
+
+**One exception, and it is a global one:** `globals.css` ships an *unscoped* `!important` rule —
+`[data-state="checked"] { background-color: #ff9ce3 }` (cyan `#2ad4fc` in dark). It matches **any**
+Radix element in the checked state, so a checked `Checkbox`, the selected `SelectItem`, and a
+checked `DropdownMenuCheckboxItem` all pick up brand pink automatically. That is the one place brand
+color reaches the primitives without a call-site class. Don't fight it, and don't try to restyle a
+checked state with a utility — `!important` will win.
+
+⚠️ **This stylesheet is pre-compiled — there is no Tailwind JIT at render time.** The standard
+utility scale is fully available (spacing, sizing, color, type, flex/grid, radius, shadow, opacity,
+transitions, and the `sm:`/`md:`/`lg:`/`hover:`/`focus:`/`dark:`/`group-hover:` variants). But an
+**arbitrary value you invent** (`p-[13px]`, `bg-[#123456]`) will silently not resolve unless it
+already appears above or in the app's source. For a genuine one-off, use an inline `style` — which
+is what the app itself does for the wordmark.
+
+## Glass is the surface language
+
+`.glass` and `.glass-subtle` are global utility classes — the primary panel surface, used in
+preference to `Card` for page sections.
+
+```jsx
+<section className="glass space-y-3 p-4 sm:p-5">…</section>
+```
+
+`.glass` = `rgba(255,255,255,0.55)` + `backdrop-filter: blur(20px) saturate(180%)` + 16px radius.
+**It is invisible on a white background** — it only reads over color, so give it a backdrop
+(a gradient wash, artwork, a photo). `.glass-subtle` is the lighter 12px-radius variant.
+
+## Signature patterns worth copying
+
+**The wordmark** — the single most recognizable element. Lowercase, fluid-clamped, pink glow (not a
+gradient):
+
+```jsx
+<h1 className="lowercase font-bold" style={{
+  fontSize: 'clamp(32px, calc(32px + 52 * ((100vw - 360px) / 1080)), 84px)',
+  letterSpacing: 'clamp(-1px, calc(-1px + -3 * ((100vw - 360px) / 1080)), -4px)',
+  lineHeight: 1, color: '#ff9ce3',
+  textShadow: '0 0 40px rgba(255, 156, 227, 0.25)',
+}}>music nerd</h1>
+```
+
+**The pink-glow lift** — the signature hover, on circular link tiles and cards:
+`transition-all duration-300 group-hover:scale-110 group-hover:shadow-[0_0_15px_rgba(239,149,255,0.45)]`.
+Listen-platform tiles swap the glow to blue (`rgba(0,199,242,0.45)`).
+
+**Glass icon tiles** (the artist-page link grid — a component you won't find in this library, so
+build it from utilities):
+`w-12 h-12 rounded-full backdrop-blur-sm bg-white/70 dark:bg-white/10 border border-white/40`.
+
+**Page shell** — a centered column; there is no container primitive:
+`w-full max-w-[800px] mx-auto px-4 py-5 space-y-6`. Sections stack on `space-y-6`, content inside a
+panel on `space-y-3`, inline clusters on `gap-2`. `duration-300` is the de-facto motion standard.
+
+## Traps
+
+- **`Input` ships with no border, no height, and no focus ring.** A bare `<Input/>` is an invisible
+  blank. Always add chrome: `<Input className="h-10 rounded-md border border-input px-3 py-2" />`.
+  `Textarea` is likewise missing its focus-ring width.
+- **The `default` Button variant has no hover state** (stock `hover:bg-primary/90` was removed).
+- **KoHo is not a usable font.** `globals.css` declares `.koho-extralight`, `.koho-light`, and
+  `.pink-btn` in `"KoHo", sans-serif`, but KoHo is loaded nowhere — those classes silently render as
+  system sans. **Assume the app font is the default Tailwind sans stack.** Don't apply `.koho-*`.
+- Prefer token swaps over `!important` dark-mode patches, and prefer `.glass` panels over opaque,
+  hard-edged flat cards.
+- Avoid ALL-CAPS shouting, corporate copy, and sharp brutalist geometry — they contradict the
+  lowercase, glassy, playful personality.
+
+## Where the truth lives
+
+Read `styles.css` (and the `_ds_bundle.css` it imports) for the real token and utility definitions,
+`guidelines/DESIGN.md` for the full design system of record, and each component's `.prompt.md` +
+`.d.ts` for its actual API.

--- a/.design-sync/ds-entry.ts
+++ b/.design-sync/ds-entry.ts
@@ -1,0 +1,149 @@
+// Design-system entry for design-sync (--entry). MusicNerdWeb is a Next.js app, not a published
+// component library, so there is no dist/ to point the converter at. This file IS the library
+// boundary: it re-exports exactly the components that belong in the design system.
+//
+// Why hand-written rather than letting the converter synthesize an entry from src/: a synthesized
+// entry does `export * from` EVERY source file, which would pull the async server components
+// (ArtistLinks, ArtistLinksGrid) — and through them Drizzle, postgres and next-auth — into a
+// browser bundle. Those cannot render in a design runtime anyway. Enumerating keeps the bundle
+// to real, renderable UI.
+//
+// Anything added here must also be listed in .design-sync/config.json `componentSrcMap` (that map
+// is the component list — there is no .d.ts tree to derive it from).
+
+// ── Primitives: shadcn/ui + Radix (src/components/ui/) ──────────────────────
+export { AspectRatio } from "@/components/ui/aspect-ratio";
+export { Badge, badgeVariants } from "@/components/ui/badge";
+export { Button, buttonVariants } from "@/components/ui/button";
+export { Calendar } from "@/components/ui/calendar";
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+export {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+} from "@/components/ui/carousel";
+export { Checkbox } from "@/components/ui/checkbox";
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+} from "@/components/ui/drawer";
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+} from "@/components/ui/dropdown-menu";
+export {
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+} from "@/components/ui/form";
+export { Input } from "@/components/ui/input";
+export { Label } from "@/components/ui/label";
+export { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+} from "@/components/ui/select";
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+} from "@/components/ui/table";
+export { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+export { Textarea } from "@/components/ui/textarea";
+export {
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+} from "@/components/ui/toast";
+export {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "@/components/ui/tooltip";
+
+// ── Brand components (src/app/_components/) ─────────────────────────────────
+// These carry MusicNerd's identity; DESIGN.md: "brand identity is carried by the custom
+// components + global utilities, not the primitives."
+export { ThemeProvider, useTheme } from "@/app/_components/ThemeProvider";
+export { ThemeToggle } from "@/app/_components/ThemeToggle";
+export { EditModeContext, EditModeProvider } from "@/app/_components/EditModeContext";
+
+export { default as EditModeToggle } from "@/app/_components/EditModeToggle";
+export { default as BookmarkButton } from "@/app/_components/BookmarkButton";
+export { default as Footer } from "@/app/_components/Footer";
+export { default as LoadingPage } from "@/app/_components/LoadingPage";
+export { default as PleaseLoginPage } from "@/app/_components/PleaseLoginPage";
+export { default as SlidingText } from "@/app/_components/SlidingText";
+export { default as TypeWriter } from "@/app/_components/TypeWriter";
+
+// DELIBERATELY NOT EXPORTED: HomePageSplash.
+// It is the whole homepage — the "music nerd" wordmark PLUS ActivityFeed. ActivityFeed imports
+// next/link, whose module scope reads Next-internal `process.env.__NEXT_*` globals that only exist
+// because the Next compiler substitutes them at build time. In a plain browser bundle that is a
+// hard `ReferenceError: process is not defined` at IIFE init, which took down all 29 components,
+// not just this one. ActivityFeed also fetches /api/activity, which no design runtime can serve.
+// Shipping it would drag Next's router internals into every rendered design to display a
+// permanently-empty feed. The wordmark itself is pure inline-styled markup, so it is documented
+// as a copyable recipe in .design-sync/conventions.md instead.

--- a/.design-sync/groups/AspectRatio.md
+++ b/.design-sync/groups/AspectRatio.md
@@ -1,0 +1,3 @@
+---
+category: Layout
+---

--- a/.design-sync/groups/Badge.md
+++ b/.design-sync/groups/Badge.md
@@ -1,0 +1,3 @@
+---
+category: Content
+---

--- a/.design-sync/groups/BookmarkButton.md
+++ b/.design-sync/groups/BookmarkButton.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/.design-sync/groups/Button.md
+++ b/.design-sync/groups/Button.md
@@ -1,0 +1,3 @@
+---
+category: Actions
+---

--- a/.design-sync/groups/Calendar.md
+++ b/.design-sync/groups/Calendar.md
@@ -1,0 +1,3 @@
+---
+category: Content
+---

--- a/.design-sync/groups/Card.md
+++ b/.design-sync/groups/Card.md
@@ -1,0 +1,3 @@
+---
+category: Layout
+---

--- a/.design-sync/groups/Carousel.md
+++ b/.design-sync/groups/Carousel.md
@@ -1,0 +1,3 @@
+---
+category: Content
+---

--- a/.design-sync/groups/Checkbox.md
+++ b/.design-sync/groups/Checkbox.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/.design-sync/groups/Dialog.md
+++ b/.design-sync/groups/Dialog.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/.design-sync/groups/Drawer.md
+++ b/.design-sync/groups/Drawer.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/.design-sync/groups/DropdownMenu.md
+++ b/.design-sync/groups/DropdownMenu.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/.design-sync/groups/EditModeToggle.md
+++ b/.design-sync/groups/EditModeToggle.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/.design-sync/groups/Footer.md
+++ b/.design-sync/groups/Footer.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/.design-sync/groups/Form.md
+++ b/.design-sync/groups/Form.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/.design-sync/groups/Input.md
+++ b/.design-sync/groups/Input.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/.design-sync/groups/Label.md
+++ b/.design-sync/groups/Label.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/.design-sync/groups/LoadingPage.md
+++ b/.design-sync/groups/LoadingPage.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/.design-sync/groups/PleaseLoginPage.md
+++ b/.design-sync/groups/PleaseLoginPage.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/.design-sync/groups/Popover.md
+++ b/.design-sync/groups/Popover.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/.design-sync/groups/Select.md
+++ b/.design-sync/groups/Select.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/.design-sync/groups/SlidingText.md
+++ b/.design-sync/groups/SlidingText.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/.design-sync/groups/Table.md
+++ b/.design-sync/groups/Table.md
@@ -1,0 +1,3 @@
+---
+category: Layout
+---

--- a/.design-sync/groups/Tabs.md
+++ b/.design-sync/groups/Tabs.md
@@ -1,0 +1,3 @@
+---
+category: Navigation
+---

--- a/.design-sync/groups/Textarea.md
+++ b/.design-sync/groups/Textarea.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/.design-sync/groups/ThemeToggle.md
+++ b/.design-sync/groups/ThemeToggle.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/.design-sync/groups/Toast.md
+++ b/.design-sync/groups/Toast.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/.design-sync/groups/Tooltip.md
+++ b/.design-sync/groups/Tooltip.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/.design-sync/groups/TypeWriter.md
+++ b/.design-sync/groups/TypeWriter.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/.design-sync/overrides/dts.mjs
+++ b/.design-sync/overrides/dts.mjs
@@ -1,0 +1,580 @@
+// forked from design-sync lib/dts.mjs — MusicNerdWeb is a Next.js app with no shipped .d.ts tree,
+// so props are extracted from the .tsx sources instead of a declaration tree.
+//
+// The upstream adapter assumes a published package: it globs `<typesRoot>/**/*.d.ts` and reads the
+// export list from `pkgJson.types`. Neither exists here — typesRoot falls back to the repo root
+// (which globbed 2.4GB of .next/ and OOM'd v8), and every <Name>Props came out as
+// `{ [key: string]: unknown }`, which would have taught the design agent nothing about
+// Button's variant/size or any other real API.
+//
+// Only projectFor() is changed. It now:
+//   1. bounds the glob to src/ (no repo-wide .d.ts scan → no OOM)
+//   2. loads the component .tsx SOURCES into the ts-morph project, so propsBodyFor's primary
+//      lookup finds real declarations (e.g. `export interface ButtonProps extends
+//      React.ButtonHTMLAttributes<…>, VariantProps<typeof buttonVariants>`)
+//   3. points `entry` at the real source entry (.design-sync/ds-entry.ts) so the fallback path —
+//      used by components with no <Name>Props interface, like the forwardRef'd Card family —
+//      can resolve props from the component's call signature
+//   4. teaches the compiler the `@/*` → `src/*` path alias the sources import through
+//
+// Everything below projectFor is upstream, unmodified.
+//
+// .d.ts extraction via ts-morph (real TS checker). Resolves the apparent
+// structural type of each <Name>Props — unwraps Omit/Pick, follows extends
+// chains and intersections, resolves `(typeof X)[number]` / mapped types to
+// literal unions.
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { Project, Node, ts } from 'ts-morph';
+
+export function findTypesRoot(pkgDir, pkgJson) {
+  // Workspace/monorepo packages often point dev `types` at src/*.ts (no .d.ts
+  // tree there); publishConfig carries the published .d.ts entry — prefer it
+  // when it exists on disk.
+  const pubTypes = pkgJson.publishConfig?.types;
+  if (pubTypes && existsSync(join(pkgDir, pubTypes))) return dirname(join(pkgDir, pubTypes));
+  const t = pkgJson.types || pkgJson.typings;
+  if (t) return dirname(join(pkgDir, t));
+  const hasDts = (d) => { try { return readdirSync(d).some((f) => f.endsWith('.d.ts')); } catch { return false; } };
+  for (const c of ['build/ts', 'dist/types', 'types', 'lib', 'dist']) {
+    const p = join(pkgDir, c);
+    if (existsSync(p) && (c !== 'dist' || hasDts(p))) return p;
+  }
+  return pkgDir;
+}
+
+// *Props are prop interfaces; ALL-CAPS are object constants; *Manager /
+// *Placements / *Context are utility singletons; use* are hooks — none
+// renderable. (dts.nonComponents also catches React.Context by symbol kind;
+// the suffix check is belt-and-suspenders for DSes where that misses.)
+export const isComponentName = (n) => !n.endsWith('Props') && !/^[A-Z][A-Z0-9_]+$/.test(n)
+  && !/(?:Manager|Placements|Context)$/.test(n) && !/^use[A-Z]/.test(n);
+
+// Partition into roots and subcomponents. A name is a subcomponent ONLY when
+// another name is a PascalCase prefix of it AND the suffix is an actual
+// namespace member of that prefix per the `compounds` map (i.e. Table.Row
+// exists, so top-level TableRow is the same subpart). Name shape alone
+// can't distinguish TableRow (only renders inside Table) from ButtonGroup
+// (standalone) — the compounds membership is the reliable signal. For DSes
+// that export subparts top-level only (no `Table.Row` namespace), this
+// conservatively does nothing.
+export function partitionSubcomponents(names, compounds) {
+  const set = new Set(names);
+  const parentOf = new Map();
+  for (const n of names) {
+    const parts = n.match(/[A-Z][a-z0-9]*/g) ?? [];
+    // Try longest prefix first, keep trying shorter ones — `ListItemText`
+    // with compounds {List: ['ItemText']} must reach `List` even if
+    // `ListItem` is itself a top-level name.
+    for (let i = parts.length - 1; i >= 1; i--) {
+      const prefix = parts.slice(0, i).join('');
+      if (!set.has(prefix)) continue;
+      const suffix = parts.slice(i).join('');
+      if ((compounds?.get(prefix) ?? []).includes(suffix)) { parentOf.set(n, prefix); break; }
+    }
+  }
+  // Flatten transitively — TableRowCell → TableRow → Table becomes
+  // TableRowCell → Table, so the caller's per-root bucketing doesn't lose
+  // subs whose immediate parent is itself a sub. Terminates: each parent has
+  // strictly fewer PascalCase parts than its child.
+  for (const [n] of parentOf) {
+    let p = parentOf.get(n);
+    while (parentOf.has(p)) p = parentOf.get(p);
+    parentOf.set(n, p);
+  }
+  return { parentOf };
+}
+
+// One Project per package — loadDts/exportedNames share it.
+const projects = new Map();
+
+function projectFor(pkgDir, typesRoot) {
+  if (projects.has(pkgDir)) return projects.get(pkgDir);
+  // Derive node_modules for cross-package resolution (React, peer deps).
+  // Normalize separators — pkgDir may have backslashes on Windows.
+  const posix = pkgDir.split('\\').join('/');
+  const i = posix.lastIndexOf('/node_modules/');
+  let nodeModules = i >= 0 ? join(pkgDir.slice(0, i), 'node_modules') : join(pkgDir, '..');
+  // Workspace packages live outside node_modules — walk up to the hoisted
+  // root node_modules so @types/react resolves (otherwise React utility types
+  // collapse to `any` and inherited props drop out of the emitted bodies).
+  if (!existsSync(join(nodeModules, '@types', 'react'))) {
+    for (let d = pkgDir; ; d = dirname(d)) {
+      if (existsSync(join(d, 'node_modules', '@types', 'react'))) { nodeModules = join(d, 'node_modules'); break; }
+      if (dirname(d) === d) break;
+    }
+  }
+  const pj = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'));
+  // FORK: no `types` field and no declaration tree — the source entry IS the export list.
+  const SRC_ENTRY = join(pkgDir, '.design-sync', 'ds-entry.ts');
+  // Same publishConfig preference as findTypesRoot — keep the two in sync.
+  const pubEntry = pj.publishConfig?.types;
+  const dtsEntry = join(pkgDir, (pubEntry && existsSync(join(pkgDir, pubEntry)) ? pubEntry : null) || pj.types || pj.typings || 'index.d.ts');
+  const entry = existsSync(dtsEntry) ? dtsEntry : SRC_ENTRY;
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      jsx: ts.JsxEmit.ReactJSX,
+      skipLibCheck: true,
+      strict: false,
+      // FORK: the sources import through the app's `@/*` alias (tsconfig.json compilerOptions.paths).
+      // Without it every `@/components/ui/button` import is unresolved and props collapse to `any`.
+      baseUrl: pkgDir,
+      paths: { '@/*': ['./src/*'] },
+    },
+  });
+  // Add the package's own .d.ts tree plus @types/react (otherwise
+  // `ComponentPropsWithoutRef<…>` is `any` and intersection types collapse).
+  const reactTypes = join(nodeModules, '@types', 'react', 'index.d.ts');
+  // FORK: glob the .tsx SOURCES under src/, not a .d.ts tree. Bounded to src/ on purpose —
+  // the upstream repo-root glob walked .next/ (2.4GB) and blew the v8 heap.
+  const root = typesRoot ?? dirname(entry);
+  project.addSourceFilesAtPaths([`${pkgDir}/src/**/*.{ts,tsx}`, `!${pkgDir}/src/**/*.test.*`]);
+  project.addSourceFilesAtPaths([`${root}/src/types/**/*.d.ts`]);
+  console.error(`  [DTS] parsed ${project.getSourceFiles().length} source files from ${pkgDir}/src`);
+  // ts-morph StandardizedFilePath is always forward-slash; normalize pkgDir
+  // once so fp.startsWith(pkgDir) in isOwnProp/propsBodyFor works on Windows.
+  // Trailing slash so a sibling node_modules package whose name is a prefix of
+  // this one (foo vs foo-icons) isn't mis-classified as in-package.
+  const pkgDirStd = pkgDir.split('\\').join('/').replace(/\/?$/, '/');
+  if (existsSync(reactTypes)) project.addSourceFileAtPath(reactTypes);
+  else console.error(
+    '\n[DTS_REACT] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n' +
+    '[DTS_REACT] @types/react not found in node_modules. React utility types\n' +
+    '[DTS_REACT] (ComponentPropsWithoutRef, FC, …) will resolve to `any`, so\n' +
+    '[DTS_REACT] components whose props extend them will emit EMPTY bodies.\n' +
+    '[DTS_REACT] Fix: `npm i -D @types/react` then rebuild.\n' +
+    '[DTS_REACT] ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n',
+  );
+  if (existsSync(entry)) project.addSourceFileAtPath(entry);
+  const ctx = { project, entry, pkgDir: pkgDirStd };
+  projects.set(pkgDir, ctx);
+  return ctx;
+}
+
+// Keep a prop unless its declaration lives in React/DOM types or a CSS-in-JS
+// style-system base (hundreds of token-typed style props from the component
+// library's styled-props layer). The small KEEP_PROP set passes regardless so
+// structural props survive when inherited from React. ts-morph's getFilePath()
+// returns StandardizedFilePath (forward-slash), so the substring checks are
+// cross-platform.
+const KEEP_PROP = /^(children|className|style|as|asChild|ref|id)$/;
+// Style-system bases are detected by SHAPE, two-tier (canonical contract —
+// the call sites point here):
+// - EXTERNAL packages: >STYLE_SYSTEM_THRESHOLD CSS/token-named props,
+//   counted per package directory (the node_modules/<pkg>/ boundary), so a
+//   style system split across small per-category .d.ts files still crosses
+//   the bar in aggregate. Paths with no node_modules/ segment fall back to
+//   per-file counting at the in-package bar.
+// - IN-PACKAGE files: >IN_PACKAGE_FILE_THRESHOLD CSS-named props in ONE
+//   file. Hand-written API layers (tens of CSS-named props) are the DS's
+//   own API and are never filtered; only a generated style system crosses
+//   this bar. Left unfiltered, printing hundreds of token-typed unions per
+//   component costs minutes of build time and tens of GB of retained
+//   checker cache, and bloats every emitted .d.ts.
+// All props declared in a flagged file/package are filtered (KEEP_PROP
+// passes regardless). ASSUMPTION: when inherited shorthands are real API,
+// override per component with cfg.dtsPropsFor.<Name>.
+const CSS_PROP_NAME =
+  /^(m[tblrxy]?$|p[tblrxy]?$|margin|padding|bg|background|color|border|width|height|flex|grid|gap|font|text|display|position|top|left|right|bottom|z|opacity|overflow|shadow|rounded|space)/;
+const STYLE_SYSTEM_THRESHOLD = 15;
+const IN_PACKAGE_FILE_THRESHOLD = 100;
+// The package that owns a path: its deepest node_modules/<pkg>/ boundary
+// (trailing slash), or null for workspace paths. Identity comparison against
+// ownerOf(pkgDir) is the single in-package/external discriminator.
+function ownerOf(p) {
+  const m = /^(.*\/node_modules\/(?:@[^/]+\/)?[^/]+)\//.exec(p);
+  return m ? m[1] + '/' : null;
+}
+function detectStyleSystemDirs(props, pkgDir, declFile) {
+  const pkgOwner = ownerOf(pkgDir);
+  const cssByDir = new Map();
+  for (const p of props) {
+    if (!CSS_PROP_NAME.test(p.getName())) continue;
+    const d = p.getDeclarations()[0];
+    if (!d) continue;
+    const fp = d.getSourceFile().getFilePath();
+    // Key shape encodes the tier (see the canonical contract above
+    // CSS_PROP_NAME): external packages → node_modules/<pkg>/ prefix key
+    // (trailing slash); in-package declarations → exact FILE key. The
+    // DEEPEST node_modules boundary decides: a dep nested under the
+    // package's own node_modules (un-hoisted version conflict) is external.
+    // One principle, no orientation cases: a declaration is IN-PACKAGE iff
+    // the package that OWNS its file is the package being synced.
+    // ownerOf() = deepest node_modules package boundary, null for
+    // workspace paths. This derives every layout — nested dep under the
+    // package's own node_modules (different owner → external), dual-publish
+    // nested manifest (same owner → in-package even though pkgDir sits
+    // below the boundary), DS synced from inside a host package's
+    // node_modules (host files have a shallower owner → external).
+    // In-package files key per-FILE; external files key per owning package.
+    // Ownerless externals (sibling workspace packages) key per-file at the
+    // in-package bar — the documented out-of-scope fallback in the
+    // canonical block above.
+    const owner = ownerOf(fp);
+    const inPackage = owner === pkgOwner && (owner !== null || fp.startsWith(pkgDir));
+    const key = inPackage ? fp : (owner ?? fp);
+    // Never flag the file that declares the component's own Props: in a
+    // rolled-up single-file .d.ts the generated style layer co-lives with
+    // the API interfaces, and a per-FILE flag would drop the component's
+    // own props. Separate generated files still filter; rollups fall back
+    // to unfiltered (slow but correct). External dir keys are unaffected.
+    if (key === declFile) continue;
+    cssByDir.set(key, (cssByDir.get(key) ?? 0) + 1);
+  }
+  // Per-tier bars — rationale in the canonical block above CSS_PROP_NAME.
+  const keys = [];
+  for (const [k, n] of cssByDir) {
+    const bar = k.endsWith('/') ? STYLE_SYSTEM_THRESHOLD : IN_PACKAGE_FILE_THRESHOLD;
+    if (n > bar) keys.push(k);
+  }
+  return keys;
+}
+function isOwnProp(p, pkgDir, styleSystemDirs) {
+  const name = p.getName();
+  if (KEEP_PROP.test(name)) return true;
+  const d = p.getDeclarations()[0];
+  if (!d) return true;
+  const fp = d.getSourceFile().getFilePath();
+  // FORK: upstream assumes pkgDir is `node_modules/<pkg>`, so node_modules is never INSIDE it.
+  // Here pkgDir is the app repo root, so every dependency's .d.ts sits under it and reads as
+  // "in-package" by path prefix. That let a GLOBAL JSX augmentation from Next's vendored satori
+  // (`tw?: string`, documented "Specify styles using Tailwind CSS classes") into every component
+  // contract — inviting the design agent to write tw= instead of className= and ship silently
+  // unstyled markup. Next's bundled vendor types are never this DS's API.
+  // Scoped deliberately to next/dist/compiled/ and NOT to all of node_modules: Radix declares
+  // genuine API there (Dialog.open, Checkbox.checked, Select.value) that must survive.
+  if (fp.includes('/next/dist/compiled/')) return false;
+  // Same owner-identity discriminator as detectStyleSystemDirs, same order
+  // of authority: a flagged in-package FILE drops first (exact match); then
+  // owner-equality keeps the DS's own API — checked BEFORE dir keys because
+  // a flagged dir key can be an ANCESTOR of pkgDir (DS synced from inside a
+  // host package's node_modules) and must not swallow in-package files;
+  // then flagged external packages drop by prefix.
+  if (styleSystemDirs.some((k) => !k.endsWith('/') && fp === k)) return false;
+  const owner = ownerOf(fp);
+  if (owner === ownerOf(pkgDir) && (owner !== null || fp.startsWith(pkgDir))) return true;
+  if (styleSystemDirs.some((k) => k.endsWith('/') && fp.startsWith(k))) return false;
+  if (fp.includes('/@types/react/') || fp.includes('/typescript/lib/')) return false;
+  // DOM-noise name filters apply only to props inherited from other packages.
+  if (/^(on[A-Z]|aria-)/.test(name)) return false;
+  return true;
+}
+
+// Keep well-known aliases as-written instead of expanding to their full union.
+const KEEP_ALIAS = /^(ReactNode|ReactElement|CSSProperties|JSX\.Element|Key|Ref|RefObject)$/;
+
+function typeText(t, at) {
+  const alias = t.getAliasSymbol()?.getName();
+  if (alias && KEEP_ALIAS.test(alias)) return `React.${alias}`;
+  if (t.isBoolean()) return 'boolean';
+  let s;
+  if (t.isUnion()) {
+    // Render each member so ReactNode/boolean collapse while literal unions
+    // stay expanded; dedup, drop `undefined` (optionality is the `?`).
+    const parts = t.getUnionTypes().map((u) => typeText(u, at)).filter((p) => p !== 'undefined');
+    let uniq = [...new Set(parts)];
+    if (uniq.length === 2 && uniq.includes('true') && uniq.includes('false')) return 'boolean';
+    // Collapse the structural expansion of React.ReactNode (string | number |
+    // ReactElement<…> | Iterable<ReactNode> | ReactPortal | Promise<…>) back to
+    // the alias — when the alias symbol is lost, the expansion blows past the
+    // length cap below and would truncate into invalid TS.
+    if (uniq.includes('ReactPortal') && uniq.some((u) => u.startsWith('Iterable<ReactNode>'))) {
+      const RN_MEMBER = /^(string|number|bigint|boolean|ReactPortal|Iterable<ReactNode>.*|ReactElement<.*|Promise<.*)$/;
+      uniq = [...new Set([...uniq.filter((u) => !RN_MEMBER.test(u)), 'React.ReactNode'])];
+    }
+    // Function-type members are invalid un-parenthesized inside a union
+    // (`string | (x) => void` doesn't parse) — wrap them.
+    if (uniq.length > 1) uniq = uniq.map((u) => (u.includes('=>') ? `(${u})` : u));
+    // Cap very wide unions (icon-name sets can be 600+ members).
+    if (uniq.length > 24) uniq = [...uniq.slice(0, 16), `(string & {}) /* +${uniq.length - 16} more */`];
+    s = uniq.join(' | ').replace(/\bfalse \| true\b/, 'boolean');
+  } else {
+    s = t.getText(at, ts.TypeFormatFlags.NoTruncation).replace(/import\("[^"]*"\)\./g, '');
+  }
+  // Never hard-slice an over-long type — a cut generic/object literal is
+  // invalid TS and fails the validator's [DTS_PARSE] check (and the app's
+  // API-contract parse). Fall back to a safe wide type instead; the JSDoc
+  // line above the prop carries the human-readable detail.
+  return s.length > 240 ? 'unknown' : s;
+}
+
+// PascalCase value exports from the entry module. The checker knows value vs
+// type, so type-only exports never enter the set.
+export function exportedNames(pkgDir, pkgJson) {
+  const { project, entry } = projectFor(pkgDir, findTypesRoot(pkgDir, pkgJson));
+  const sf = project.getSourceFile(entry);
+  const names = new Set();
+  if (!sf) return names;
+  for (const [name, decls] of sf.getExportedDeclarations()) {
+    if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) continue;
+    const hasValue = decls.some((d) =>
+      Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) ||
+      Node.isClassDeclaration(d) || Node.isSourceFile(d));
+    if (hasValue) names.add(name);
+  }
+  return names;
+}
+
+// Builds the context propsBodyFor/jsdocFor read from. `nonComponents` /
+// `compounds` are derived from the checker's symbol kinds.
+export function loadDts(typesRoot) {
+  // typesRoot is always under <nm>/<pkg>/… — walk up to the real package
+  // root: the nearest package.json with a `name` field, skipping stubs
+  // (`{"type":"module"}` in esm/ or dist/). dirname-fixed-point is the
+  // cross-platform root test (`/` vs `C:\`).
+  let walk = typesRoot;
+  for (; walk !== dirname(walk); walk = dirname(walk)) {
+    const pj = join(walk, 'package.json');
+    if (existsSync(pj)) {
+      try { if (JSON.parse(readFileSync(pj, 'utf8')).name) break; } catch {}
+    }
+  }
+  // projectFor normalizes pkgDir to forward-slashes (ts-morph's
+  // StandardizedFilePath) — use that for every fp.startsWith() downstream.
+  const { project, entry, pkgDir } = projectFor(walk, typesRoot);
+  const sf = project.getSourceFile(entry);
+  const nonComponents = new Set();
+  const compounds = new Map();
+  if (sf) for (const [name, decls] of sf.getExportedDeclarations()) {
+    if (!/^[A-Z][A-Za-z0-9]*$/.test(name)) continue;
+    // Declaration-merged names (`interface Button {}` + `const Button: …`)
+    // return both decls — prefer the value decl so the merge isn't
+    // misclassified as type-only by whichever the checker listed first.
+    const d = decls.find((x) =>
+      Node.isVariableDeclaration(x) || Node.isFunctionDeclaration(x) ||
+      Node.isClassDeclaration(x) || Node.isSourceFile(x)) ?? decls[0];
+    // Namespace export (`export * as X`) → compound with its own value members.
+    if (Node.isSourceFile(d)) {
+      const members = [...d.getExportedDeclarations().entries()]
+        .filter(([n, ds]) => /^[A-Z][a-z]/.test(n) && ds.some((x) => !Node.isInterfaceDeclaration(x) && !Node.isTypeAliasDeclaration(x)))
+        .map(([n]) => n);
+      if (members.length) compounds.set(name, members);
+      else nonComponents.add(name);
+      continue;
+    }
+    // Type-only / enum / Context / abstract-class are not components.
+    if (Node.isInterfaceDeclaration(d) || Node.isTypeAliasDeclaration(d) || Node.isEnumDeclaration(d)) {
+      nonComponents.add(name);
+      continue;
+    }
+    if (Node.isClassDeclaration(d) && d.isAbstract()) { nonComponents.add(name); continue; }
+    if (Node.isClassDeclaration(d)) continue;  // always renderable; compounds via statics aren't handled here
+    if (!Node.isVariableDeclaration(d) && !Node.isFunctionDeclaration(d)) continue;
+    // `const X: FC<…> & { Sub: … }` (possibly through an alias/Omit) —
+    // PascalCase callable properties declared in-package are compound members
+    // (React.Component lifecycle names have underscores / fail the full match).
+    const t = d.getType();
+    const members = [];
+    // PascalCase props can't be style-system CSS-shorthands, so the empty
+    // list is correct here — detectStyleSystemDirs would contribute nothing.
+    const noStyle = [];
+    for (const p of t.getProperties()) {
+      const pn = p.getName();
+      if (!/^[A-Z][a-zA-Z0-9]*$/.test(pn) || !isOwnProp(p, pkgDir, noStyle)) continue;
+      if (p.getTypeAtLocation(d).getCallSignatures().length) members.push(pn);
+    }
+    if (members.length) compounds.set(name, members);
+    // Only provably-not-renderable consts are filtered: a plain object/record
+    // type whose every property is a primitive (token/enum
+    // objects like Colors or Sizes). Anything with a call signature, construct signature, or a
+    // non-primitive property stays — class components and forwardRef wrappers
+    // without call sigs on the instance type must not be dropped here.
+    if (t.isObject() && !t.getCallSignatures().length && !t.getConstructSignatures().length && !members.length && !t.isAny()) {
+      const props = t.getProperties();
+      if (props.length && props.every((p) => {
+        const pt = p.getTypeAtLocation(d);
+        return pt.isString() || pt.isNumber() || pt.isStringLiteral() || pt.isNumberLiteral();
+      })) nonComponents.add(name);
+    }
+  }
+  return { project, entry, pkgDir, nonComponents, compounds };
+}
+
+// Returns { body, generics, extendsClause, prelude } for emit.mjs. Types are
+// fully resolved into `body`, so extendsClause/prelude stay empty.
+export function propsBodyFor(name, ctx) {
+  if (ctx.dtsPropsFor?.[name]) {
+    return { body: ctx.dtsPropsFor[name], generics: '', extendsClause: '', prelude: '' };
+  }
+  const { project, entry, pkgDir } = ctx;
+  // Find <Name>Props across the package's own files (not @types/react).
+  // Skip deprecated/legacy/experimental dirs so a stale copy doesn't shadow
+  // the live one.
+  let decl = null;
+  for (const sf of project.getSourceFiles()) {
+    const fp = sf.getFilePath();
+    if (!fp.startsWith(pkgDir)) continue;
+    if (/\/(deprecated|legacy|experimental)\//i.test(fp)) continue;
+    decl = sf.getInterface(`${name}Props`) ?? sf.getTypeAlias(`${name}Props`);
+    if (decl) break;
+  }
+  // Fallback: derive from the component symbol's first call signature.
+  // Prefer the value decl (declaration-merging — see loadDts).
+  if (!decl) {
+    const decls = project.getSourceFile(entry)?.getExportedDeclarations().get(name) ?? [];
+    const exp = decls.find((d) =>
+      Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) || Node.isClassDeclaration(d)) ?? decls[0];
+    if (!exp || Node.isSourceFile(exp)) return null;
+    const sig = exp.getType().getCallSignatures()[0];
+    const p0 = sig?.getParameters()[0];
+    if (!p0) return null;
+    return emitBody(p0.getTypeAtLocation(exp), exp, '', pkgDir);
+  }
+  const generics = decl.getTypeParameters?.().length
+    ? `<${decl.getTypeParameters().map((p) => p.getText()).join(', ')}>`
+    : '';
+  return emitBody(decl.getType(), decl, generics, pkgDir);
+}
+
+let loggedStyleSystemDirs;
+function emitBody(type, at, generics, pkgDir) {
+  const lines = [];
+  const props = type.getApparentType().getProperties();
+  // `at` is the component's own Props declaration site — its file is exempt
+  // from per-FILE flagging (see detectStyleSystemDirs).
+  const styleSystemDirs = detectStyleSystemDirs(props, pkgDir, at.getSourceFile().getFilePath());
+  // Surface a one-shot [DTS_STYLE_SYSTEM] line per flagged package so the
+  // self-heal loop routes to cfg.dtsPropsFor when the heuristic guesses
+  // wrong. ASSUMPTION: props from the named packages are token-typed
+  // style shorthands; override a component's contract with cfg.dtsPropsFor.
+  loggedStyleSystemDirs ??= new Set();
+  for (const dir of styleSystemDirs) {
+    if (loggedStyleSystemDirs.has(dir)) continue;
+    loggedStyleSystemDirs.add(dir);
+    const isDirKey = dir.endsWith('/');
+    const pkg = /\/node_modules\/((?:@[^/]+\/)?[^/]+)\/$/.exec(dir)?.[1]
+      ?? (dir.startsWith(pkgDir) ? dir.slice(pkgDir.length) : dir);
+    const bar = isDirKey ? STYLE_SYSTEM_THRESHOLD : IN_PACKAGE_FILE_THRESHOLD;
+    console.error(
+      `[DTS_STYLE_SYSTEM] filtering ${pkg} props (>${bar} CSS-shorthand-named props) — override a component with cfg.dtsPropsFor.<Name> if these are real API`,
+    );
+  }
+  for (const p of props) {
+    if (!isOwnProp(p, pkgDir, styleSystemDirs)) continue;
+    const optional = p.hasFlags(ts.SymbolFlags.Optional) ? '?' : '';
+    const pt = p.getTypeAtLocation(at);
+    let tt = typeText(pt, at);
+    // Structural hint when the type text hides the shape (aliased functions /
+    // arrays) — smartDefaultProps reads these to pick the right required-stub.
+    const members = pt.isUnion() ? pt.getUnionTypes() : [pt];
+    if (members.some((u) => u.getCallSignatures().length)) tt += ' /* @fn */';
+    // Tuples are not @arr — `[]` has the wrong length and `[0]` access crashes
+    // either way; optional tuples are safer left unset.
+    else if (members.some((u) => u.isArray())) tt += ' /* @arr */';
+    // Leading JSDoc on the prop declaration, if any.
+    const d = p.getDeclarations()[0];
+    const doc = d?.getJsDocs?.()?.[0]?.getDescription()?.trim();
+    if (doc) lines.push(`  /** ${doc.replace(/\s+/g, ' ').slice(0, 120)} */`);
+    const pn = p.getName();
+    // Hyphenated/index-signature names (`data-*`, `aria-*`) must be quoted.
+    const key = /^[a-zA-Z_$][\w$]*$/.test(pn) ? pn : JSON.stringify(pn);
+    lines.push(`  ${key}${optional}: ${tt};`);
+  }
+  if (!lines.length) return null;
+  return { body: lines.join('\n'), generics, extendsClause: '', prelude: '' };
+}
+
+// Scaffold-preview defaults from the resolved props body. Conservative: fill
+// only what's needed for a meaningful first render (children + variant axis +
+// visibility toggles + required arrays). Optional string/number/Date props are
+// left unset — filling them with placeholder values crashes more than it
+// helps.
+//
+// Void-element-ish components — a string `children` would throw at render.
+const VOID_LIKE = /^(Text|Number|Search|Password|File|Masked)?Input$|^(TextField|TextArea|Textarea|Img|Image|Avatar|Hr|Br|Spacer|Divider|Separator|Slider|Progress|ProgressBar)$/;
+// Ordered preference for the variant axis — earlier wins. `type` is last so
+// the HTML `type` attr ("button"|"submit"|"reset") doesn't beat `variant`.
+const VARIANT_RANK = ['variant', 'intent', 'kind', 'appearance', 'tone', 'status', 'size', 'color', 'type'];
+export function smartDefaultProps(name, pb) {
+  const body = pb?.body ?? '';
+  const props = {};
+  let variants = null;
+  // Matches the 2-space indent emitBody writes — keep the two in sync.
+  // `.+` (not `[^;]+`) so object-param types with inner semicolons still match.
+  for (const m of body.matchAll(/^ {2}([a-zA-Z_$][\w$]*)(\??)\s*:\s*(.+);$/gm)) {
+    const [, prop, q, t] = m;
+    if (prop in props) continue;
+    const req = !q;
+    // Union of string literals, optionally with a `string & {}` escape-hatch
+    // member (the "autocomplete these, accept any string" TS pattern).
+    if (/^(?:(?:"[^"]*"|\(?string\s*&\s*\{\}\)?)\s*\|?\s*)+$/.test(t)) {
+      const lits = [...t.matchAll(/"([^"]*)"/g)].map((l) => l[1]).filter(Boolean);
+      if (lits.length >= 2) {
+        const rank = VARIANT_RANK.indexOf(prop.toLowerCase());
+        // Displace on strictly better rank (prop names are unique, so no ties).
+        if (!variants || (rank >= 0 && (variants.rank < 0 || rank < variants.rank))) {
+          variants = { prop, values: lits.slice(0, 4), rank };
+        }
+        if (req) props[prop] = lits[0];
+        continue;
+      }
+    }
+    // Structural hints (/* @fn */, /* @arr */) from emitBody are authoritative
+    // over the text regexes — `(() => void)[]` has @arr, so the `=>` in the
+    // element type must not flip it to isFn. The text regexes cover
+    // cfg.dtsPropsFor overrides with no hints.
+    const hasFn = t.includes('/* @fn */'), hasArr = t.includes('/* @arr */');
+    const isFn = hasFn || (!hasArr && /=>|\)\s*:/.test(t));
+    const isArr = !isFn && (hasArr || /\[\]|Array</.test(t));
+    if (prop === 'children' && /React\.ReactNode|ReactElement/.test(t) && !isFn && !VOID_LIKE.test(name)) props.children = name;
+    // Visibility toggles — an overlay/dialog with open=false renders nothing.
+    else if (/^(open|isOpen|visible|show|defaultOpen|expanded|checked|active|selected)$/.test(prop) && t === 'boolean') props[prop] = true;
+    // Callable (required or optional) — optional stays unset (DSes guard
+    // optional callbacks); required gets a noop.
+    else if (isFn) { if (req) props[prop] = { $raw: '()=>null' }; }
+    // Arrays (required or optional). `[]` is crash-safe but renders nothing.
+    // Props that look like data/option lists get a small sample so the
+    // preview has visible rows; element shape is best-effort from the type
+    // text (string[] → strings; otherwise {id,label,value}).
+    else if (isArr) {
+      const isList = /^(items|options|tabs|rows|columns|data|actions|fields|links|steps|choices|values)$/i.test(prop);
+      const elT = t.replace(/\/\*.*?\*\//g, '').trim();
+      const elIsString = /^(?:readonly\s+)?string\[\]|^ReadonlyArray<string>|^Array<string>/.test(elT);
+      // Over-provision keys — extra ones are ignored, and this covers the
+      // common {id|key} + {label|text|name|title} + value conventions.
+      props[prop] = isList
+        ? elIsString
+          ? ['Item 1', 'Item 2', 'Item 3']
+          : [1, 2, 3].map((i) => {
+            const s = String(i), l = `Item ${i}`;
+            return { id: s, key: s, value: s, label: l, text: l, name: l, title: l };
+          })
+        : [];
+    }
+    // Optional everything-else stays unset — the component's own defaults are
+    // safer than a placeholder.
+    else if (!req) continue;
+    // Required props get a type-appropriate stub so the render doesn't crash
+    // on `undefined.…` / `undefined()`. `$raw` values are emitted verbatim by
+    // scaffoldPropsExpr (not JSON-stringified).
+    else if (/\bDate\b/.test(t)) props[prop] = { $raw: 'new Date()' };
+    else if (/ElementType|ComponentType|JSXElementConstructor/.test(t)) props[prop] = 'div';
+    else if (/React\.ReactNode|ReactElement/.test(t)) props[prop] = name;
+    else if (/^string\b/.test(t)) props[prop] = name;
+    else if (/^number\b/.test(t)) props[prop] = 0;
+    else if (/^boolean\b/.test(t)) props[prop] = false;
+    else if (/^\{/.test(t) || /Record<|Partial<|Pick<|Omit</.test(t)) props[prop] = {};
+    // Fallback: required prop of unrecognized shape — `{}` is the least likely
+    // to crash `.foo` access.
+    else props[prop] = {};
+  }
+  return { props, variants };
+}
+
+// One-line JSDoc from the component's own declaration.
+export function jsdocFor(name, ctx) {
+  const decls = ctx.project?.getSourceFile(ctx.entry)?.getExportedDeclarations().get(name) ?? [];
+  const exp = decls.find((d) =>
+    Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) || Node.isClassDeclaration(d)) ?? decls[0];
+  if (!exp || Node.isSourceFile(exp)) return '';
+  const doc = exp.getJsDocs?.()?.[0]?.getDescription()
+    ?? exp.getSymbol?.()?.compilerSymbol.getDocumentationComment?.(undefined)?.[0]?.text;
+  if (!doc) return '';
+  return doc.split('\n').find((l) => l.trim() && !l.trim().startsWith('@'))
+    ?.trim().replace(/\s+/g, ' ').replace(/[^\w\s.,()'/:+-]/g, '').slice(0, 140) ?? '';
+}

--- a/.design-sync/overrides/source-kit.mjs
+++ b/.design-sync/overrides/source-kit.mjs
@@ -1,0 +1,187 @@
+// Non-storybook `package` adapter. Bundles dist/ when present (the authoritative
+// component list comes from shipped .d.ts; with no dist it synthesizes an
+// entry from src/ as a last resort) and opportunistically enriches each
+// component from src/ — JSDoc and dir-derived group. Every enrichment miss
+// degrades to the plain-dist behaviour.
+//
+// Discovery is heuristic-based; each heuristic has a `.design-sync/config.json`
+// override (ASSUMPTION comments below name them) so repos that don't match the
+// defaults write config, not code. `componentSrcMap` is the single override
+// knob for component inclusion: non-null value = add/pin src path, null =
+// exclude a .d.ts-exported internal.
+
+import { existsSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { Project, Node, ts } from 'ts-morph';
+// forked from design-sync lib/source-kit.mjs — Next.js App Router private-folder convention.
+//
+// Group derivation takes the last src/ path segment that isn't GENERIC_DIR. MusicNerd's brand
+// components live in `src/app/_components/`, and `_components` doesn't match the generic set
+// (which has `components`), so every brand component was forced into a group literally named
+// "components" — and because that group is non-generic, it also OUTRANKED the `category: Brand`
+// frontmatter in .design-sync/groups/*.md, so the regroup stubs silently did nothing.
+//
+// The leading underscore is Next.js's "private folder" marker (excluded from routing); it carries
+// no design meaning. Strip it before the generic-dir test so `_components` reads as `components`.
+//
+// Sibling imports are repointed at the staged lib (they don't exist under overrides/), EXCEPT
+// ./dts.mjs — that resolves to the forked dts.mjs alongside this file, so both forks share one
+// ts-morph project instead of building two.
+import { leadingJsdoc, readText, slash, walk } from '../../.ds-sync/lib/common.mjs';
+import { resolveDistEntry } from '../../.ds-sync/lib/bundle.mjs';
+import { exportedNames, isComponentName } from './dts.mjs';
+
+const NON_IMPL_RX = /\.(stories|test|spec)\./;
+const SRC_IMPL_RX = /\.(tsx|jsx)$/;
+// Dir names that don't usefully group components — skip so the emitted path
+// is `components/<group>/<Name>` not `components/components/<Name>`.
+const GENERIC_DIR = new Set(['components', 'component', 'src', 'lib', 'ui', 'packages', 'react']);
+const slug = (s) => s.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'general';
+
+// No .d.ts → scan src files for PascalCase value exports via ts-morph.
+function deriveComponentsFromSrc(srcFiles) {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    compilerOptions: { jsx: ts.JsxEmit.Preserve, allowJs: true, skipLibCheck: true },
+  });
+  const seen = new Set();
+  for (const p of srcFiles) {
+    if (NON_IMPL_RX.test(p) || !SRC_IMPL_RX.test(p)) continue;
+    const sf = project.addSourceFileAtPathIfExists(p);
+    if (!sf) continue;
+    for (const [name, decls] of sf.getExportedDeclarations()) {
+      // `export default function Button()` is keyed as 'default' — recover
+      // the declared name from the function/class node.
+      const real = name === 'default'
+        ? decls.map((d) => d.getName?.()).find((n) => n && n !== 'default')
+        : name;
+      if (!real || !/^[A-Z][A-Za-z0-9]*$/.test(real)) continue;
+      if (decls.some((d) => Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) || Node.isClassDeclaration(d))) {
+        seen.add(real);
+      }
+    }
+  }
+  return [...seen].sort().map((name) => ({ name, group: 'general' }));
+}
+
+export async function resolvePackage(ctx) {
+  const { PKG_DIR, pkgJson, ENTRY_OVERRIDE, PKG, OUT, cfg } = ctx;
+  const srcMap = cfg.componentSrcMap ?? {};
+
+  // ── 1. src/ discovery (best-effort; feeds enrichment + synth-entry fallback).
+  // ASSUMPTION: source root is first of src/ | lib/ | components/. Override: cfg.srcDir.
+  const srcRoot = [cfg.srcDir, 'src', 'lib', 'components']
+    .map((d) => d && resolve(PKG_DIR, d))
+    .find((d) => d && existsSync(d));
+  const srcFiles = srcRoot ? walk(srcRoot, (n) => /\.(tsx|jsx|mdx?)$/.test(n)) : [];
+
+  // ── 2. entry: dist if it exists, else synthesize from src/ (last resort).
+  let entry = resolveDistEntry({ pkgDir: PKG_DIR, pkgJson, override: ENTRY_OVERRIDE, pkgName: PKG, soft: true });
+  let synthEntry = false;
+  if (!entry) {
+    if (!srcRoot) {
+      console.error(`[NO_DIST] ${PKG} has no built entry and no src/ to synthesize from — run its build.`);
+      process.exit(1);
+    }
+    const comps = srcFiles.filter((p) => SRC_IMPL_RX.test(p) && !NON_IMPL_RX.test(p));
+    entry = join(OUT, '.pkg-entry.mjs');
+    writeFileSync(entry, comps.map((p) => `export * from ${JSON.stringify(p)};`).join('\n') + '\n');
+    synthEntry = true;
+    console.error(
+      `[NO_DIST] no built entry — synthesizing from ${comps.length} src files (run the package's build for best results)`,
+    );
+  }
+
+  // ── 3. component list: from shipped .d.ts (authoritative when dist exists).
+  // ASSUMPTION: components = PascalCase value exports in the .d.ts tree.
+  // Override: cfg.componentSrcMap (non-null adds/pins, null excludes).
+  const exported = exportedNames(PKG_DIR, pkgJson);
+  // FORK: componentSrcMap IS the component list here, not a set of tweaks to a discovered one.
+  // ds-entry.ts exports ~110 symbols, but ~77 of those are compound sub-parts (CardHeader,
+  // DialogFooter, SelectItem…) and 2 are context providers. Auto-discovering them would mint a
+  // card and a near-empty contract for each — dozens of duplicate previews and a pane no human
+  // can browse. They all still SHIP in the bundle (window.MusicNerd.CardHeader works) and each
+  // compound's authored preview demonstrates its sub-parts in a real composition; they just
+  // don't get their own cards. Seeding from srcMap keeps that curation stable even though this
+  // repo's export list is fully resolvable.
+  const curated = Object.values(srcMap).some((v) => v !== null);
+  const names = new Set(curated ? [] : [...exported].filter(isComponentName));
+  for (const [k, v] of Object.entries(srcMap)) {
+    if (v === null) { names.delete(k); continue; }
+    // Names reach `<script>` blocks in the emitted HTML — reject anything
+    // that isn't a plain PascalCase identifier.
+    if (!/^[A-Z][A-Za-z0-9]*$/.test(k)) {
+      console.error(`[CONFIG] componentSrcMap: "${k}" is not a valid component name (PascalCase identifiers only)`);
+      continue;
+    }
+    names.add(k);
+  }
+  let components = [...names].sort().map((name) => ({ name, group: 'general' }));
+  if (!components.length && synthEntry) {
+    components = deriveComponentsFromSrc(srcFiles).filter((c) => srcMap[c.name] !== null);
+  }
+  if (!components.length) {
+    if (cfg.cssEntry || existsSync(join(PKG_DIR, 'styles.css'))) {
+      console.error('[ZERO_MATCH] no component exports — treating as tokens-only DS');
+      return { shape: 'package', entry, components: [], tokensOnly: true };
+    }
+    console.error(`[ZERO_MATCH] no PascalCase exports in ${PKG} and no styles — nothing to sync`);
+    process.exit(1);
+  }
+
+  // ── 4. src/ enrichment per component. Every miss degrades to plain-dist.
+  if (srcRoot) {
+    for (const c of components) {
+      // Pinned via config → skip fuzzy-find entirely.
+      let hit = typeof srcMap[c.name] === 'string' ? slash(resolve(PKG_DIR, srcMap[c.name])) : null;
+      if (!hit) {
+        // ASSUMPTION: <Name>.tsx | <name>/<name>.tsx | <Name>/index.tsx |
+        // <kebab-name>.tsx, case-insensitive; dir-match ranks above
+        // bare-file match, then prefer one that actually exports `c.name`.
+        // Override: cfg.componentSrcMap.
+        const kebab = c.name.replace(/([a-z0-9])([A-Z])/g, '$1-$2');
+        const nameRx = new RegExp(
+          `(?:^|/)(?:${c.name}/(?:index|${c.name})\\.(tsx|jsx)|(?:${c.name}|${kebab})\\.(tsx|jsx))$`,
+          'i',
+        );
+        const hits = srcFiles
+          .filter((p) => nameRx.test(p) && !NON_IMPL_RX.test(p))
+          .sort(
+            (a, b) =>
+              (b.toLowerCase().includes(`/${c.name.toLowerCase()}/`) ? 1 : 0) -
+              (a.toLowerCase().includes(`/${c.name.toLowerCase()}/`) ? 1 : 0),
+          );
+        const exportRx = new RegExp(`export\\s+(?:default\\s+)?(?:const|let|var|function|class)\\s+${c.name}\\b`);
+        hit = hits.find((p) => exportRx.test(readText(p))) ?? hits[0];
+      }
+      if (!hit || !existsSync(hit)) continue;
+      c.srcPath = hit;
+      c.doc = leadingJsdoc(readText(hit), c.name) || undefined;
+      // group = last src/ path segment that isn't the component's own dir or
+      // a generic container name — else JSDoc @category — else 'general'.
+      c.group = slug(
+        slash(relative(srcRoot, dirname(hit)))
+          .split('/')
+          // FORK: strip Next.js's leading-underscore private-folder marker before the generic
+          // test, so `_components` is recognized as the generic `components`. `app` and `pages`
+          // are Next.js router roots — structural, not design categories — so they're generic too.
+          // With every segment of `app/_components` filtered, the group falls through to the
+          // `category:` frontmatter in .design-sync/groups/*.md, which is what we want it to use.
+          .filter((s) => {
+            const seg = s.toLowerCase().replace(/^_+/, '');
+            return s && seg !== c.name.toLowerCase()
+              && !GENERIC_DIR.has(seg) && seg !== 'app' && seg !== 'pages';
+          })
+          .at(-1)
+        || (c.doc && /@category\s+(\S+)/.exec(c.doc)?.[1])
+        || 'general',
+      );
+    }
+  }
+
+  console.error(
+    `  package: ${components.length} components` +
+      (srcRoot ? ` (${components.filter((c) => c.srcPath).length} src-matched)` : ' (no src/ — dist-only)'),
+  );
+  return { shape: 'package', entry, components, synthEntry, exported };
+}

--- a/.design-sync/previews/AspectRatio.tsx
+++ b/.design-sync/previews/AspectRatio.tsx
@@ -1,0 +1,75 @@
+import { AspectRatio, Badge } from "musicnerdweb";
+
+/**
+ * A 1:1 artist artwork tile — the shape Spotify images arrive in. AspectRatio is a bare
+ * Radix re-export with no styling of its own: it only reserves the box (padding-bottom
+ * trick), so it renders as nothing unless the parent has a width AND it has a child.
+ * Here the parent is `w-64` and the child is an absolutely-filled brand gradient standing
+ * in for the artwork.
+ */
+export const Square = () => (
+  <div className="w-64">
+    <AspectRatio ratio={1}>
+      <div className="flex h-full w-full items-end rounded-lg bg-gradient-to-br from-pastypink via-[#7c3aed] to-pastyblue p-3">
+        <span className="rounded bg-black/40 px-2 py-1 text-sm font-medium text-white">
+          Floating Points
+        </span>
+      </div>
+    </AspectRatio>
+  </div>
+);
+
+/**
+ * 16:9 — the ratio the Spotify/YouTube embeds on the artist page need. Same component,
+ * only `ratio` changes; the wrapper width is identical to the 1:1 story above, so the
+ * height difference is entirely the ratio doing its job.
+ */
+export const Video = () => (
+  <div className="w-80">
+    <AspectRatio ratio={16 / 9}>
+      <div className="flex h-full w-full items-center justify-center rounded-lg border bg-muted">
+        <span className="text-sm text-muted-foreground">Spotify embed · 16:9</span>
+      </div>
+    </AspectRatio>
+  </div>
+);
+
+/**
+ * The ratio axis in one row: 1:1 (artwork), 4:3, 16:9 (embed), 3:4 (portrait press shot).
+ * Equal-width columns, so each box's height is a direct readout of its ratio.
+ */
+export const RatioScale = () => (
+  <div className="grid w-[520px] grid-cols-4 items-start gap-3">
+    {[
+      ["1:1", 1, "from-pastypink to-[#7c3aed]"],
+      ["4:3", 4 / 3, "from-pastyblue to-jellygreen"],
+      ["16:9", 16 / 9, "from-jellygreen to-pastyblue"],
+      ["3:4", 3 / 4, "from-[#7c3aed] to-pastypink"],
+    ].map(([label, ratio, grad]) => (
+      <div key={label as string} className="space-y-1.5">
+        <AspectRatio ratio={ratio as number}>
+          <div className={`h-full w-full rounded-md bg-gradient-to-br ${grad}`} />
+        </AspectRatio>
+        <p className="text-center text-xs text-muted-foreground">{label as string}</p>
+      </div>
+    ))}
+  </div>
+);
+
+/**
+ * In situ: an artwork tile inside a card, with the genre badge below. This is the whole
+ * point of the component in a music directory — the grid stays on a rigid baseline even
+ * before any image has loaded, so a slow Spotify CDN never reflows the page.
+ */
+export const InArtistCard = () => (
+  <div className="w-56 overflow-hidden rounded-lg border bg-card shadow-sm">
+    <AspectRatio ratio={1}>
+      <div className="h-full w-full bg-gradient-to-br from-[#ff9ce3] via-pastypink to-pastyblue" />
+    </AspectRatio>
+    <div className="space-y-2 p-3">
+      <p className="font-medium leading-none">Yaeji</p>
+      <p className="text-xs text-muted-foreground">9 platform links</p>
+      <Badge variant="secondary">house</Badge>
+    </div>
+  </div>
+);

--- a/.design-sync/previews/Badge.tsx
+++ b/.design-sync/previews/Badge.tsx
@@ -1,0 +1,73 @@
+import { Badge } from "musicnerdweb";
+
+/**
+ * The four stock variants, side by side. Base is always
+ * `rounded-full border px-2.5 py-0.5 text-xs font-semibold` — only the fill changes.
+ * `outline` is the only variant with a visible border (the other three set
+ * `border-transparent`), so it reads as the quietest of the set.
+ */
+export const Variants = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Badge>default</Badge>
+    <Badge variant="secondary">secondary</Badge>
+    <Badge variant="destructive">destructive</Badge>
+    <Badge variant="outline">outline</Badge>
+  </div>
+);
+
+/**
+ * Genre pills on an artist record — the densest real use. `secondary` is the house style
+ * for taxonomy; `outline` demotes a low-confidence tag the community hasn't confirmed.
+ */
+export const GenrePills = () => (
+  <div className="max-w-sm space-y-3">
+    <p className="text-sm font-medium">Jamie xx</p>
+    <div className="flex flex-wrap gap-2">
+      <Badge variant="secondary">electronic</Badge>
+      <Badge variant="secondary">uk garage</Badge>
+      <Badge variant="secondary">house</Badge>
+      <Badge variant="secondary">downtempo</Badge>
+      <Badge variant="outline">+ unverified: trip hop</Badge>
+    </div>
+  </div>
+);
+
+/**
+ * Status pills in the moderation and agent queues — the semantic axis. `default` (primary
+ * fill) = approved, `outline` = pending, `destructive` = rejected, `secondary` = the
+ * neutral machine-written state. Note DESIGN.md's warning: nothing in the component
+ * enforces this mapping, so it lives entirely in convention at the call site.
+ */
+export const StatusPills = () => (
+  <div className="max-w-md space-y-2 text-sm">
+    {[
+      ["Yaeji → Bandcamp", <Badge key="a">Approved</Badge>],
+      ["Overmono → Deezer", <Badge key="b" variant="outline">Pending review</Badge>],
+      ["Kelela → Tidal", <Badge key="c" variant="destructive">Rejected</Badge>],
+      ["Four Tet → MusicBrainz", <Badge key="d" variant="secondary">Auto-mapped</Badge>],
+    ].map(([label, badge], i) => (
+      <div
+        key={i}
+        className="flex items-center justify-between rounded-md border bg-card px-3 py-2"
+      >
+        <span className="text-muted-foreground">{label}</span>
+        {badge}
+      </div>
+    ))}
+  </div>
+);
+
+/**
+ * Brand-tinted badges via `className` overrides — how confidence levels are colored in
+ * the agent-work view. The pink here is the raw `#ff9ce3` literal users actually see,
+ * not the `pastypink` token (#ef95ff); DESIGN.md flags the two as a real fragmentation.
+ * Shown against `maroon` text, the brand's ink color.
+ */
+export const BrandTinted = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Badge className="bg-jellygreen text-maroon hover:bg-jellygreen">high confidence</Badge>
+    <Badge className="bg-pastyblue text-maroon hover:bg-pastyblue">medium</Badge>
+    <Badge className="bg-[#ff9ce3] text-maroon hover:bg-[#ff9ce3]">low</Badge>
+    <Badge className="bg-pastypink text-maroon hover:bg-pastypink">manual</Badge>
+  </div>
+);

--- a/.design-sync/previews/BookmarkButton.tsx
+++ b/.design-sync/previews/BookmarkButton.tsx
@@ -1,0 +1,66 @@
+import { BookmarkButton } from "musicnerdweb";
+
+/**
+ * BookmarkButton is localStorage-backed: it reads `bookmarks_<userId>` on mount and
+ * derives its own `bookmarked` state from it. There is no controlled prop, so the only
+ * honest way to show the *filled* state is to seed the store the component actually reads.
+ * Two distinct userIds keep the two cells independent.
+ */
+const SEEDED_USER = "user-seeded-bookmarks";
+const EMPTY_USER = "user-no-bookmarks";
+
+if (typeof window !== "undefined") {
+  window.localStorage.setItem(
+    `bookmarks_${SEEDED_USER}`,
+    JSON.stringify([{ artistId: "artist-arca", artistName: "Arca" }]),
+  );
+  window.localStorage.removeItem(`bookmarks_${EMPTY_USER}`);
+}
+
+/**
+ * The two states side by side. Un-bookmarked is a white pill with a `pastypink` 2px border
+ * and pink label + icon; bookmarked inverts to a solid `pastypink` fill with white content.
+ * Both are locked to `w-[120px]` so the label swap ("Bookmark" → "Bookmarked") never
+ * reflows the row it sits in — that fixed width is the whole reason the component exists
+ * as a wrapper instead of a bare Button.
+ */
+export const States = () => (
+  <div className="flex flex-wrap items-center gap-3">
+    <BookmarkButton
+      userId={EMPTY_USER}
+      artistId="artist-jpegmafia"
+      artistName="JPEGMAFIA"
+    />
+    <BookmarkButton
+      userId={SEEDED_USER}
+      artistId="artist-arca"
+      artistName="Arca"
+    />
+  </div>
+);
+
+/**
+ * In the app this button sits on the artist header, to the right of the name and next to
+ * the other row actions. The fixed 120px width plus `flex-shrink-0` is what stops it from
+ * being squeezed by a long artist name.
+ */
+export const OnArtistHeader = () => (
+  <div className="w-full max-w-md rounded-xl border border-border bg-card p-4">
+    <div className="flex items-center gap-3">
+      <div className="h-14 w-14 flex-shrink-0 rounded-full bg-gradient-to-br from-pastypink to-pastyblue" />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-lg font-bold text-maroon">
+          Yaeji
+        </div>
+        <div className="truncate text-sm text-muted-foreground">
+          house · korean-american · added by @cxy
+        </div>
+      </div>
+      <BookmarkButton
+        userId={SEEDED_USER}
+        artistId="artist-arca"
+        artistName="Yaeji"
+      />
+    </div>
+  </div>
+);

--- a/.design-sync/previews/Button.tsx
+++ b/.design-sync/previews/Button.tsx
@@ -1,0 +1,68 @@
+import { Button } from "musicnerdweb";
+
+/**
+ * The full cva variant axis. Copy from the repo's own call sites: `outline` is the
+ * workhorse (admin tables, leaderboard range pickers), `destructive` is reserved for
+ * revoke/delete, `ghost` for low-emphasis row actions.
+ *
+ * Note the `default` variant has NO hover state — stock shadcn ships `hover:bg-primary/90`
+ * and it was removed here (DESIGN.md, known inconsistency #9). That is the shipped
+ * behavior, so the preview shows it truthfully rather than patching it.
+ */
+export const Variants = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Button>Add artist</Button>
+    <Button variant="secondary">Save draft</Button>
+    <Button variant="outline">Edit links</Button>
+    <Button variant="ghost">Dismiss</Button>
+    <Button variant="destructive">Revoke key</Button>
+    <Button variant="link">View on Spotify</Button>
+  </div>
+);
+
+/** Every size token. `icon` is a square 40px tap target used across the artist page. */
+export const Sizes = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Button size="sm">Small</Button>
+    <Button size="default">Default</Button>
+    <Button size="lg">Large</Button>
+    <Button size="icon" aria-label="Bookmark">★</Button>
+  </div>
+);
+
+/** Disabled is the one interactive state that renders statically. */
+export const Disabled = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Button disabled>Adding…</Button>
+    <Button variant="outline" disabled>
+      Searching…
+    </Button>
+    <Button variant="destructive" disabled>
+      Revoke key
+    </Button>
+  </div>
+);
+
+/**
+ * The brand move: shadcn Button restyled with the pastypink token via className.
+ * This is exactly how EditModeToggle and BookmarkButton apply brand color — DESIGN.md is
+ * explicit that identity lives at the custom-component layer, never by forking the primitive.
+ */
+export const BrandAccent = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Button
+      variant="outline"
+      size="sm"
+      className="border-pastypink/50 text-pastypink hover:bg-pastypink hover:text-white"
+    >
+      Edit mode
+    </Button>
+    <Button
+      variant="outline"
+      size="sm"
+      className="border-pastypink bg-pastypink text-white hover:bg-pastypink/90"
+    >
+      Bookmarked
+    </Button>
+  </div>
+);

--- a/.design-sync/previews/Calendar.tsx
+++ b/.design-sync/previews/Calendar.tsx
@@ -1,0 +1,49 @@
+import { Calendar } from "musicnerdweb";
+
+/**
+ * Single-month, single-day select — the base shape. Every day cell is a ghost Button
+ * (`buttonVariants({ variant: "ghost" })` at h-9 w-9), so the calendar inherits the
+ * button system rather than defining its own hit targets. The selected day flips to
+ * `bg-primary text-primary-foreground`; today gets `bg-accent`.
+ */
+export const Default = () => (
+  <Calendar
+    mode="single"
+    defaultMonth={new Date(2026, 6, 1)}
+    selected={new Date(2026, 6, 9)}
+    className="rounded-lg border bg-card"
+  />
+);
+
+/**
+ * The real in-app usage: the profile leaderboard date-range filter
+ * (`src/app/profile/DatePicker.tsx` — `mode="range"`, `numberOfMonths={2}`), which
+ * normally lives inside a Popover. Range middles are `bg-accent`, the two endpoints are
+ * `bg-primary`, and `showOutsideDays` leaves the neighbouring month's days visible in
+ * muted-foreground.
+ */
+export const ContributionRange = () => (
+  <Calendar
+    mode="range"
+    numberOfMonths={2}
+    defaultMonth={new Date(2026, 5, 1)}
+    selected={{ from: new Date(2026, 5, 14), to: new Date(2026, 6, 2) }}
+    className="rounded-lg border bg-card"
+  />
+);
+
+/**
+ * Disabled days — future dates can't be filtered on, since no submissions exist yet.
+ * `day_disabled` is `text-muted-foreground opacity-50`, which is a *very* light touch:
+ * on white it reads only barely differently from an outside-month day. Worth knowing
+ * before relying on it as the sole affordance.
+ */
+export const WithDisabledDays = () => (
+  <Calendar
+    mode="single"
+    defaultMonth={new Date(2026, 6, 1)}
+    selected={new Date(2026, 6, 6)}
+    disabled={{ after: new Date(2026, 6, 13) }}
+    className="rounded-lg border bg-card"
+  />
+);

--- a/.design-sync/previews/Card.tsx
+++ b/.design-sync/previews/Card.tsx
@@ -1,0 +1,103 @@
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Badge,
+} from "musicnerdweb";
+
+/**
+ * The canonical compound: Header (Title + Description) → Content → Footer.
+ * Card is stock shadcn — `rounded-lg border bg-card shadow-sm`, every section on `p-6`.
+ */
+export const Default = () => (
+  <Card className="max-w-sm">
+    <CardHeader>
+      <CardTitle>Jamie xx</CardTitle>
+      <CardDescription>
+        Electronic producer and DJ. 14 platform links collected by the community.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <div className="flex flex-wrap gap-2">
+        <Badge variant="secondary">electronic</Badge>
+        <Badge variant="secondary">house</Badge>
+        <Badge variant="outline">uk</Badge>
+      </div>
+    </CardContent>
+    <CardFooter className="gap-2">
+      <Button size="sm">Open artist</Button>
+      <Button size="sm" variant="outline">
+        Edit links
+      </Button>
+    </CardFooter>
+  </Card>
+);
+
+/**
+ * Header + Content only — the shape the leaderboard and admin tables use.
+ * Note the mauve title color (`#9b83a0`), applied as a literal at the call site;
+ * DESIGN.md flags this micro-palette as un-tokenized design debt.
+ */
+export const Sectioned = () => (
+  <Card className="max-w-md shadow-2xl">
+    <CardHeader className="text-center">
+      <CardTitle className="text-[#9b83a0]">Leaderboard</CardTitle>
+      <CardDescription>Top contributors this week</CardDescription>
+    </CardHeader>
+    <CardContent>
+      <ol className="space-y-2 text-sm">
+        {[
+          ["1", "vinylwitch", "142"],
+          ["2", "bpmhunter", "118"],
+          ["3", "crate.digger", "97"],
+        ].map(([rank, name, points]) => (
+          <li
+            key={rank}
+            className="flex items-center justify-between border-b pb-2 last:border-b-0"
+          >
+            <span className="flex items-center gap-3">
+              <span className="text-muted-foreground">{rank}</span>
+              <span className="font-medium">{name}</span>
+            </span>
+            <span className="text-muted-foreground">{points} pts</span>
+          </li>
+        ))}
+      </ol>
+    </CardContent>
+  </Card>
+);
+
+/**
+ * The competing surface language. DESIGN.md: the codebase mostly uses the custom
+ * `.glass` panel (`glass p-4 sm:p-5 space-y-3`, 16px radius) rather than Card for primary
+ * layout — two padding conventions coexist. Shown side by side so the difference is a
+ * deliberate choice, not an accident.
+ */
+export const CardVsGlassPanel = () => (
+  // The brand wash is load-bearing here, not decoration: `.glass` is rgba(255,255,255,0.55)
+  // with a backdrop-filter, so on a plain white page it is literally invisible. It only reads
+  // as glass over color — which is how it always appears in the app (over the hero gradient
+  // and artist imagery). Card, being opaque `bg-card`, looks identical on any backdrop.
+  <div className="rounded-2xl bg-gradient-to-br from-pastypink via-[#7c3aed] to-pastyblue p-6">
+    <div className="flex flex-wrap items-start gap-4">
+      <Card className="w-64">
+        <CardHeader>
+          <CardTitle className="text-lg">shadcn Card</CardTitle>
+          <CardDescription>Opaque bg-card, rounded-lg (8px), p-6</CardDescription>
+        </CardHeader>
+      </Card>
+      <div className="glass w-64 space-y-3 p-4 sm:p-5">
+        <h3 className="text-lg font-semibold leading-none tracking-tight text-maroon">
+          .glass panel
+        </h3>
+        <p className="text-sm text-maroon/80">
+          Translucent, blur(20px) saturate(180%), 16px radius — the primary surface.
+        </p>
+      </div>
+    </div>
+  </div>
+);

--- a/.design-sync/previews/Carousel.tsx
+++ b/.design-sync/previews/Carousel.tsx
@@ -1,0 +1,112 @@
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+  AspectRatio,
+  Badge,
+} from "musicnerdweb";
+
+const ARTISTS = [
+  ["Jamie xx", "electronic", "from-pastypink to-[#7c3aed]"],
+  ["Floating Points", "modal jazz", "from-pastyblue to-jellygreen"],
+  ["Yaeji", "house", "from-[#ff9ce3] to-pastyblue"],
+  ["Overmono", "breakbeat", "from-jellygreen to-pastypink"],
+  ["Kelela", "r&b", "from-[#7c3aed] to-pastyblue"],
+  ["Four Tet", "idm", "from-pastypink to-jellygreen"],
+];
+
+/**
+ * Featured-artists rail — three cards per view (`basis-1/3`). CarouselItem defaults to
+ * `basis-full` (one slide fills the viewport), so a multi-up rail is entirely a call-site
+ * decision: without an explicit basis you get a one-at-a-time hero, not a rail.
+ *
+ * The arrows are absolutely positioned OUTSIDE the track (`-left-12` / `-right-12`), so
+ * the Carousel needs horizontal room around it — hence `px-12` on the wrapper. Drop that
+ * padding and both buttons clip off the edge of the card.
+ */
+export const FeaturedArtists = () => (
+  <div className="w-[560px] px-12">
+    <Carousel className="w-full">
+      <CarouselContent>
+        {ARTISTS.map(([name, genre, grad]) => (
+          <CarouselItem key={name} className="basis-1/3">
+            <div className="overflow-hidden rounded-lg border bg-card shadow-sm">
+              <AspectRatio ratio={1}>
+                <div className={`h-full w-full bg-gradient-to-br ${grad}`} />
+              </AspectRatio>
+              <div className="space-y-1.5 p-3">
+                <p className="truncate text-sm font-medium leading-none">{name}</p>
+                <Badge variant="secondary">{genre}</Badge>
+              </div>
+            </div>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  </div>
+);
+
+/**
+ * The default `basis-full` shape: one slide at a time, a full-bleed hero for the
+ * homepage's featured artist. Because this Carousel hardcodes `loop: true` (a repo
+ * modification — stock shadcn leaves loop off), both arrows are always enabled; you never
+ * see the disabled end-of-track state that stock gives you for free.
+ */
+export const SingleSlideHero = () => (
+  <div className="w-[520px] px-12">
+    <Carousel className="w-full">
+      <CarouselContent>
+        {ARTISTS.slice(0, 3).map(([name, genre, grad]) => (
+          <CarouselItem key={name}>
+            <div
+              className={`flex h-40 items-end rounded-xl bg-gradient-to-br ${grad} p-4`}
+            >
+              <div>
+                <p className="text-xl font-semibold text-white drop-shadow">{name}</p>
+                <p className="text-sm text-white/80">Featured this week · {genre}</p>
+              </div>
+            </div>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  </div>
+);
+
+/**
+ * A text-only rail — the "recently added" activity strip. Same `basis-1/3` sizing as the
+ * artwork rail, so the gutter that CarouselContent's `-ml-4` / CarouselItem's `pl-4` create
+ * is legible without artwork carrying it. Note `basis-1/2` renders unevenly here: with
+ * `loop: true` embla can settle mid-snap, so odd slide counts per view are safer.
+ */
+export const CompactRail = () => (
+  <div className="w-[560px] px-12">
+    <Carousel className="w-full">
+      <CarouselContent>
+        {[
+          ["Overmono", "Deezer + Tidal added"],
+          ["Kelela", "MusicBrainz ID resolved"],
+          ["Four Tet", "Bandcamp link approved"],
+          ["Yaeji", "Apple Music mapped"],
+          ["Jamie xx", "Beatport link approved"],
+          ["Floating Points", "Wikidata ID resolved"],
+        ].map(([name, note]) => (
+          <CarouselItem key={name} className="basis-1/3">
+            <div className="rounded-lg border bg-card p-4">
+              <p className="font-medium leading-none">{name}</p>
+              <p className="mt-1.5 truncate text-xs text-muted-foreground">{note}</p>
+            </div>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  </div>
+);

--- a/.design-sync/previews/Checkbox.tsx
+++ b/.design-sync/previews/Checkbox.tsx
@@ -1,0 +1,102 @@
+import { Checkbox, Label } from "musicnerdweb";
+
+/**
+ * Every state the primitive encodes. 16px square, `border-primary`, and on check it fills
+ * with `bg-primary` — which in this app resolves to the brand pink, so Checkbox is one of
+ * the few primitives where brand color reaches the semantic token layer unaided.
+ *
+ * BUG VISIBLE HERE: `indeterminate` renders the Check icon but NO fill. The Radix Indicator
+ * is shown for both `checked` and `indeterminate`, while the background is gated on
+ * `data-[state=checked]` only — so indeterminate paints a checkmark on a white square, which
+ * reads as "checked, unstyled" rather than "partially selected". Stock shadcn shows a dash.
+ * The admin select-all header hits this on every partial page selection.
+ */
+export const States = () => (
+  <div className="flex flex-col gap-3">
+    <div className="flex items-center gap-2">
+      <Checkbox id="cb-unchecked" />
+      <Label htmlFor="cb-unchecked">Unchecked</Label>
+    </div>
+    <div className="flex items-center gap-2">
+      <Checkbox id="cb-checked" defaultChecked />
+      <Label htmlFor="cb-checked">Checked</Label>
+    </div>
+    <div className="flex items-center gap-2">
+      <Checkbox id="cb-ind" checked="indeterminate" />
+      <Label htmlFor="cb-ind">Indeterminate (select-all, page partially selected)</Label>
+    </div>
+    <div className="flex items-center gap-2">
+      <Checkbox id="cb-dis" className="peer" disabled />
+      <Label htmlFor="cb-dis">Disabled</Label>
+    </div>
+    <div className="flex items-center gap-2">
+      <Checkbox id="cb-dis-checked" className="peer" disabled defaultChecked />
+      <Label htmlFor="cb-dis-checked">Disabled + checked</Label>
+    </div>
+  </div>
+);
+
+/**
+ * The canonical call site: the row-selection column of the admin UGC table (columns.tsx).
+ * Header checkbox is `indeterminate` when some-but-not-all page rows are selected; each row
+ * gets an `aria-label`-only checkbox with no visible Label. Note the header reads as an
+ * unfilled checkmark rather than a dash — see the `States` cell for why.
+ */
+export const TableSelection = () => (
+  <div className="w-full max-w-2xl overflow-hidden rounded-md border border-input">
+    <table className="w-full text-sm">
+      <thead className="border-b border-input bg-muted/50">
+        <tr className="text-left">
+          <th className="w-10 px-3 py-2">
+            <Checkbox checked="indeterminate" aria-label="Select all" />
+          </th>
+          <th className="px-3 py-2 font-medium">Artist</th>
+          <th className="px-3 py-2 font-medium">Platform</th>
+          <th className="px-3 py-2 font-medium">Contributor</th>
+        </tr>
+      </thead>
+      <tbody>
+        {[
+          { a: "Yaeji", p: "Bandcamp", u: "0xkim.eth", sel: true },
+          { a: "Arca", p: "SoundCloud", u: "nerdvana", sel: true },
+          { a: "Floating Points", p: "Deezer", u: "sam.b", sel: false },
+          { a: "Jamie xx", p: "Apple Music", u: "0xkim.eth", sel: false },
+        ].map((r) => (
+          <tr key={r.a} className="border-b border-input/60 last:border-0">
+            <td className="px-3 py-2">
+              <Checkbox defaultChecked={r.sel} aria-label={`Select ${r.a}`} />
+            </td>
+            <td className="px-3 py-2">{r.a}</td>
+            <td className="px-3 py-2 text-muted-foreground">{r.p}</td>
+            <td className="px-3 py-2 text-muted-foreground">{r.u}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+/**
+ * A checklist of platforms — the shape a "which links to sync" filter takes. Worth looking at
+ * for density: at 16px with `bg-primary` pink fill and a hairline unchecked border, the
+ * checked and unchecked rows carry very different visual weight in a stacked list.
+ */
+export const PlatformFilter = () => (
+  <div className="w-full max-w-xs space-y-3 rounded-lg border border-input p-4">
+    <p className="text-sm font-semibold">Sync ID mappings for</p>
+    {[
+      { id: "deezer", label: "Deezer", on: true },
+      { id: "apple", label: "Apple Music", on: true },
+      { id: "musicbrainz", label: "MusicBrainz", on: true },
+      { id: "tidal", label: "Tidal", on: false },
+      { id: "ytm", label: "YouTube Music", on: false },
+    ].map((p) => (
+      <div key={p.id} className="flex items-center gap-2">
+        <Checkbox id={`pf-${p.id}`} defaultChecked={p.on} />
+        <Label htmlFor={`pf-${p.id}`} className="font-normal">
+          {p.label}
+        </Label>
+      </div>
+    ))}
+  </div>
+);

--- a/.design-sync/previews/Dialog.tsx
+++ b/.design-sync/previews/Dialog.tsx
@@ -1,0 +1,70 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from "musicnerdweb";
+
+/**
+ * Rendered `open` so the open state is what the card actually shows — a closed Dialog
+ * renders nothing. Ported from the admin "Create MCP API Key" modal, which is the
+ * canonical Dialog composition in this repo.
+ *
+ * `modal={false}` keeps Radix from marking the rest of the page inert and locking scroll
+ * inside the preview frame; it does not change how the content itself renders.
+ *
+ * Note DialogContent hardcodes `dark:bg-gray-900` instead of the `bg-background` token
+ * (DESIGN.md known inconsistency #12) — shipped behavior, shown as-is.
+ */
+export const Open = () => (
+  <Dialog open modal={false}>
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Create MCP API Key</DialogTitle>
+        <DialogDescription>
+          Enter a label to identify this key (e.g. agent name or purpose).
+        </DialogDescription>
+      </DialogHeader>
+      <div className="space-y-2">
+        <Label htmlFor="key-label">Label</Label>
+        <Input
+          id="key-label"
+          placeholder="id-mapping-agent"
+          defaultValue="id-mapping-agent"
+          className="h-10 rounded-md border border-input px-3 py-2"
+        />
+      </div>
+      <DialogFooter className="gap-2">
+        <Button variant="outline">Cancel</Button>
+        <Button>Create key</Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+);
+
+/**
+ * A destructive confirmation — the other shape Dialog is used for in admin
+ * (revoke key, delete submission).
+ */
+export const Destructive = () => (
+  <Dialog open modal={false}>
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Revoke this key?</DialogTitle>
+        <DialogDescription>
+          `id-mapping-agent` will immediately lose write access to the MCP server. This
+          cannot be undone.
+        </DialogDescription>
+      </DialogHeader>
+      <DialogFooter className="gap-2">
+        <Button variant="outline">Cancel</Button>
+        <Button variant="destructive">Revoke key</Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+);

--- a/.design-sync/previews/Drawer.tsx
+++ b/.design-sync/previews/Drawer.tsx
@@ -1,0 +1,95 @@
+import {
+  Button,
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  Badge,
+} from "musicnerdweb";
+
+/**
+ * Drawer is vaul, not Radix: it portals to document.body and its content is `fixed inset-x-0
+ * bottom-0`. It renders nothing closed, so `open` is forced. `modal={false}` keeps vaul from
+ * marking the page inert / locking scroll inside the preview frame — it does not change how the
+ * content itself renders. Positioning classes are left alone; the card viewport is sized to fit
+ * the sheet plus its overlay.
+ *
+ * No Drawer consumer exists in the repo yet, so this composes the mobile counterpart of the
+ * artist-page "add artist data" flow.
+ */
+export const Open = () => (
+  <Drawer open modal={false}>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>Add a link for Four Tet</DrawerTitle>
+          <DrawerDescription>
+            Pick a platform. Your submission is reviewed before it goes live.
+          </DrawerDescription>
+        </DrawerHeader>
+        <div className="grid grid-cols-2 gap-2 px-4">
+          <Button variant="outline" className="justify-start">
+            Spotify
+          </Button>
+          <Button variant="outline" className="justify-start">
+            Bandcamp
+          </Button>
+          <Button variant="outline" className="justify-start">
+            SoundCloud
+          </Button>
+          <Button variant="outline" className="justify-start">
+            Deezer
+          </Button>
+        </div>
+        <DrawerFooter>
+          <Button>Continue</Button>
+          <DrawerClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+  </Drawer>
+);
+
+/**
+ * A denser sheet: the mobile moderation queue for a UGC submission. Exercises DrawerHeader with
+ * secondary metadata and a two-action footer (approve / reject).
+ */
+export const ModerationSheet = () => (
+  <Drawer open modal={false}>
+      <DrawerContent>
+        <DrawerHeader>
+          <div className="flex items-center gap-2">
+            <DrawerTitle>Review submission</DrawerTitle>
+            <Badge>listen</Badge>
+          </div>
+          <DrawerDescription>
+            Submitted by @vinylghost, 2 hours ago.
+          </DrawerDescription>
+        </DrawerHeader>
+        <div className="space-y-2 px-4 text-sm">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Artist</span>
+            <span className="font-medium">Jamie xx</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Platform</span>
+            <span className="font-medium">Bandcamp</span>
+          </div>
+          <p className="break-all rounded-md bg-muted px-2 py-1.5 font-mono text-xs">
+            bandcamp.com/jamiexx
+          </p>
+        </div>
+        <DrawerFooter className="flex-row gap-2">
+          <Button className="flex-1">Approve</Button>
+          <DrawerClose asChild>
+            <Button variant="outline" className="flex-1">
+              Reject
+            </Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+  </Drawer>
+);

--- a/.design-sync/previews/DropdownMenu.tsx
+++ b/.design-sync/previews/DropdownMenu.tsx
@@ -1,0 +1,99 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  DropdownMenuCheckboxItem,
+} from "musicnerdweb";
+
+/**
+ * A closed DropdownMenu renders nothing (content is portaled + `fixed`), so `defaultOpen` is
+ * required for the card to show anything. Positioning classes are untouched — the card's
+ * viewport is sized around the floating panel instead.
+ *
+ * Composition mirrors the nav account menu in PrivyLogin.tsx (Leaderboard / User Profile /
+ * theme / Log Out).
+ */
+export const Open = () => (
+  <div className="flex min-h-[400px] items-start justify-center pt-6">
+    <DropdownMenu defaultOpen modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">@vinylghost</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="center" sideOffset={8} className="w-44">
+        <DropdownMenuLabel>My account</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>Leaderboard</DropdownMenuItem>
+        <DropdownMenuItem>User Profile</DropdownMenuItem>
+        <DropdownMenuItem>Dark mode</DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>Log Out</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  </div>
+);
+
+/**
+ * The artist-page "add artist data" picker (AddArtistDataOptions.tsx): a scrollable list of
+ * platform link examples, with the pink focus tint the repo applies to those items.
+ */
+export const PlatformPicker = () => (
+  <div className="flex min-h-[400px] items-start justify-center pt-6">
+    <DropdownMenu defaultOpen modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="h-11">
+          Add artist data
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="center"
+        sideOffset={8}
+        className="max-h-52 w-56 overflow-auto"
+      >
+        <DropdownMenuItem className="cursor-pointer text-xs">
+          bandcamp.com/artist-name
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer text-xs">
+          deezer.com/artist/12345
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer text-xs">
+          instagram.com/artist-name
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer text-xs">
+          soundcloud.com/artist-name
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer text-xs">
+          open.spotify.com/artist/1a2b3c
+        </DropdownMenuItem>
+        <DropdownMenuItem className="cursor-pointer text-xs" disabled>
+          x.com/artist-name
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  </div>
+);
+
+/**
+ * Checkbox items — the coverage filter on the Agent Work tab. Sweeps the checked indicator
+ * and the `pl-8` indent variant of the item.
+ */
+export const WithCheckboxes = () => (
+  <div className="flex min-h-[400px] items-start justify-center pt-6">
+    <DropdownMenu defaultOpen modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">Platforms</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="center" sideOffset={8} className="w-52">
+        <DropdownMenuLabel>Show mappings for</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuCheckboxItem checked>Deezer</DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem checked>Apple Music</DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem>MusicBrainz</DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem>Tidal</DropdownMenuCheckboxItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  </div>
+);

--- a/.design-sync/previews/EditModeToggle.tsx
+++ b/.design-sync/previews/EditModeToggle.tsx
@@ -1,0 +1,39 @@
+import { EditModeToggle } from "musicnerdweb";
+
+/**
+ * EditModeToggle reads `EditModeContext` and returns `null` unless `canEdit` is true —
+ * so it only ever renders for whitelisted contributors and admins. The design-sync
+ * provider stack already supplies `EditModeProvider canEdit`, which is why it appears
+ * here at all.
+ *
+ * Resting state: an outline Button restyled with the brand token —
+ * `border-pastypink/50 text-pastypink`, pencil icon, "Edit". The hover inversion
+ * (solid pink fill, white text) does not fire in a static capture, so this shows the
+ * resting state truthfully rather than faking it.
+ */
+export const Default = () => (
+  <div className="flex items-center gap-2">
+    <EditModeToggle />
+  </div>
+);
+
+/**
+ * Its real home: pinned to the right of an artist-page section heading, where it flips
+ * the surrounding link grid between read and write. Shown at the same scale it appears
+ * in the app — deliberately small, low-emphasis, and the only pink thing in the row.
+ */
+export const OnSectionHeader = () => (
+  <div className="w-full max-w-md rounded-xl border border-border bg-card p-4">
+    <div className="mb-3 flex items-center justify-between">
+      <h3 className="text-sm font-bold uppercase tracking-wide text-maroon">
+        Listen
+      </h3>
+      <EditModeToggle />
+    </div>
+    <ul className="space-y-1.5 text-sm text-muted-foreground">
+      <li>Spotify · open.spotify.com/artist/2nvl0N9GwyX69RRBMEZ4OD</li>
+      <li>Bandcamp · yaeji.bandcamp.com</li>
+      <li>SoundCloud · soundcloud.com/yaeji</li>
+    </ul>
+  </div>
+);

--- a/.design-sync/previews/Footer.tsx
+++ b/.design-sync/previews/Footer.tsx
@@ -1,0 +1,23 @@
+import { Footer } from "musicnerdweb";
+
+/**
+ * The whole component is one line of copy — "Made in Seattle by @cxy @clt and friends" —
+ * in `text-maroon`, bold, `text-[14px]` on mobile stepping up to `text-[25px]` at `sm`.
+ * The handles are underlined anchors. There is no border, no background, no nav: the
+ * footer is intentionally a signature, not a sitemap.
+ *
+ * It ships `mt-auto`, which only does anything inside a flex column — so the wrapper here
+ * is a min-height flex column that pins it to the bottom, exactly as `layout.tsx` does.
+ * Without that wrapper the `mt-auto` is a no-op and the component reads as floating text.
+ */
+export const Default = () => (
+  <div className="flex h-[220px] w-full max-w-2xl flex-col rounded-xl border border-border bg-background">
+    <div className="flex-1 px-6 py-6">
+      <p className="text-sm text-muted-foreground">
+        …end of the artist grid. Page content ends here; the footer is pushed to the
+        bottom of the viewport by <code className="text-foreground">mt-auto</code>.
+      </p>
+    </div>
+    <Footer />
+  </div>
+);

--- a/.design-sync/previews/Form.tsx
+++ b/.design-sync/previews/Form.tsx
@@ -1,0 +1,189 @@
+import * as React from "react";
+import { useForm } from "react-hook-form";
+import {
+  Button,
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  Textarea,
+} from "musicnerdweb";
+
+/**
+ * `Form` is just react-hook-form's `FormProvider` re-exported — it renders no DOM. What the
+ * design system actually owns is the FormItem / FormLabel / FormControl / FormDescription /
+ * FormMessage stack: `space-y-2` between parts, `text-sm text-muted-foreground` for the
+ * description, `text-sm font-medium text-destructive` for the message, and FormLabel
+ * flipping to `text-destructive` when the field has an error.
+ *
+ * NOTE the Input here carries hand-added chrome (`h-10 rounded-md border border-input`).
+ * FormControl does not supply any — and the base Input has no border or height — so a
+ * literal port of AddArtist.tsx (`<Input {...field} />`) renders an invisible field.
+ */
+export const Default = () => {
+  const form = useForm({
+    defaultValues: { artistUrl: "https://open.spotify.com/artist/2VZNmg3v9nbVMnRkZadyi5" },
+  });
+
+  return (
+    <Form {...form}>
+      <form className="w-full max-w-lg space-y-6">
+        <FormField
+          control={form.control}
+          name="artistUrl"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Artist URL</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="Paste a Spotify or Deezer artist URL"
+                  className="h-10 rounded-md border border-input px-3 py-2"
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription>
+                Copy the URL from the artist&apos;s Spotify or Deezer page.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="button" className="bg-pastypink text-white hover:bg-pastypink/90">
+          Add artist
+        </Button>
+      </form>
+    </Form>
+  );
+};
+
+/**
+ * The error state — the whole reason FormMessage exists. FormLabel turns `text-destructive`,
+ * FormMessage prints the resolver message, and FormControl sets `aria-invalid`.
+ *
+ * The error is injected with `setError` in an effect because a static render never runs a
+ * submit; this is exactly the state a failed urlmap regex check produces.
+ */
+export const WithError = () => {
+  const form = useForm({ defaultValues: { artistUrl: "sondcloud.com/arca1000000" } });
+
+  React.useEffect(() => {
+    form.setError("artistUrl", {
+      type: "manual",
+      message: "That host doesn't match any platform in urlmap.",
+    });
+  }, [form]);
+
+  const error = form.formState.errors.artistUrl;
+
+  return (
+    <Form {...form}>
+      <form className="w-full max-w-lg space-y-6">
+        <FormField
+          control={form.control}
+          name="artistUrl"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Artist URL</FormLabel>
+              <FormControl>
+                <Input
+                  className={`h-10 rounded-md border px-3 py-2 ${
+                    error ? "border-destructive" : "border-input"
+                  }`}
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription>
+                Supported: Spotify, Deezer, Bandcamp, SoundCloud, Apple Music.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="button" className="bg-pastypink text-white hover:bg-pastypink/90">
+          Add artist
+        </Button>
+      </form>
+    </Form>
+  );
+};
+
+/**
+ * A multi-field form, which is where the `space-y-2` inside FormItem and the outer field
+ * rhythm actually get tested. Mixes Input and Textarea controls through FormControl's Slot.
+ */
+export const MultiField = () => {
+  const form = useForm({
+    defaultValues: {
+      label: "id-mapping-agent",
+      spotifyUrl: "https://open.spotify.com/artist/6UBAOAqvpz7GwxLIleJm3O",
+      notes: "",
+    },
+  });
+
+  return (
+    <Form {...form}>
+      <form className="w-full max-w-lg space-y-5">
+        <FormField
+          control={form.control}
+          name="label"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Key label</FormLabel>
+              <FormControl>
+                <Input
+                  className="h-10 rounded-md border border-input px-3 py-2"
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription>Shown in the MCP audit log for every write.</FormDescription>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="spotifyUrl"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Spotify artist URL</FormLabel>
+              <FormControl>
+                <Input
+                  className="h-10 rounded-md border border-input px-3 py-2"
+                  {...field}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="notes"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Reviewer notes</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="Why is this mapping high-confidence?"
+                  className="min-h-[80px]"
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription>Optional — attached to the UGC submission.</FormDescription>
+            </FormItem>
+          )}
+        />
+        <div className="flex gap-2">
+          <Button type="button" variant="outline">
+            Cancel
+          </Button>
+          <Button type="button" className="bg-pastypink text-white hover:bg-pastypink/90">
+            Submit
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+};

--- a/.design-sync/previews/Input.tsx
+++ b/.design-sync/previews/Input.tsx
@@ -1,0 +1,132 @@
+import { Input, Label } from "musicnerdweb";
+
+/**
+ * THE MOST IMPORTANT FACT ABOUT THIS COMPONENT.
+ *
+ * `Input` was stripped of its chrome: the base class list has NO border, NO fixed height
+ * (`h-10`), and NO focus ring — only `rounded-md bg-background px-3 py-2`. On a light
+ * background it renders as an invisible rectangle. Stock shadcn ships
+ * `h-10 border border-input focus-visible:ring-2`; all three were removed here.
+ *
+ * The left cell is the shipped default. The right cell is what every real form in the app
+ * has to re-add by hand via className. That re-adding is the actual convention.
+ */
+export const BareVsStyled = () => (
+  <div className="grid w-full max-w-xl gap-6 sm:grid-cols-2">
+    <div className="space-y-2">
+      <Label className="text-muted-foreground">Shipped default (no border)</Label>
+      <Input placeholder="Search for an artist…" />
+      <p className="text-xs text-muted-foreground">
+        `&lt;Input /&gt;` with no className. There is a real input here.
+      </p>
+    </div>
+    <div className="space-y-2">
+      <Label>What call sites actually write</Label>
+      <Input
+        placeholder="Search for an artist…"
+        className="h-10 rounded-md border border-input px-3 py-2"
+      />
+      <p className="text-xs text-muted-foreground">
+        `h-10 rounded-md border border-input` bolted on at the call site.
+      </p>
+    </div>
+  </div>
+);
+
+/**
+ * The nav SearchBar composition: a leading Lucide magnifier absolutely positioned over a
+ * `pl-10` Input. Ported from SearchBar.tsx, with the border added so the field is visible.
+ */
+export const WithLeadingIcon = () => (
+  <div className="relative w-full max-w-[400px]">
+    <Input
+      type="text"
+      placeholder="Search for an artist..."
+      defaultValue="Arca"
+      className="h-10 rounded-md border border-input pl-10 pr-3 py-2"
+    />
+    <svg
+      className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  </div>
+);
+
+/** The static states an Input can be captured in: empty, filled, disabled, read-only. */
+export const States = () => {
+  const chrome = "h-10 rounded-md border border-input px-3 py-2";
+  return (
+    <div className="grid w-full max-w-md gap-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="in-empty">Artist name</Label>
+        <Input id="in-empty" placeholder="e.g. Yaeji" className={chrome} />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="in-filled">Spotify URL</Label>
+        <Input
+          id="in-filled"
+          defaultValue="https://open.spotify.com/artist/2VZNmg3v9nbVMnRkZadyi5"
+          className={chrome}
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="in-disabled">Wallet address</Label>
+        <Input
+          id="in-disabled"
+          disabled
+          defaultValue="0x4a1e…9c02 (linked via Privy)"
+          className={chrome}
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="in-invalid">Bandcamp URL</Label>
+        <Input
+          id="in-invalid"
+          defaultValue="bandcamp/notarealartist"
+          aria-invalid
+          className="h-10 rounded-md border border-destructive px-3 py-2"
+        />
+        <p className="text-sm font-medium text-destructive">
+          Doesn&apos;t match the Bandcamp URL pattern in urlmap.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * The `glass-subtle` wrapper pattern from AddArtistData: the Input keeps its borderless
+ * default and the surrounding glass pill supplies the chrome. This is the one place the
+ * stripped-bare default is actually load-bearing rather than a bug.
+ *
+ * `.glass-subtle` is a translucent white — it needs a saturated backdrop to be visible at
+ * all, so the card sits on the brand gradient the artist page uses.
+ */
+export const GlassWrapper = () => (
+  <div className="w-full rounded-xl bg-gradient-to-br from-pastypink via-[#7c3aed] to-pastyblue p-8">
+    <div className="flex max-w-md gap-2">
+      <div className="glass-subtle flex h-11 flex-grow items-center rounded-lg px-3">
+        <Input
+          placeholder="Paste a profile link…"
+          defaultValue="https://soundcloud.com/jamie-xx"
+          className="w-full border-0 bg-transparent p-0 text-sm text-black outline-none placeholder:text-muted-foreground"
+        />
+      </div>
+      <button
+        type="button"
+        className="h-11 shrink-0 rounded-lg bg-pastypink px-4 text-sm font-medium text-white"
+      >
+        Submit
+      </button>
+    </div>
+  </div>
+);

--- a/.design-sync/previews/Label.tsx
+++ b/.design-sync/previews/Label.tsx
@@ -1,0 +1,77 @@
+import { Checkbox, Input, Label } from "musicnerdweb";
+
+/**
+ * Label is the thinnest wrapper in the kit: a Radix Label with a single, variant-less cva
+ * — `text-sm font-medium leading-none` plus the `peer-disabled:` pair. There is no size or
+ * tone axis to show, so the axis worth showing is *what it labels*.
+ */
+export const Default = () => (
+  <div className="w-full max-w-sm space-y-1.5">
+    <Label htmlFor="lb-artist">Artist name</Label>
+    <Input
+      id="lb-artist"
+      defaultValue="Floating Points"
+      className="h-10 rounded-md border border-input px-3 py-2"
+    />
+  </div>
+);
+
+/**
+ * `peer-disabled:opacity-70` is the only state the cva encodes, and it is a footgun: it fires
+ * off the SIBLING control's `peer` marker, so a disabled control that forgot `className="peer"`
+ * leaves its label at full strength — indistinguishable from an enabled field.
+ *
+ * The two rows below are the whole axis: enabled at full strength, and a disabled control
+ * whose Label has dimmed itself to 70%. The footgun is that this ONLY happens if the control
+ * carries `className="peer"` — a disabled control that forgot the marker leaves its label at
+ * full strength, indistinguishable from row 1. Worth noting that 70% opacity is a very quiet
+ * disabled signal to begin with.
+ */
+export const PeerDisabled = () => (
+  <div className="flex w-full max-w-lg flex-col gap-4">
+    <div className="flex items-center gap-2">
+      <Checkbox id="lb-enabled" className="peer" defaultChecked />
+      <Label htmlFor="lb-enabled" className="text-base">
+        Whitelisted contributor — enabled
+      </Label>
+    </div>
+    <div className="flex items-center gap-2">
+      <Checkbox id="lb-peer" className="peer" disabled />
+      <Label htmlFor="lb-peer" className="text-base">
+        Admin role — disabled, label dimmed via peer
+      </Label>
+    </div>
+  </div>
+);
+
+/**
+ * The repo leans on Label for two things it wasn't really designed for: an inline error
+ * string (AddArtistData renders rejection text as a red `<Label>`), and admin field
+ * captions. Both are just className overrides on the same primitive — shown as shipped.
+ */
+export const AsErrorText = () => (
+  <div className="w-full max-w-md space-y-3">
+    <div className="space-y-1.5">
+      <Label htmlFor="lb-url">Platform link</Label>
+      <Input
+        id="lb-url"
+        defaultValue="https://sondcloud.com/arca1000000"
+        className="h-10 rounded-md border border-destructive px-3 py-2"
+      />
+      <Label className="text-xs leading-relaxed text-red-600">
+        We couldn&apos;t match that host to any platform in urlmap. Supported: Spotify,
+        Deezer, Bandcamp, SoundCloud, Apple Music.
+      </Label>
+    </div>
+    <div className="space-y-1.5">
+      <Label htmlFor="lb-key" className="uppercase tracking-wide text-muted-foreground">
+        MCP key label
+      </Label>
+      <Input
+        id="lb-key"
+        defaultValue="id-mapping-agent"
+        className="h-10 rounded-md border border-input px-3 py-2"
+      />
+    </div>
+  </div>
+);

--- a/.design-sync/previews/LoadingPage.tsx
+++ b/.design-sync/previews/LoadingPage.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from "react";
+import { LoadingPage } from "musicnerdweb";
+
+/**
+ * Two capture-harness facts drive this file:
+ *
+ * 1. LoadingPage is a `fixed inset-0 z-[9999]` full-viewport scrim. Dropped straight into a
+ *    preview grid it blankets the whole sheet. The wrapper below carries an inline
+ *    `transform: translateZ(0)`, which makes it the containing block for `position: fixed`
+ *    descendants, bounding the overlay to this card. (Inline style, not a Tailwind arbitrary
+ *    property — the DS stylesheet does not emit those.)
+ *
+ * 2. The spinner is `<img src="/spinner.svg">`. The preview server serves only the bundle dir
+ *    and its MIME table has no `.svg` entry, so the request 404s / mis-types and the browser
+ *    paints a broken-image glyph. `useRealSpinner` re-points that exact <img> at the REAL
+ *    public/spinner.svg, inlined as a data URI — so the card shows the shipped asset, not a
+ *    substitute. Remove this shim once the harness serves public/ with an svg MIME type.
+ */
+const SPINNER_DATA_URI = "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiBzdHlsZT0ibWFyZ2luOiBhdXRvOyBiYWNrZ3JvdW5kOiBub25lOyBkaXNwbGF5OiBibG9jazsgc2hhcGUtcmVuZGVyaW5nOiBhdXRvOyIgd2lkdGg9IjIwMHB4IiBoZWlnaHQ9IjIwMHB4IiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ieE1pZFlNaWQiPgo8ZyB0cmFuc2Zvcm09InJvdGF0ZSgwIDUwIDUwKSI+CiAgPHJlY3QgeD0iMjkuNSIgeT0iOS41IiByeD0iMjAuNSIgcnk9IjIwLjUiIHdpZHRoPSI0MSIgaGVpZ2h0PSI0MSIgZmlsbD0iI2ZmOWFlMSI+CiAgICA8YW5pbWF0ZSBhdHRyaWJ1dGVOYW1lPSJvcGFjaXR5IiB2YWx1ZXM9IjE7MCIga2V5VGltZXM9IjA7MSIgZHVyPSIwLjYyNXMiIGJlZ2luPSItMC41NDY4NzVzIiByZXBlYXRDb3VudD0iaW5kZWZpbml0ZSI+PC9hbmltYXRlPgogIDwvcmVjdD4KPC9nPjxnIHRyYW5zZm9ybT0icm90YXRlKDQ1IDUwIDUwKSI+CiAgPHJlY3QgeD0iMjkuNSIgeT0iOS41IiByeD0iMjAuNSIgcnk9IjIwLjUiIHdpZHRoPSI0MSIgaGVpZ2h0PSI0MSIgZmlsbD0iI2ZmOWFlMSI+CiAgICA8YW5pbWF0ZSBhdHRyaWJ1dGVOYW1lPSJvcGFjaXR5IiB2YWx1ZXM9IjE7MCIga2V5VGltZXM9IjA7MSIgZHVyPSIwLjYyNXMiIGJlZ2luPSItMC40Njg3NXMiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIj48L2FuaW1hdGU+CiAgPC9yZWN0Pgo8L2c+PGcgdHJhbnNmb3JtPSJyb3RhdGUoOTAgNTAgNTApIj4KICA8cmVjdCB4PSIyOS41IiB5PSI5LjUiIHJ4PSIyMC41IiByeT0iMjAuNSIgd2lkdGg9IjQxIiBoZWlnaHQ9IjQxIiBmaWxsPSIjZmY5YWUxIj4KICAgIDxhbmltYXRlIGF0dHJpYnV0ZU5hbWU9Im9wYWNpdHkiIHZhbHVlcz0iMTswIiBrZXlUaW1lcz0iMDsxIiBkdXI9IjAuNjI1cyIgYmVnaW49Ii0wLjM5MDYyNXMiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIj48L2FuaW1hdGU+CiAgPC9yZWN0Pgo8L2c+PGcgdHJhbnNmb3JtPSJyb3RhdGUoMTM1IDUwIDUwKSI+CiAgPHJlY3QgeD0iMjkuNSIgeT0iOS41IiByeD0iMjAuNSIgcnk9IjIwLjUiIHdpZHRoPSI0MSIgaGVpZ2h0PSI0MSIgZmlsbD0iI2ZmOWFlMSI+CiAgICA8YW5pbWF0ZSBhdHRyaWJ1dGVOYW1lPSJvcGFjaXR5IiB2YWx1ZXM9IjE7MCIga2V5VGltZXM9IjA7MSIgZHVyPSIwLjYyNXMiIGJlZ2luPSItMC4zMTI1cyIgcmVwZWF0Q291bnQ9ImluZGVmaW5pdGUiPjwvYW5pbWF0ZT4KICA8L3JlY3Q+CjwvZz48ZyB0cmFuc2Zvcm09InJvdGF0ZSgxODAgNTAgNTApIj4KICA8cmVjdCB4PSIyOS41IiB5PSI5LjUiIHJ4PSIyMC41IiByeT0iMjAuNSIgd2lkdGg9IjQxIiBoZWlnaHQ9IjQxIiBmaWxsPSIjZmY5YWUxIj4KICAgIDxhbmltYXRlIGF0dHJpYnV0ZU5hbWU9Im9wYWNpdHkiIHZhbHVlcz0iMTswIiBrZXlUaW1lcz0iMDsxIiBkdXI9IjAuNjI1cyIgYmVnaW49Ii0wLjIzNDM3NXMiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIj48L2FuaW1hdGU+CiAgPC9yZWN0Pgo8L2c+PGcgdHJhbnNmb3JtPSJyb3RhdGUoMjI1IDUwIDUwKSI+CiAgPHJlY3QgeD0iMjkuNSIgeT0iOS41IiByeD0iMjAuNSIgcnk9IjIwLjUiIHdpZHRoPSI0MSIgaGVpZ2h0PSI0MSIgZmlsbD0iI2ZmOWFlMSI+CiAgICA8YW5pbWF0ZSBhdHRyaWJ1dGVOYW1lPSJvcGFjaXR5IiB2YWx1ZXM9IjE7MCIga2V5VGltZXM9IjA7MSIgZHVyPSIwLjYyNXMiIGJlZ2luPSItMC4xNTYyNXMiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIj48L2FuaW1hdGU+CiAgPC9yZWN0Pgo8L2c+PGcgdHJhbnNmb3JtPSJyb3RhdGUoMjcwIDUwIDUwKSI+CiAgPHJlY3QgeD0iMjkuNSIgeT0iOS41IiByeD0iMjAuNSIgcnk9IjIwLjUiIHdpZHRoPSI0MSIgaGVpZ2h0PSI0MSIgZmlsbD0iI2ZmOWFlMSI+CiAgICA8YW5pbWF0ZSBhdHRyaWJ1dGVOYW1lPSJvcGFjaXR5IiB2YWx1ZXM9IjE7MCIga2V5VGltZXM9IjA7MSIgZHVyPSIwLjYyNXMiIGJlZ2luPSItMC4wNzgxMjVzIiByZXBlYXRDb3VudD0iaW5kZWZpbml0ZSI+PC9hbmltYXRlPgogIDwvcmVjdD4KPC9nPjxnIHRyYW5zZm9ybT0icm90YXRlKDMxNSA1MCA1MCkiPgogIDxyZWN0IHg9IjI5LjUiIHk9IjkuNSIgcng9IjIwLjUiIHJ5PSIyMC41IiB3aWR0aD0iNDEiIGhlaWdodD0iNDEiIGZpbGw9IiNmZjlhZTEiPgogICAgPGFuaW1hdGUgYXR0cmlidXRlTmFtZT0ib3BhY2l0eSIgdmFsdWVzPSIxOzAiIGtleVRpbWVzPSIwOzEiIGR1cj0iMC42MjVzIiBiZWdpbj0iMHMiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIj48L2FuaW1hdGU+CiAgPC9yZWN0Pgo8L2c+CjwhLS0gW2xkaW9dIGdlbmVyYXRlZCBieSBodHRwczovL2xvYWRpbmcuaW8vIC0tPjwvc3ZnPg==";
+
+function useRealSpinner(ref: React.RefObject<HTMLDivElement>) {
+  useEffect(() => {
+    const img = ref.current?.querySelector<HTMLImageElement>('img[alt="Loading"]');
+    if (img) img.src = SPINNER_DATA_URI;
+  });
+}
+
+const Frame = ({ children }: { children: React.ReactNode }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useRealSpinner(ref as React.RefObject<HTMLDivElement>);
+  return (
+    <div
+      ref={ref}
+      className="relative h-64 w-full max-w-md overflow-hidden rounded-xl border border-border bg-card"
+      style={{ transform: "translateZ(0)" }}
+    >
+      {/* Real page content, so the scrim has something to veil. On a blank white card the
+          bg-white/80 + backdrop-blur-sm treatment would be completely invisible. */}
+      <div className="space-y-3 p-5">
+        <div className="text-xl font-bold text-maroon">Sudan Archives</div>
+        <div className="h-4 w-full rounded bg-muted" />
+        <div className="h-4 w-5/6 rounded bg-muted" />
+        <div className="h-28 w-full rounded-lg bg-gradient-to-br from-pastypink via-purple-600 to-pastyblue" />
+      </div>
+      {children}
+    </div>
+  );
+};
+
+/**
+ * Default state: an 80%-white blurred scrim over the page, with a white `rounded-xl shadow-lg`
+ * card holding the 48px spinner and the message. It also locks `body` scroll while mounted.
+ */
+export const Default = () => (
+  <Frame>
+    <LoadingPage />
+  </Frame>
+);
+
+/**
+ * `message` is the only prop. Call sites use it to name the operation being awaited — the
+ * add-artist flow names the artist being written, so the wait is attributable rather than generic.
+ */
+export const WithMessage = () => (
+  <Frame>
+    <LoadingPage message="Adding Yaeji…" />
+  </Frame>
+);

--- a/.design-sync/previews/PleaseLoginPage.tsx
+++ b/.design-sync/previews/PleaseLoginPage.tsx
@@ -1,0 +1,33 @@
+import { PleaseLoginPage } from "musicnerdweb";
+
+/**
+ * The gate shown in place of any authenticated route. It is deliberately spare: a centered
+ * `text-2xl` bold heading and one `pastypink` Button whose click proxies to the real nav
+ * login button (`#login-btn`). Wrapped in a bounded, page-like frame so the centering is
+ * legible instead of collapsing to a bare stack of two elements.
+ *
+ * Note the button's hover is `hover:bg-gray-200` — a grey, not a pink tint. That is the
+ * shipped styling (DESIGN.md flags it as an inconsistency); the preview shows it as-is.
+ */
+const Page = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex h-[220px] w-full max-w-md items-center justify-center rounded-xl border border-border bg-background">
+    {children}
+  </div>
+);
+
+/** Default copy — the generic route guard. */
+export const Default = () => (
+  <Page>
+    <PleaseLoginPage />
+  </Page>
+);
+
+/**
+ * `text` is the only prop, and every real call site overrides it to name the thing being
+ * gated (profile, bookmarks, the add-artist flow) rather than leaving the generic string.
+ */
+export const CustomCopy = () => (
+  <Page>
+    <PleaseLoginPage text="Log in to add an artist to MusicNerd" />
+  </Page>
+);

--- a/.design-sync/previews/Popover.tsx
+++ b/.design-sync/previews/Popover.tsx
@@ -1,0 +1,87 @@
+import {
+  Button,
+  Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Badge,
+} from "musicnerdweb";
+
+/**
+ * Popover portals to document.body and positions itself `fixed` against its trigger, so it
+ * only renders when forced open — hence `defaultOpen`. Positioning classes are left alone;
+ * the card viewport is sized to fit the floating panel.
+ *
+ * Composition follows the profile DatePicker (the repo's only Popover), generalized to the
+ * artist-page "link details" affordance.
+ */
+export const Open = () => (
+  <div className="flex min-h-[360px] items-start justify-center pt-6">
+    <Popover defaultOpen>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Spotify link details</Button>
+      </PopoverTrigger>
+      <PopoverContent align="center" sideOffset={8}>
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <h4 className="text-sm font-semibold leading-none">Spotify</h4>
+            <p className="text-sm text-muted-foreground">
+              Added by @vinylghost on Mar 4, 2025.
+            </p>
+          </div>
+          <p className="break-all rounded-md bg-muted px-2 py-1.5 font-mono text-xs">
+            open.spotify.com/artist/4tZwfgrHOc3mvqYlEYSvVi
+          </p>
+          <div className="flex items-center gap-2">
+            <Badge>listen</Badge>
+            <span className="text-xs text-muted-foreground">Verified link</span>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  </div>
+);
+
+/**
+ * Wider panel with a form-ish body: the "add a platform link" flow. Shows that PopoverContent's
+ * default `w-72` is overridable and that padding survives a denser layout.
+ */
+export const WithActions = () => (
+  <div className="flex min-h-[360px] items-start justify-center pt-6">
+    <Popover defaultOpen>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Add link</Button>
+      </PopoverTrigger>
+      {/* Radix autofocuses the first field on open, which paints a native focus ring in the
+          capture; suppressed so the card shows the resting state. */}
+      <PopoverContent
+        align="center"
+        sideOffset={8}
+        className="w-80"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <h4 className="text-sm font-semibold leading-none">
+              Suggest a link for Jamie xx
+            </h4>
+            <p className="text-sm text-muted-foreground">
+              Submissions are reviewed by a moderator before they go live.
+            </p>
+          </div>
+          {/* Input ships with no border/height of its own — styled here so it reads as a field. */}
+          <Input
+            defaultValue="bandcamp.com/jamiexx"
+            className="h-10 w-full rounded-md border border-input px-3 py-2 text-sm"
+          />
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" size="sm">
+              Cancel
+            </Button>
+            <Button size="sm">Submit</Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  </div>
+);

--- a/.design-sync/previews/Select.tsx
+++ b/.design-sync/previews/Select.tsx
@@ -1,0 +1,96 @@
+import {
+  Label,
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "musicnerdweb";
+
+/**
+ * Rendered `open` — a closed Select shows only its trigger, and the listbox is the part
+ * worth reviewing. `modal={false}` stops Radix from marking the rest of the frame inert.
+ *
+ * SelectContent is PORTALED to document.body and positioned `fixed` by Radix. Do not try to
+ * re-anchor it inside the card with `className="relative"`: `cn()` is tailwind-merge, so
+ * `relative` REPLACES Radix's `fixed` and the -50% transform yanks the panel off-screen.
+ * Positioning is left alone here on purpose.
+ *
+ * Composition ported from the admin user-role filter (whitelisted-data-table.tsx), extended
+ * with a SelectLabel/SelectSeparator group so the full part inventory is on screen. Note the
+ * trigger DOES carry `h-10 border border-input` — unlike Input, Select was not stripped.
+ */
+export const Open = () => (
+  <div className="w-[220px] space-y-1.5">
+    <Label htmlFor="sel-role">Filter role</Label>
+    <Select open modal={false} defaultValue="Whitelisted">
+      <SelectTrigger id="sel-role" className="w-[220px]">
+        <SelectValue placeholder="Filter Role" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>Roles</SelectLabel>
+          <SelectItem value="All">All Users</SelectItem>
+          <SelectItem value="Admin">Admins</SelectItem>
+          <SelectItem value="Whitelisted">Whitelisted Users</SelectItem>
+          <SelectItem value="User">Users</SelectItem>
+        </SelectGroup>
+        <SelectSeparator />
+        <SelectGroup>
+          <SelectLabel>Moderation</SelectLabel>
+          <SelectItem value="Hidden">Hidden Users</SelectItem>
+          <SelectItem value="Banned" disabled>
+            Banned Users (coming soon)
+          </SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  </div>
+);
+
+/**
+ * Closed triggers — the only Select surface that renders inline. Left is the standard admin
+ * filter; right is the SourceCard "type" pill, which squashes the trigger down to a
+ * rounded-full 10px badge (`h-auto py-0.5 px-2 text-[10px]`) and colors it per source type.
+ * That badge-shaped trigger is a real, load-bearing override in this repo.
+ */
+export const Triggers = () => (
+  <div className="flex flex-wrap items-end gap-6">
+    <div className="space-y-1.5">
+      <Label>Placeholder (no value)</Label>
+      <Select>
+        <SelectTrigger className="w-[180px]">
+          <SelectValue placeholder="Filter Role" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="All">All Users</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+    <div className="space-y-1.5">
+      <Label>Disabled</Label>
+      <Select disabled defaultValue="Deezer">
+        <SelectTrigger className="w-[180px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="Deezer">Deezer</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+    <div className="space-y-1.5">
+      <Label>SourceCard type pill</Label>
+      <Select defaultValue="interview">
+        <SelectTrigger className="h-auto w-auto min-w-0 gap-1 rounded-full border border-purple-200 bg-purple-50 px-2 py-0.5 text-[10px] capitalize text-purple-700">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="interview">interview</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  </div>
+);

--- a/.design-sync/previews/SlidingText.tsx
+++ b/.design-sync/previews/SlidingText.tsx
@@ -1,0 +1,77 @@
+import { SlidingText } from "musicnerdweb";
+
+/**
+ * A vertical word carousel: it takes `ReactNode[]`, stacks them, and translates the stack
+ * up by one slot every `interval` ms until it reaches the last item — then it resets to 0
+ * and "expands" (stops animating). Each slot is clamped to the `.home-text-height` global
+ * (36px → 70px, fluid) and the outer div is `overflow-hidden`, so exactly one item shows.
+ *
+ * Because it animates on a timer, a static capture freezes one frame. That is the honest
+ * artifact — the interval here is stretched so the captured frame is a stable one.
+ *
+ * Two traps, both learned the hard way:
+ *  • Do NOT typeset slots with the `.home-text-h2` global. It looks like a pure type class
+ *    but globals.css also attaches `color: … !important` to it (`:first-child` → #ff9ce3,
+ *    everything else → #9b83a0), which silently overrides any `text-*` utility on the node.
+ *    Size the slots with plain Tailwind and keep colour under your own control.
+ *  • The source declares `transition-max-height`, which is not a real Tailwind utility, so
+ *    the collapse is instant rather than eased. Left as-is; that's the shipped behavior.
+ */
+
+/**
+ * Sizing rule for slots: the component wraps each node in a div whose `max-height` is the
+ * `.home-text-height` clamp (36→70px, fluid), but it never sets a `height`. So a node
+ * SHORTER than the clamp leaves the slot short of the window and the NEXT word peeks in
+ * underneath. Every node therefore gets a fixed `h-16` box — taller than the clamp at any
+ * viewport, so each slot fills the window exactly and only one word is ever visible.
+ */
+const SLOT = "flex h-16 items-center text-4xl font-bold";
+
+/**
+ * The homepage hero pattern this exists for: a fixed lead-in on the left, the rotating noun
+ * on the right. Slots are ReactNode, so each carries its own brand colour — the frame you
+ * catch is whichever word is up.
+ */
+export const HeroRotator = () => (
+  <div className="flex w-full max-w-xl items-center justify-center gap-3 rounded-xl border border-border bg-card px-6 py-6">
+    <span className="text-4xl font-bold text-maroon">Discover</span>
+    <SlidingText
+      interval={9000}
+      items={[
+        <span key="a" className={SLOT} style={{ color: "#ff9ce3" }}>
+          artists
+        </span>,
+        <span key="b" className={`${SLOT} text-pastyblue`}>
+          labels
+        </span>,
+        <span key="c" className={`${SLOT} text-jellygreen`}>
+          collectors
+        </span>,
+      ]}
+    />
+  </div>
+);
+
+/**
+ * The same machine over a saturated backdrop — the only context where the brand's glass and
+ * gradient surfaces actually read (`.glass` is white-on-white and invisible otherwise).
+ * Slots here are composites, not bare strings, which is the point of the `ReactNode[]` API.
+ */
+export const OnGradient = () => (
+  <div className="flex w-full max-w-xl items-center justify-center rounded-xl bg-gradient-to-br from-pastypink via-purple-600 to-pastyblue px-6 py-8">
+    <SlidingText
+      interval={9000}
+      items={[
+        <span key="a" className={`${SLOT} text-white`}>
+          Sudan Archives
+        </span>,
+        <span key="b" className={`${SLOT} text-white`}>
+          JPEGMAFIA
+        </span>,
+        <span key="c" className={`${SLOT} text-white`}>
+          Yaeji
+        </span>,
+      ]}
+    />
+  </div>
+);

--- a/.design-sync/previews/Table.tsx
+++ b/.design-sync/previews/Table.tsx
@@ -1,0 +1,136 @@
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Badge,
+} from "musicnerdweb";
+
+/**
+ * The profile "My entries" table (`src/app/profile/UserEntriesTable.tsx`): one row per
+ * UGC submission — date, artist, platform, submitted URL, status.
+ *
+ * Note this Table is NOT stock shadcn: `TableCell` carries
+ * `whitespace-nowrap overflow-hidden text-ellipsis` and tighter `p-2` padding
+ * (stock is `p-4`, wrapping). Every cell truncates rather than wraps.
+ */
+export const Default = () => (
+  <Table>
+    <TableHeader>
+      <TableRow>
+        <TableHead className="w-[110px]">Date</TableHead>
+        <TableHead>Artist</TableHead>
+        <TableHead>Platform</TableHead>
+        <TableHead>Submitted URL</TableHead>
+        <TableHead className="text-right">Status</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {[
+        ["Jul 09, 2026", "Jamie xx", "Spotify", "https://open.spotify.com/artist/2SBRfBHOwGKA8fdQrRAtc4", "Approved"],
+        ["Jul 08, 2026", "Floating Points", "Bandcamp", "https://floatingpoints.bandcamp.com/album/cascade", "Approved"],
+        ["Jul 08, 2026", "Yaeji", "SoundCloud", "https://soundcloud.com/kraeji", "Pending"],
+        ["Jul 06, 2026", "Overmono", "Apple Music", "https://music.apple.com/us/artist/overmono/1113641144", "Approved"],
+      ].map(([date, artist, platform, url, status]) => (
+        <TableRow key={url}>
+          <TableCell className="text-muted-foreground">{date}</TableCell>
+          <TableCell className="font-medium">{artist}</TableCell>
+          <TableCell>{platform}</TableCell>
+          <TableCell className="text-muted-foreground">{url}</TableCell>
+          <TableCell className="text-right">
+            <Badge variant={status === "Approved" ? "secondary" : "outline"}>{status}</Badge>
+          </TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+);
+
+/**
+ * Truncation, on purpose. The same MusicBrainz/Deezer URL in three columns of decreasing
+ * width: it silently loses its tail rather than wrapping to a second line. This is the most
+ * consequential deviation from stock shadcn Table — and it only bites under `table-fixed`,
+ * since in the default auto layout the table just widens to fit and no cell ever clips.
+ */
+export const TruncatingCells = () => (
+  <Table style={{ tableLayout: "fixed" }}>
+    <TableHeader>
+      <TableRow>
+        <TableHead style={{ width: 100 }}>Artist</TableHead>
+        <TableHead style={{ width: 130 }}>narrow</TableHead>
+        <TableHead style={{ width: 210 }}>medium</TableHead>
+        <TableHead>wide</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {[
+        ["Kelela", "https://musicbrainz.org/artist/9e4b8d5f-9c15-4b31-a2f6-72d0e4e19b21"],
+        ["Four Tet", "https://www.deezer.com/en/artist/1147?utm_source=musicnerd"],
+      ].map(([artist, url]) => (
+        <TableRow key={artist}>
+          <TableCell className="font-medium">{artist}</TableCell>
+          <TableCell className="text-muted-foreground">{url}</TableCell>
+          <TableCell className="text-muted-foreground">{url}</TableCell>
+          <TableCell className="text-muted-foreground">{url}</TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+);
+
+/**
+ * The full compound: Caption + Header + Body + Footer, with a selected row
+ * (`data-[state=selected]:bg-muted`) — the admin moderation queue pattern. Footer is
+ * `bg-muted/50 font-medium` and is the only place a total belongs.
+ */
+export const WithFooterAndSelection = () => (
+  <Table>
+    <TableCaption>Cross-platform ID mapping coverage — agent run #48</TableCaption>
+    <TableHeader>
+      <TableRow>
+        <TableHead>Platform</TableHead>
+        <TableHead className="text-right">Mapped</TableHead>
+        <TableHead className="text-right">Excluded</TableHead>
+        <TableHead className="text-right">Coverage</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      <TableRow>
+        <TableCell className="font-medium">Deezer</TableCell>
+        <TableCell className="text-right">12,480</TableCell>
+        <TableCell className="text-right">312</TableCell>
+        <TableCell className="text-right">86%</TableCell>
+      </TableRow>
+      <TableRow data-state="selected">
+        <TableCell className="font-medium">Apple Music</TableCell>
+        <TableCell className="text-right">9,104</TableCell>
+        <TableCell className="text-right">844</TableCell>
+        <TableCell className="text-right">63%</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell className="font-medium">MusicBrainz</TableCell>
+        <TableCell className="text-right">13,902</TableCell>
+        <TableCell className="text-right">96</TableCell>
+        <TableCell className="text-right">95%</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell className="font-medium">Tidal</TableCell>
+        <TableCell className="text-right">4,331</TableCell>
+        <TableCell className="text-right">1,207</TableCell>
+        <TableCell className="text-right">30%</TableCell>
+      </TableRow>
+    </TableBody>
+    <TableFooter>
+      <TableRow>
+        <TableCell>Total</TableCell>
+        <TableCell className="text-right">39,817</TableCell>
+        <TableCell className="text-right">2,459</TableCell>
+        <TableCell className="text-right">68%</TableCell>
+      </TableRow>
+    </TableFooter>
+  </Table>
+);

--- a/.design-sync/previews/Tabs.tsx
+++ b/.design-sync/previews/Tabs.tsx
@@ -1,0 +1,121 @@
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  Badge,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "musicnerdweb";
+
+/**
+ * The admin dashboard nav (`src/app/admin/AdminTabs.tsx`) — six sections, pending counts
+ * baked into the trigger labels. `defaultValue` is required or no panel renders.
+ * Stock shadcn/Radix: `bg-muted` rail, active trigger lifts to `bg-background` + shadow-sm.
+ */
+export const Default = () => (
+  <Tabs defaultValue="ugc" className="w-[620px]">
+    <TabsList>
+      <TabsTrigger value="ugc">UGC (14)</TabsTrigger>
+      <TabsTrigger value="claims">Claims (3)</TabsTrigger>
+      <TabsTrigger value="artist-data">Artist Data</TabsTrigger>
+      <TabsTrigger value="users">Users</TabsTrigger>
+      <TabsTrigger value="mcp-keys">MCP Keys</TabsTrigger>
+      <TabsTrigger value="agent-work">Agent Work</TabsTrigger>
+    </TabsList>
+    <TabsContent value="ugc">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Artist</TableHead>
+            <TableHead>Platform</TableHead>
+            <TableHead>Contributor</TableHead>
+            <TableHead className="text-right">Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {[
+            ["Yaeji", "Bandcamp", "vinylwitch"],
+            ["Overmono", "Deezer", "bpmhunter"],
+            ["Kelela", "SoundCloud", "crate.digger"],
+          ].map(([artist, platform, who]) => (
+            <TableRow key={artist}>
+              <TableCell className="font-medium">{artist}</TableCell>
+              <TableCell>{platform}</TableCell>
+              <TableCell className="text-muted-foreground">@{who}</TableCell>
+              <TableCell className="text-right">
+                <Badge variant="outline">Pending</Badge>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TabsContent>
+    <TabsContent value="claims">Claims queue</TabsContent>
+    <TabsContent value="artist-data">Artist data tools</TabsContent>
+    <TabsContent value="users">User directory</TabsContent>
+    <TabsContent value="mcp-keys">MCP API keys</TabsContent>
+    <TabsContent value="agent-work">Agent activity</TabsContent>
+  </Tabs>
+);
+
+/**
+ * A different tab selected (`defaultValue="agent-work"`, the last trigger), proving the
+ * active-state axis: only the selected trigger gets `bg-background text-foreground shadow-sm`;
+ * the rest stay `text-muted-foreground` on the muted rail.
+ */
+export const SecondPanelActive = () => (
+  <Tabs defaultValue="agent-work" className="w-[620px]">
+    <TabsList>
+      <TabsTrigger value="ugc">UGC (14)</TabsTrigger>
+      <TabsTrigger value="claims">Claims (3)</TabsTrigger>
+      <TabsTrigger value="artist-data">Artist Data</TabsTrigger>
+      <TabsTrigger value="users">Users</TabsTrigger>
+      <TabsTrigger value="mcp-keys">MCP Keys</TabsTrigger>
+      <TabsTrigger value="agent-work">Agent Work</TabsTrigger>
+    </TabsList>
+    <TabsContent value="ugc">UGC queue</TabsContent>
+    <TabsContent value="agent-work">
+      <div className="grid grid-cols-3 gap-3">
+        {[
+          ["Deezer", "12,480", "86% coverage"],
+          ["Apple Music", "9,104", "63% coverage"],
+          ["MusicBrainz", "13,902", "95% coverage"],
+        ].map(([platform, mapped, note]) => (
+          <div key={platform} className="rounded-lg border bg-card p-4">
+            <p className="text-sm text-muted-foreground">{platform}</p>
+            <p className="text-2xl font-semibold">{mapped}</p>
+            <p className="text-xs text-muted-foreground">{note}</p>
+          </div>
+        ))}
+      </div>
+    </TabsContent>
+  </Tabs>
+);
+
+/**
+ * Two triggers, one disabled (`disabled:opacity-50`) — the artist page's Bio / Fun Facts
+ * split before the AI content has generated. Also the narrow, non-admin shape of the
+ * component: a short rail rather than a six-way one.
+ */
+export const TwoUpWithDisabled = () => (
+  <Tabs defaultValue="bio" className="w-[420px]">
+    <TabsList>
+      <TabsTrigger value="bio">Bio</TabsTrigger>
+      <TabsTrigger value="fun-facts" disabled>
+        Fun Facts
+      </TabsTrigger>
+    </TabsList>
+    <TabsContent value="bio">
+      <div className="rounded-lg border bg-card p-4 text-sm leading-relaxed text-muted-foreground">
+        Floating Points is the project of Sam Shepherd — a London producer whose work moves
+        between modal jazz, broken house, and orchestral composition.
+      </div>
+    </TabsContent>
+    <TabsContent value="fun-facts">Not generated yet.</TabsContent>
+  </Tabs>
+);

--- a/.design-sync/previews/Textarea.tsx
+++ b/.design-sync/previews/Textarea.tsx
@@ -1,0 +1,73 @@
+import { Label, Textarea } from "musicnerdweb";
+
+/**
+ * The shipped default. Two deliberate-looking deviations from stock shadcn are visible here:
+ *
+ * 1. `min-h-[50px]` instead of stock `min-h-[80px]` — the empty field is noticeably squatter
+ *    than a shadcn Textarea anywhere else.
+ * 2. The focus ring is BROKEN: the class list has `focus-visible:ring-ring` and
+ *    `focus-visible:ring-offset-2` but no `focus-visible:ring-2`, so ring width stays 0 and
+ *    nothing paints on focus. Unlike Input, the border IS present.
+ */
+export const Default = () => (
+  <div className="w-full max-w-md space-y-1.5">
+    <Label htmlFor="ta-default">Artist bio</Label>
+    <Textarea
+      id="ta-default"
+      placeholder="Tell us about this artist…"
+    />
+    <p className="text-sm text-muted-foreground">
+      Empty height is 50px — stock shadcn is 80px.
+    </p>
+  </div>
+);
+
+/**
+ * Realistic content at the height an editor actually uses. The AI-bio review surface passes
+ * `rows` / a min-height override rather than living with the 50px default.
+ */
+export const Filled = () => (
+  <div className="w-full max-w-lg space-y-1.5">
+    <Label htmlFor="ta-bio">AI-generated bio (editable before publish)</Label>
+    <Textarea
+      id="ta-bio"
+      rows={6}
+      className="min-h-[140px]"
+      defaultValue={
+        "Yaeji is a Korean-American producer and vocalist whose work folds house, hip-hop and Korean-language pop into something quietly euphoric. Since 'Raingurl' broke out in 2017 she has released on Godmode and XL Recordings, and her 2023 album 'With A Hammer' pushed further into live instrumentation."
+      }
+    />
+    <p className="text-sm text-muted-foreground">
+      Regenerated automatically whenever a platform link changes.
+    </p>
+  </div>
+);
+
+/** The two non-default static states: disabled and error. */
+export const States = () => (
+  <div className="grid w-full max-w-lg gap-5">
+    <div className="space-y-1.5">
+      <Label htmlFor="ta-disabled">Fun fact (regenerating…)</Label>
+      <Textarea
+        id="ta-disabled"
+        disabled
+        className="min-h-[70px]"
+        defaultValue="Arca scored the runway music for Björk's Cornucopia tour."
+      />
+    </div>
+    <div className="space-y-1.5">
+      <Label htmlFor="ta-error" className="text-destructive">
+        Moderation note
+      </Label>
+      <Textarea
+        id="ta-error"
+        aria-invalid
+        className="min-h-[70px] border-destructive"
+        defaultValue="dupe"
+      />
+      <p className="text-sm font-medium text-destructive">
+        Rejection notes must be at least 20 characters — reviewers see this text.
+      </p>
+    </div>
+  </div>
+);

--- a/.design-sync/previews/ThemeToggle.tsx
+++ b/.design-sync/previews/ThemeToggle.tsx
@@ -1,0 +1,37 @@
+import { ThemeToggle } from "musicnerdweb";
+
+/**
+ * A hand-rolled pill switch — NOT a Radix Switch. It renders two buttons and lets the
+ * `sm:` breakpoint pick one: a 48px circle below `sm`, and this 112×32 pill at and above
+ * it. The knob is an absolutely-positioned 24px white circle that slides left↔right, and
+ * the "Light Mode" / "Dark Mode" labels cross-fade on opacity so the pill never resizes.
+ *
+ * Previews capture light mode, so this is the resting light state: knob left, purple Sun,
+ * "Light Mode" label pushed to the right edge (`justify-end pr-2`). The dark state swaps
+ * to a `#2d3748` track, a black knob and a `pastyblue` Moon.
+ */
+export const Default = () => (
+  <div className="flex items-center gap-4">
+    <ThemeToggle />
+  </div>
+);
+
+/**
+ * Where it actually lives: far right of the nav bar, next to the wordmark and search.
+ * Placed on a plain surface because the toggle carries its own `#f3f4f6` track — it has
+ * no border, so it needs a lighter or darker surface behind it to read as a control.
+ */
+export const InNavBar = () => (
+  <div className="flex w-full max-w-xl items-center gap-4 rounded-xl border border-border bg-card px-4 py-3">
+    <span
+      className="text-lg font-extrabold tracking-tight"
+      style={{ color: "#ff9ce3" }}
+    >
+      MusicNerd
+    </span>
+    <div className="h-9 flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm text-muted-foreground">
+      Search artists…
+    </div>
+    <ThemeToggle />
+  </div>
+);

--- a/.design-sync/previews/Toast.tsx
+++ b/.design-sync/previews/Toast.tsx
@@ -1,0 +1,83 @@
+import {
+  Toast,
+  ToastAction,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "musicnerdweb";
+
+/**
+ * Toast needs ToastProvider + ToastViewport (the viewport is itself `fixed`), and each Toast
+ * must be forced `open` — nothing renders otherwise. ToastClose is `opacity-0` until
+ * group-hover, which never fires in a headless capture, so `opacity-100` is passed to make the
+ * dismiss affordance visible. The capture also takes no animation settle, so
+ * `animation: none` pins the toast at its resting position instead of mid `slide-in`.
+ *
+ * The wrapper + `absolute` viewport is a HARNESS workaround, not a DS pattern: the card's
+ * `.ds-single` root carries a `transform`, which makes it the containing block for anything
+ * `position: fixed`. ToastViewport is rendered inline (Radix does not portal it), so its
+ * `fixed bottom-0` resolved against that box and stranded the toast at the frame edge in a sea
+ * of whitespace. Merging `absolute` over its `fixed` (ToastViewport uses cn()/tailwind-merge)
+ * anchors it inside a bounded relative box. The toast's own appearance is untouched.
+ *
+ * Copy comes from EditablePlatformLink.tsx ("<Platform> link has been removed") and the
+ * admin claims table.
+ */
+export const Default = () => (
+  <div className="relative h-40 w-full">
+    <ToastProvider duration={Infinity}>
+    <Toast open style={{ animation: "none" }}>
+      <div className="grid gap-1">
+        <ToastTitle>Spotify link has been removed</ToastTitle>
+        <ToastDescription>
+          The change is live on Four Tet&apos;s profile.
+        </ToastDescription>
+      </div>
+      <ToastAction altText="Undo removing the Spotify link">Undo</ToastAction>
+      <ToastClose className="opacity-100" />
+    </Toast>
+      <ToastViewport className="absolute inset-x-0 top-0 max-w-full p-3" />
+    </ToastProvider>
+  </div>
+);
+
+/**
+ * The destructive variant, as fired by SearchBar.tsx when adding an artist fails.
+ */
+export const Destructive = () => (
+  <div className="relative h-40 w-full">
+    <ToastProvider duration={Infinity}>
+    <Toast open variant="destructive" style={{ animation: "none" }}>
+      <div className="grid gap-1">
+        <ToastTitle>Error</ToastTitle>
+        <ToastDescription>
+          Failed to add artist — please try again.
+        </ToastDescription>
+      </div>
+      <ToastAction altText="Retry adding the artist">Retry</ToastAction>
+      <ToastClose className="opacity-100" />
+    </Toast>
+      <ToastViewport className="absolute inset-x-0 top-0 max-w-full p-3" />
+    </ToastProvider>
+  </div>
+);
+
+/**
+ * Title-only toast (no description, no action) — the shape most `toast({ title })` calls in the
+ * repo actually produce, e.g. the admin claims table's `Claim Approved`.
+ */
+export const TitleOnly = () => (
+  <div className="relative h-40 w-full">
+    <ToastProvider duration={Infinity}>
+    <Toast open style={{ animation: "none" }}>
+      <div className="grid gap-1">
+        <ToastTitle>Claim approved</ToastTitle>
+      </div>
+      <ToastClose className="opacity-100" />
+    </Toast>
+      <ToastViewport className="absolute inset-x-0 top-0 max-w-full p-3" />
+    </ToastProvider>
+  </div>
+);

--- a/.design-sync/previews/Tooltip.tsx
+++ b/.design-sync/previews/Tooltip.tsx
@@ -1,0 +1,53 @@
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "musicnerdweb";
+
+/**
+ * TooltipContent is portaled and `fixed`, and hover never happens in a headless capture — so
+ * the Tooltip is forced `open` and wrapped in the required TooltipProvider. Positioning is
+ * left to Radix; the card viewport is what makes it fit.
+ *
+ * Content copied in spirit from the artist-page fun-facts buttons, which are the repo's only
+ * Tooltip consumers (a one-line description under each prompt button).
+ */
+export const Open = () => (
+  <TooltipProvider>
+    <div className="flex min-h-[240px] items-start justify-center pt-6">
+      <Tooltip open>
+        <TooltipTrigger asChild>
+          <Button variant="outline" size="sm">
+            Surprise me
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={8} className="whitespace-nowrap">
+          <p>An unexpected fact about this artist</p>
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  </TooltipProvider>
+);
+
+/**
+ * Tooltip anchored to the side, on an icon-only trigger — the pattern used for the small
+ * platform-link icons on the artist page, where the label has nowhere else to live.
+ */
+export const OnIconTrigger = () => (
+  <TooltipProvider>
+    <div className="flex min-h-[240px] items-center justify-center">
+      <Tooltip open>
+        <TooltipTrigger asChild>
+          <Button variant="outline" size="icon" aria-label="Bandcamp">
+            <span className="text-sm font-semibold">B</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="right" sideOffset={10}>
+          <p>Open on Bandcamp</p>
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  </TooltipProvider>
+);

--- a/.design-sync/previews/TypeWriter.tsx
+++ b/.design-sync/previews/TypeWriter.tsx
@@ -1,0 +1,48 @@
+import { TypeWriter } from "musicnerdweb";
+
+/**
+ * Types `text` out one character at a time. Two timers gate it: `startDelay` (default
+ * 1000ms) before the first character, then `typingDelay` (default 80ms) per character.
+ *
+ * Three things a preview author must know:
+ *  1. At the shipped defaults a static capture lands INSIDE the 1000ms start delay and
+ *     photographs an empty string. Both cells below collapse `startDelay` to 0 and
+ *     `typingDelay` to 1ms so the capture catches the settled, fully-typed frame — which
+ *     is the frame a user spends ~all of their time looking at anyway.
+ *  2. It accepts a `className` prop and then never applies it — the render is a bare
+ *     `<span>{displayText}</span>`. So ALL typography must come from the PARENT element.
+ *     That is not a workaround; it is the only way to style this component today.
+ *  3. Do not reach for the `.home-text-h2` global to typeset it: that class also carries
+ *     `color: … !important` in globals.css and will hijack whatever colour you set.
+ */
+
+/** The settled frame at hero scale, with the parent supplying size, weight and colour. */
+export const HeroHeadline = () => (
+  <div className="w-full max-w-xl rounded-xl border border-border bg-card px-6 py-6">
+    <h2 className="text-4xl font-bold text-maroon">
+      <TypeWriter text="who made this?" startDelay={0} typingDelay={1} />
+    </h2>
+  </div>
+);
+
+/**
+ * Inline inside body copy, with the parent supplying the brand pink users actually SEE —
+ * `#ff9ce3`, a raw literal that lives in no palette (wordmark, highlight glows). It is
+ * applied by inline style, exactly as the app applies it. A blinking caret is composed
+ * alongside, since the component ships none of its own.
+ */
+export const InlineAccent = () => (
+  <div className="w-full max-w-md rounded-xl border border-border bg-card px-6 py-6">
+    <p className="text-lg text-muted-foreground">
+      Now indexing{" "}
+      <span className="font-bold" style={{ color: "#ff9ce3" }}>
+        <TypeWriter text="Sudan Archives" startDelay={0} typingDelay={1} />
+        <span
+          className="ml-0.5 inline-block h-4 w-0.5 align-middle"
+          style={{ backgroundColor: "#ff9ce3" }}
+        />
+      </span>{" "}
+      across 40+ platforms.
+    </p>
+  </div>
+);

--- a/.design-sync/tailwind.ds.config.ts
+++ b/.design-sync/tailwind.ds.config.ts
@@ -1,0 +1,171 @@
+// Tailwind config used ONLY to compile the design-sync stylesheet (.design-sync/.cache/ds-tailwind.css).
+//
+// Why this exists: the app's tailwind.config.ts JIT-compiles only the classes that appear in src/.
+// The claude.ai/design agent writes NEW markup with utilities the app never happened to use, and a
+// rendered design receives nothing but styles.css — so any class missing from this stylesheet is
+// silently unstyled. We therefore extend the app config with:
+//   1. content globs that also cover the authored preview cards
+//   2. a safelist covering the general Tailwind utility surface + the MusicNerd brand palette
+//
+// Theme, plugins, and brand colors are inherited verbatim from the app config — this file adds
+// coverage, it never redefines design values.
+import type { Config } from "tailwindcss";
+import appConfig from "../tailwind.config";
+
+// Tailwind's default numeric scales, spelled out so safelist regexes stay readable.
+const SPACE = "0|px|0\\.5|1|1\\.5|2|2\\.5|3|3\\.5|4|5|6|7|8|9|10|11|12|14|16|20|24|28|32|36|40|48|56|64|72|80|96";
+const FRACTION = "1/2|1/3|2/3|1/4|3/4|1/5|2/5|3/5|4/5|1/6|5/6|1/12|5/12|7/12|11/12";
+const SIZE = `${SPACE}|${FRACTION}|auto|full|screen|min|max|fit|svh|dvh|lvh`;
+const TEXT = "xs|sm|base|lg|xl|2xl|3xl|4xl|5xl|6xl|7xl|8xl|9xl";
+const WEIGHT = "thin|extralight|light|normal|medium|semibold|bold|extrabold|black";
+const RADIUS = "none|sm|DEFAULT|md|lg|xl|2xl|3xl|full";
+const SHADOW = "sm|DEFAULT|md|lg|xl|2xl|inner|none";
+const SCALE_1_100 = "0|5|10|20|25|30|40|50|60|70|75|80|90|95|100";
+
+// Palette. Deliberately NOT the full 22-hue Tailwind rainbow: DESIGN.md's standing rule is
+// "don't introduce a fourth pink or a new blue", so we ship the brand trio, the shadcn semantic
+// tokens, the neutrals, and only the accent hues the app actually reaches for (counted from src/).
+// A curated palette both keeps the stylesheet small and steers the design agent on-brand.
+const HUE =
+  "slate|gray|zinc|neutral|red|orange|amber|yellow|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose";
+const SHADE = "50|100|200|300|400|500|600|700|800|900|950";
+const BRAND = "maroon|pastyblue|pastypink|jellygreen";
+const SEMANTIC =
+  "border|input|ring|background|foreground|primary|secondary|destructive|muted|accent|popover|card|primary-foreground|secondary-foreground|destructive-foreground|muted-foreground|accent-foreground|popover-foreground|card-foreground";
+const COLOR = `(?:${HUE})-(?:${SHADE})|(?:${BRAND})|(?:${SEMANTIC})|white|black|transparent|current|inherit`;
+// Tailwind slash-opacity (bg-white/70, border-white/40) is the backbone of the .glass language.
+const ALPHA = "(?:/(?:5|10|20|30|40|50|60|70|80|90))?";
+
+/** Interaction + responsive variants worth generating for a given family. */
+const V_STATE = ["hover", "focus", "focus-visible", "active", "disabled", "group-hover"];
+const V_RESPONSIVE = ["sm", "md", "lg", "xl"];
+const V_THEME = ["dark"];
+const V_ALL = [...V_STATE, ...V_RESPONSIVE, ...V_THEME];
+// Colors are the combinatorial hot spot (palette x alpha x variant). Responsive color variants are
+// vanishingly rare in real markup, so colors get state+theme variants only — this is what keeps the
+// stylesheet at a couple of MB instead of ~30.
+const V_COLOR = ["hover", "focus", "dark", "group-hover"];
+
+const safelist: Config["safelist"] = [
+  // ---- Brand identity arbitrary values ----
+  // Tailwind only emits an arbitrary value it literally finds in scanned source. The pink users
+  // actually SEE — #ff9ce3, the wordmark/glow pink — is applied via inline style in the app, so
+  // `text-[#ff9ce3]` was never generated and would have been silently dead for anyone writing new
+  // markup. These are listed literally (patterns cannot match arbitrary values).
+  "text-[#ff9ce3]",
+  "bg-[#ff9ce3]",
+  "border-[#ff9ce3]",
+  "shadow-[0_0_40px_rgba(255,156,227,0.25)]",
+  "shadow-[0_0_20px_rgba(255,156,227,0.3)]",
+  // The signature "pink-glow lift" hover (and its blue listen-platform variant).
+  "group-hover:shadow-[0_0_15px_rgba(239,149,255,0.45)]",
+  "group-hover:shadow-[0_0_15px_rgba(0,199,242,0.45)]",
+  "hover:shadow-[0_0_25px_rgba(239,149,255,0.5)]",
+  "hover:shadow-[0_0_30px_rgba(239,149,255,0.35)]",
+  // The hero's pink→violet wash. `#7c3aed` (violet-600) is the app's gradient partner for pink.
+  "from-[#ef95ff]",
+  "to-[#7c3aed]",
+  "via-[#7c3aed]",
+  "from-[#ff9ce3]",
+
+  // ---- Layout ----
+  // basis-* is what carousel/flex slides size on — its absence collapsed every Carousel slide.
+  { pattern: /^basis-(0|1|2|3|4|5|6|8|10|12|auto|full|1\/2|1\/3|2\/3|1\/4|3\/4|1\/5|1\/6)$/, variants: V_RESPONSIVE },
+  { pattern: /^table-(auto|fixed)$/ },
+  { pattern: /^(flex-)?(nowrap|wrap)$/ },
+  { pattern: /^(block|inline-block|inline|flex|inline-flex|grid|inline-grid|hidden|contents|table)$/, variants: V_RESPONSIVE },
+  { pattern: /^flex-(row|row-reverse|col|col-reverse|wrap|nowrap|wrap-reverse|1|auto|initial|none)$/, variants: V_RESPONSIVE },
+  { pattern: /^(grow|shrink)(-0)?$/, variants: V_RESPONSIVE },
+  { pattern: /^items-(start|end|center|baseline|stretch)$/, variants: V_RESPONSIVE },
+  { pattern: /^justify-(start|end|center|between|around|evenly)$/, variants: V_RESPONSIVE },
+  { pattern: /^self-(auto|start|end|center|stretch)$/, variants: V_RESPONSIVE },
+  { pattern: /^content-(start|end|center|between|around|evenly)$/, variants: V_RESPONSIVE },
+  { pattern: /^grid-cols-(1|2|3|4|5|6|7|8|9|10|11|12|none)$/, variants: V_RESPONSIVE },
+  { pattern: /^grid-rows-(1|2|3|4|5|6|none)$/, variants: V_RESPONSIVE },
+  { pattern: /^col-span-(1|2|3|4|5|6|7|8|9|10|11|12|full)$/, variants: V_RESPONSIVE },
+  { pattern: /^row-span-(1|2|3|4|5|6|full)$/, variants: V_RESPONSIVE },
+  { pattern: /^order-(1|2|3|4|5|6|first|last|none)$/, variants: V_RESPONSIVE },
+
+  // ---- Spacing ----
+  { pattern: new RegExp(`^-?(p|px|py|pt|pr|pb|pl)-(${SPACE})$`), variants: V_RESPONSIVE },
+  { pattern: new RegExp(`^-?(m|mx|my|mt|mr|mb|ml)-(${SPACE}|auto)$`), variants: V_RESPONSIVE },
+  { pattern: new RegExp(`^(gap|gap-x|gap-y)-(${SPACE})$`), variants: V_RESPONSIVE },
+  { pattern: new RegExp(`^-?(space-x|space-y)-(${SPACE})$`), variants: V_RESPONSIVE },
+
+  // ---- Sizing ----
+  { pattern: new RegExp(`^w-(${SIZE})$`), variants: V_RESPONSIVE },
+  { pattern: new RegExp(`^h-(${SIZE})$`), variants: V_RESPONSIVE },
+  { pattern: new RegExp(`^(min-w|min-h)-(0|full|screen|min|max|fit)$`), variants: V_RESPONSIVE },
+  { pattern: /^max-w-(0|none|xs|sm|md|lg|xl|2xl|3xl|4xl|5xl|6xl|7xl|full|min|max|fit|prose|screen-sm|screen-md|screen-lg|screen-xl|screen-2xl)$/, variants: V_RESPONSIVE },
+  { pattern: /^max-h-(none|full|screen|min|max|fit)$/, variants: V_RESPONSIVE },
+  { pattern: /^aspect-(auto|square|video)$/, variants: V_RESPONSIVE },
+
+  // ---- Typography ----
+  { pattern: new RegExp(`^text-(${TEXT})$`), variants: V_RESPONSIVE },
+  { pattern: new RegExp(`^font-(${WEIGHT})$`), variants: V_RESPONSIVE },
+  { pattern: /^font-(sans|serif|mono)$/ },
+  { pattern: /^leading-(none|tight|snug|normal|relaxed|loose|3|4|5|6|7|8|9|10)$/, variants: V_RESPONSIVE },
+  { pattern: /^tracking-(tighter|tight|normal|wide|wider|widest)$/, variants: V_RESPONSIVE },
+  { pattern: /^text-(left|center|right|justify)$/, variants: V_RESPONSIVE },
+  { pattern: /^(uppercase|lowercase|capitalize|normal-case|truncate|italic|not-italic|underline|line-through|no-underline)$/, variants: V_ALL },
+  { pattern: /^line-clamp-(1|2|3|4|5|6|none)$/, variants: V_RESPONSIVE },
+  { pattern: /^(whitespace|break)-(normal|nowrap|pre|pre-line|pre-wrap|words|all)$/, variants: V_RESPONSIVE },
+  { pattern: /^align-(baseline|top|middle|bottom)$/ },
+
+  // ---- Color (text / bg / border / ring / divide / gradient stops) ----
+  { pattern: new RegExp(`^text-(${COLOR})$`), variants: V_COLOR },
+  { pattern: new RegExp(`^bg-(${COLOR})${ALPHA}$`), variants: V_COLOR },
+  { pattern: new RegExp(`^border-(${COLOR})${ALPHA}$`), variants: V_COLOR },
+  { pattern: new RegExp(`^ring-(${COLOR})$`), variants: ["focus", "focus-visible", "dark"] },
+  { pattern: new RegExp(`^divide-(${COLOR})$`), variants: V_THEME },
+  { pattern: new RegExp(`^(from|via|to)-(${COLOR})${ALPHA}$`), variants: V_THEME },
+  { pattern: /^bg-gradient-to-(t|tr|r|br|b|bl|l|tl)$/, variants: V_THEME },
+
+  // ---- Borders & radius ----
+  { pattern: /^border(-(0|2|4|8))?$/, variants: V_ALL },
+  { pattern: /^border-(x|y|t|r|b|l)(-(0|2|4|8))?$/, variants: V_RESPONSIVE },
+  { pattern: /^border-(solid|dashed|dotted|double|none)$/ },
+  { pattern: new RegExp(`^rounded(-(${RADIUS}))?$`), variants: V_RESPONSIVE },
+  { pattern: new RegExp(`^rounded-(t|r|b|l|tl|tr|br|bl)(-(${RADIUS}))?$`), variants: V_RESPONSIVE },
+  { pattern: /^divide-(x|y)(-(0|2|4|8))?$/ },
+
+  // ---- Effects ----
+  { pattern: new RegExp(`^shadow(-(${SHADOW}))?$`), variants: V_ALL },
+  { pattern: new RegExp(`^opacity-(${SCALE_1_100})$`), variants: V_ALL },
+  { pattern: /^(backdrop-)?blur(-(none|sm|md|lg|xl|2xl|3xl))?$/, variants: V_THEME },
+  { pattern: /^backdrop-saturate-(0|50|100|150|200)$/ },
+  { pattern: /^(overflow|overflow-x|overflow-y)-(auto|hidden|clip|visible|scroll)$/, variants: V_RESPONSIVE },
+  { pattern: /^ring(-(0|1|2|4|8|inset))?$/, variants: V_ALL },
+  { pattern: /^ring-offset-(0|1|2|4|8)$/, variants: V_ALL },
+  { pattern: /^object-(contain|cover|fill|none|scale-down|center|top|bottom|left|right)$/ },
+
+  // ---- Position ----
+  { pattern: /^(static|fixed|absolute|relative|sticky)$/, variants: V_RESPONSIVE },
+  { pattern: new RegExp(`^-?(inset|inset-x|inset-y|top|right|bottom|left)-(${SPACE}|${FRACTION}|auto|full)$`), variants: V_RESPONSIVE },
+  { pattern: /^z-(0|10|20|30|40|50|auto)$/, variants: V_RESPONSIVE },
+
+  // ---- Transform & motion (the "pink-glow lift" language) ----
+  { pattern: new RegExp(`^scale(-(x|y))?-(${SCALE_1_100}|105|110|125|150)$`), variants: V_ALL },
+  { pattern: /^-?rotate-(0|1|2|3|6|12|45|90|180)$/, variants: V_ALL },
+  { pattern: new RegExp(`^-?(translate-x|translate-y)-(${SPACE}|${FRACTION}|full)$`), variants: V_ALL },
+  { pattern: /^transition(-(none|all|colors|opacity|shadow|transform))?$/, variants: V_ALL },
+  { pattern: /^duration-(0|75|100|150|200|300|500|700|1000)$/ },
+  { pattern: /^ease-(linear|in|out|in-out)$/ },
+  { pattern: /^delay-(0|75|100|150|200|300|500|700|1000)$/ },
+  { pattern: /^animate-(none|spin|ping|pulse|bounce|fadeSlideIn|accordion-down|accordion-up)$/ },
+  { pattern: /^(cursor|select|pointer-events)-(auto|none|pointer|default|text|not-allowed|all)$/, variants: V_STATE },
+  { pattern: /^(origin)-(center|top|bottom|left|right)$/ },
+  { pattern: /^(sr-only|not-sr-only)$/ },
+];
+
+const config = {
+  ...appConfig,
+  content: [
+    "./src/**/*.{ts,tsx}",
+    // authored preview cards — their layout glue must compile too
+    "./.design-sync/previews/**/*.{ts,tsx}",
+  ],
+  safelist,
+} satisfies Config;
+
+export default config;

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,8 @@ wikidata_query.py
 
 # Claude Code runtime lock (machine-specific)
 .claude/scheduled_tasks.lock
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,475 @@
+# MusicNerdWeb — Design System (DESIGN.md)
+
+## Purpose & how to use this doc
+
+This file is the **north star** for MusicNerdWeb's visual and interaction design. It is the single source of truth for color, typography, layout, components, and motion.
+
+Two rules for using it:
+
+1. **It documents what EXISTS today**, grounded in the actual code — not an aspirational redesign. Where a value is a stock shadcn/Tailwind default that was never rebranded, this doc **flags it as stock** so it can be changed *on purpose* rather than by accident.
+2. **When proposing any UI change, state it against this system.** Say which token/utility/component you are touching, whether you are following an existing convention or introducing a new one, and — if you are diverging — why. Prefer editing tokens over adding one-off hex literals.
+
+A companion section, [Known inconsistencies to reconcile](#known-inconsistencies-to-reconcile), catalogs where the current implementation contradicts itself. Treat that table as the backlog of design-debt decisions: each row is a place where a human should pick one source of truth.
+
+> **The single most important fact about this codebase:** the brand identity (candy-neon pink/blue/green over frosted glass) is applied *on top of* an **unmodified shadcn "slate" token layer**, almost entirely through hardcoded hex literals and a ~330-line wall of `!important` dark-mode overrides — not through the semantic token system. `--primary` is navy slate; the brand's pink lives outside the tokens as three different hex values. Nearly every inconsistency below traces back to this.
+
+---
+
+## Design philosophy
+
+MusicNerd is a **playful, indie, candy-neon music directory dressed in Apple-style frosted glass.** The personality lives in a handful of electric accent colors — a hot orchid pink, a bright cyan, and a jelly mint-green — set against a light-forward, rounded, glassmorphic surface language, with a lowercase-casual voice ("music nerd", "Made in Seattle by @cxy @clt and friends"). Underneath, the structural chrome (buttons, cards, inputs, semantic tokens) is stock shadcn slate — brand character is layered on top as ad-hoc hex accents and glass utilities.
+
+**Signature visual moves:**
+
+- **The neon accent trio** — `pastyblue #2ad4fc`, `pastypink #ef95ff`, `jellygreen #19ffb8`. The whimsical names ("pasty", "jelly") are themselves a voice cue. `maroon #422b46` is the deep-aubergine "ink" for footer/body text.
+- **The glowing hot-pink wordmark** — the homepage renders only a giant lowercase `music nerd` in `#ff9ce3` with a pink `textShadow` glow, fluid-sized `clamp(32px → 84px)` with tight negative letter-spacing.
+- **Apple-style glassmorphism panels** — `.glass` (translucent white + `backdrop-filter: blur(20px) saturate(180%)`) is the primary surface across 13+ artist-page components and admin. Even the scrollbar is themed to match.
+- **Ambient, calm motion** — logo spins on hover, a pulsing "Live" ping dot, staggered 30ms feed fade-ins, framer-motion scroll parallax on the artist hero. Slow (3–20s), eased, never frantic.
+- **Round everything** — circular avatars, pill indicators, `rounded-lg`/`rounded-2xl` surfaces, a pink placeholder avatar.
+- **The light→dark accent swap** — dark mode deliberately shifts the accent from **pink → cyan/green** (checked checkboxes `#ff9ce3` → `#2ad4fc`; feed live dot emerald → jellygreen). The pink wordmark is the one element forced to stay pink in both modes.
+
+**Design principles (inferred from the actual UI):**
+
+1. **Neon accents, quiet chrome.** Deploy pastypink/pastyblue/jellygreen as punctuation on top of neutral slate surfaces — never as full backgrounds or large fills.
+2. **Glass is the surface language.** Prefer `.glass` / `.glass-subtle` for panels; keep radii generous (0.75–2rem) and edges soft.
+3. **Round everything.** Circular avatars, pill indicators, rounded cards/buttons; avoid hard corners.
+4. **Motion should feel alive but calm.** Spinning logo, live ping, staggered fades, scroll parallax — slow, eased, ambient.
+5. **Pink is the identity in light; cyan/green take over in dark.** Honor the light→dark accent swap already coded into checkboxes and the live feed.
+6. **Lowercase, friendly, personal voice.** Short, casual, a little self-aware; credit real humans ("Made in Seattle by @cxy @clt and friends"); no corporate polish. Dev humor leaks through (a loading spinner's alt text is literally `alt="whyyyyy"`).
+7. **Big, fluid, tightly-tracked display type.** Use `clamp()` fluid sizing with negative letter-spacing for hero headlines — the `music nerd` wordmark is the template.
+
+**What to avoid (to stay on-brand):**
+
+- Don't introduce a **fourth pink or a new blue.** Three pinks already exist; consolidate toward named tokens instead of inventing more hex.
+- Don't make accent colors **load-bearing backgrounds** or large fills — neon-on-neon breaks the "quiet chrome" balance.
+- Don't ship **opaque, hard-edged, flat cards** where a glass panel is expected.
+- Don't rely on the **KoHo** class names expecting that typeface — KoHo never loads in the app; those classes render as system sans-serif.
+- Don't add more **`!important` dark-mode patch overrides** — the override wall is already brittle. Prefer theming via CSS-variable tokens.
+- Don't force **serious/corporate copy, ALL-CAPS shouting, or sharp geometric/brutalist styling** — it contradicts the lowercase, playful, glassy, indie personality.
+
+---
+
+## Color
+
+MusicNerdWeb's color system is **three disconnected layers that never reconcile**: a 4-color brand palette in `tailwind.config.ts`, a stock untouched shadcn "slate" semantic-token layer in `globals.css`, and a dead SCSS file (`_colors.scss`) that redefines the brand under different names and is imported nowhere. The visual identity is applied almost entirely through hardcoded hex literals (200+ occurrences) and `!important` dark-mode overrides — **not** through tokens. The brand pink alone exists as **three different hex values**.
+
+### 1. Brand palette — `tailwind.config.ts` (lines 26–29)
+
+Plain Tailwind color extensions. **Not** wired into the semantic `--primary`/`--accent` tokens.
+
+| Token (Tailwind class) | Value | Direct uses in `src/` | Notes |
+|---|---|---|---|
+| `maroon` | `#422b46` | 1 | Footer text (`.text-maroon`), forced white in dark mode |
+| `pastyblue` | `#2ad4fc` | 1 | Also hardcoded for dark checkbox + moon icon |
+| `pastypink` | `#ef95ff` | 93 | Most-used brand token; also the hero gradient pink |
+| `jellygreen` | `#19ffb8` | (via raw hex) | Appears mainly as raw hex in ActivityFeed |
+
+### 2. Semantic HSL tokens — `globals.css` `:root` / `.dark` (lines 35–90)
+
+**These are verbatim stock shadcn/ui "slate" defaults** (navy `222.2 47.4% 11.2%` primary, `210 40% 96.1%` secondary, `0 84.2% 60.2%` destructive). **None carry the brand's pink/blue/green** — the semantic layer was scaffolded from shadcn and never rebranded. Consumed as `hsl(var(--token))` via `tailwind.config.ts` (lines 30–62).
+
+| Token | Light (`:root`) | Dark (`.dark`) |
+|---|---|---|
+| `--background` | `0 0% 100%` | `222.2 84% 4.9%` |
+| `--foreground` | `222.2 84% 4.9%` | `210 40% 98%` |
+| `--card` | `0 0% 100%` | `222.2 84% 4.9%` |
+| `--card-foreground` | `222.2 84% 4.9%` | `210 40% 98%` |
+| `--popover` | `0 0% 100%` | `222.2 84% 4.9%` |
+| `--popover-foreground` | `222.2 84% 4.9%` | `210 40% 98%` |
+| `--primary` | `222.2 47.4% 11.2%` | `210 40% 98%` |
+| `--primary-foreground` | `210 40% 98%` | `222.2 47.4% 11.2%` |
+| `--secondary` | `210 40% 96.1%` | `217.2 32.6% 17.5%` |
+| `--secondary-foreground` | `222.2 47.4% 11.2%` | `210 40% 98%` |
+| `--muted` | `210 40% 96.1%` | `217.2 32.6% 17.5%` |
+| `--muted-foreground` | `215.4 16.3% 46.9%` | `215 20.2% 65.1%` |
+| `--accent` | `210 40% 96.1%` | `217.2 32.6% 17.5%` |
+| `--accent-foreground` | `222.2 47.4% 11.2%` | `210 40% 98%` |
+| `--destructive` | `0 84.2% 60.2%` | `0 62.8% 30.6%` |
+| `--destructive-foreground` | `210 40% 98%` | `210 40% 98%` |
+| `--border` | `214.3 31.8% 91.4%` | `217.2 32.6% 17.5%` |
+| `--input` | `214.3 31.8% 91.4%` | `217.2 32.6% 17.5%` |
+| `--ring` | `222.2 84% 4.9%` | `212.7 26.8% 83.9%` |
+| `--radius` | `0.5rem` | (same) |
+
+**Chart colors** (`--chart-1..5`) are **also stock shadcn defaults**:
+
+| | Light | Dark |
+|---|---|---|
+| `--chart-1` | `12 76% 61%` | `220 70% 50%` |
+| `--chart-2` | `173 58% 39%` | `160 60% 45%` |
+| `--chart-3` | `197 37% 24%` | `30 80% 55%` |
+| `--chart-4` | `43 74% 66%` | `280 65% 60%` |
+| `--chart-5` | `27 87% 67%` | `340 75% 55%` |
+
+**Custom token** — `--subtitle-color` (line 61 / 89):
+
+| | Light | Dark |
+|---|---|---|
+| `--subtitle-color` | `rgb(89, 48, 97, 0.6)` | `rgb(198, 191, 199)` |
+
+Note: the light value uses the malformed legacy 4-arg `rgb(r,g,b,a)` syntax (should be `rgba()`); the dark value drops alpha entirely.
+
+### 3. SCSS layer — `src/app/_colors.scss` (DEAD / unimported)
+
+`grep` confirms this file is **imported nowhere**. It redefines the brand under a *second* naming scheme and defines `.text-color-primary { color: $primary }` (`#2ad4fc`), which collides by name with a live definition in `globals.css`.
+
+| SCSS var | Value | Duplicates |
+|---|---|---|
+| `$primary` | `#2ad4fc` | `pastyblue` |
+| `$secondary` | `#ef95ff` | `pastypink` |
+| `$tertiary` | `#19ffb8` | `jellygreen` |
+| `$grey` | `rgb(184, 182, 182)` | — |
+| `$purple` | `rgb(25, 0, 50)` | — |
+| `$lightpurple` | `rgb(100, 0, 200)` | — |
+
+### 4. The "real" brand pink is fragmented into 3 hex values
+
+The pink actually seen on screen (splash title, highlighted leaderboard rows, checked checkboxes in light mode, focus rings) is **`#ff9ce3`** — 57 occurrences — **defined nowhere in the palette**, and different from `pastypink` `#ef95ff`. A third pink `#EDADF8` powers `.text-color-primary` and `.pink-btn`.
+
+| Pink | Where | Source |
+|---|---|---|
+| `#ef95ff` | `pastypink` / `$secondary` / HeroSection gradient | `tailwind.config.ts:28`, `_colors.scss:2` |
+| `#ff9ce3` | "Music Nerd" title, highlight borders/glows, light checked checkbox, focus rings, ActivityFeed `--feed-artist` | 57 hardcoded uses; `globals.css:168–277`, `485–488` |
+| `#EDADF8` | `.text-color-primary`, `.pink-btn` background | `globals.css:516`, `585` |
+
+### Gradients
+
+| Gradient | Definition | File |
+|---|---|---|
+| Hero brand wash | `bg-gradient-to-br from-[#ef95ff]/20 via-transparent to-[#7c3aed]/15` | `artist/[id]/_components/HeroSection.tsx:79` |
+| Hero dark overlay | `bg-gradient-to-b from-black/20 to-black/50` | `HeroSection.tsx:82` |
+| Press thumb fallback | `bg-gradient-to-br from-pastypink/10 via-purple-900/20 to-transparent` | `PressAndFeatures.tsx:68` |
+
+Note the hero uses raw hex (`#7c3aed` violet-600, `#ef95ff`) while the press thumb uses the `pastypink` token + Tailwind `purple-900` — two vocabularies for the same "pink→purple" wash.
+
+### Glass / glassmorphism — `globals.css`
+
+The "Apple-style glass" look is built from **white-alpha layers, not tokens**:
+
+| Utility | Light | Dark |
+|---|---|---|
+| `.glass` | `bg rgba(255,255,255,0.55)`; `blur(20px) saturate(180%)`; border `1px rgba(255,255,255,0.3)`; radius `1rem` | `bg rgba(30,30,30,0.55)`; border `1px rgba(255,255,255,0.08)` |
+| `.glass-subtle` | `bg rgba(255,255,255,0.35)`; `blur(12px) saturate(150%)`; border `1px rgba(255,255,255,0.25)`; radius `0.75rem` | `bg rgba(40,40,40,0.4)`; border `1px rgba(255,255,255,0.06)` |
+| `.scrollbar-glass` | thumb `rgba(255,255,255,0.18)`, hover `0.32`, track transparent, 6px | (same) |
+
+### Ad-hoc palettes hidden in overrides (not tokenized)
+
+- **Dead duplicate `:root` block (create-next-app leftover)** — `globals.css:519–528` defines a *second* `:root` with `--foreground-rgb: 0,0,0`, `--background-start-rgb: 214,219,220`, `--background-end-rgb: 255,255,255`, plus a bare `body { color: rgb(var(--foreground-rgb)); background: white }` and `.dark body { background: #1a1a1a }`. This hardcoded body background **overrides** the token-driven `@apply bg-background text-foreground` set earlier — an unmentioned dead/duplicate token layer and a direct token-vs-hardcode inconsistency.
+- **Dark-mode neutral ramp** — Tailwind slate values hardcoded as hex rather than driven by `--background`/`--muted` (lines 112–532): `#1a1a1a` (dark body), `#2d3748` (panels/search), `#4a5568` (hover/border), `#f7fafc` (near-white text), `#a0aec0` (muted text), `#374151` (borders).
+- **Leaderboard / UGC "mauve" family** — a purple-grey micro-palette used only through `!important` overrides (lines 132–304): `#9b83a0`, `#c6bfc7`, `#6f4b75`, `#b8b1b9`, `#a08ba8`, `rgb(89,48,97,0.6)`, `rgb(198,191,199)`, `rgb(111,75,117,0.8)`. `rgb(89,48,97,0.6)` is the same value as light `--subtitle-color` but re-typed as a literal everywhere.
+- **ActivityFeed** (`ActivityFeed.tsx:69–115`) defines its **own parallel token system** via injected `--feed-*` custom properties with light/dark variants — reusing brand hex (`#ff9ce3`, `#19ffb8`, `#2ad4fc`) plus one-offs `#5a4d5e`, `#3d2f42`, `#9b8a9f`, `#059669` (emerald), `#0891b2` (cyan-600), `#c44a8c`, `#e0d8e2`. This is the best-structured light/dark token set in the app and is a good candidate for promotion into the shared layer.
+
+### Interactive accents
+
+- **Checkbox checked:** light `#ff9ce3`, dark `#2ad4fc`; checkmark forced `white`.
+- **Theme-toggle moon icon (dark):** `#2ad4fc`.
+- **Notification dot:** `bg-red-600` with a forced 2px white border in dark. (The 6 `#FF0000` hits in the tree are test-fixture `colorHex` mock values in `src/__tests__/components/ArtistLinks.test.tsx`, not UI colors — there are zero `#ff0000` literals in shipping app code.)
+- **Highlight glow:** `box-shadow 0 0 20px rgba(255,156,227,0.3)` (`#ff9ce3` at 0.3), forced via `!important`.
+
+### Theme mechanism
+
+Dark mode is **class-based** (`darkMode: 'class'`) driven by a **custom `ThemeProvider`** (`_components/ThemeProvider.tsx`) — **not `next-themes`**, despite next-themes being the documented convention. It toggles `.light`/`.dark` on `<html>`, persists to `localStorage` key `musicnerd-theme`, and falls back to `prefers-color-scheme`. Because most of dark mode is expressed as `!important` overrides of hardcoded light values rather than swapped token values, the `.dark` block runs ~330 lines.
+
+---
+
+## Typography
+
+### The headline finding: the brand typeface never loads in the app
+
+The intended brand font is **KoHo** (Google font), but **it is not loaded anywhere in the Next.js app.** There is no `next/font` import in `src/`, no `<link>` font tag in `layout.tsx`, no `@font-face`/`@import` in `globals.css`, no font package in `package.json`, and no `fontFamily` key in `tailwind.config.ts`.
+
+`globals.css` *declares* `font-family: "KoHo", sans-serif` in three places — `.koho-extralight` (weight 200), `.koho-light` (weight 300), and `.pink-btn` — but because KoHo never loads, **each silently falls back to `sans-serif`**. `.pink-btn` is a shipping class (the "Log In" button), so the login button renders in system sans-serif, not KoHo.
+
+**Net effect:** the entire app renders in Tailwind's default `font-sans` stack (`ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, …`). No `font-family` is set on `body`. Stock Tailwind behavior, no customization — an unintended gap between design intent (KoHo) and reality (system font). **Assume the app font is the default sans stack.**
+
+KoHo *does* load correctly, but only in two standalone static files outside the React app — `public/tmprivacy.html` and `public/mnidprivacy.html` (Google Fonts `<link>`, weights 200–700, their own inline `koho` Tailwind family). The declared brand stack is therefore **`"KoHo", sans-serif`** with weights **200, 300, 400, 500, 600, 700** — but it only manifests on the legal pages.
+
+### Type scale — stock Tailwind defaults, no custom scale
+
+There is **no custom `fontSize` scale**; every `text-*` resolves to Tailwind built-ins. Actual usage across `src/`:
+
+| Tailwind class | Size / line-height | Uses | Role |
+|---|---|---|---|
+| `text-xs` | 12px / 16px | 108 | Badges, captions, metadata, timestamps |
+| `text-sm` | 14px / 20px | 138 | **De-facto body/UI size** — table body, card descriptions, buttons |
+| `text-base` | 16px / 24px | 22 | `Input` default |
+| `text-lg` | 18px / 28px | 40 | Sub-headings |
+| `text-xl` | 20px / 28px | 22 | Section headings |
+| `text-2xl` | 24px / 32px | 14 | `CardTitle`, artist name |
+| `text-3xl` | 30px / 36px | 5 | Page H1s ("Admin Dashboard", "User Profile") |
+| `text-4xl` | 36px / 40px | 1 | `.artist-name` utility only (`globals.css:696`, `text-4xl text-purple-500`) |
+
+No `text-5xl`+ anywhere. Root size is browser default 16px (never overridden).
+
+### Weights
+
+Four Tailwind weight utilities appear; the app maps to a narrow band:
+
+| Class | Uses | Role |
+|---|---|---|
+| `font-semibold` (600) | 62 | Dominant emphasis/heading weight (card titles, badges, table headers) |
+| `font-medium` (500) | 41 | Buttons (`text-sm font-medium`), labels |
+| `font-bold` (700) | 33 | Page H1s (`text-3xl font-bold`) |
+| `font-normal` (400) | 8 | Occasional body reset |
+
+The two light weights the brand cares about — **200 (`.koho-extralight`) and 300 (`.koho-light`)** — are defined but never render (KoHo isn't loaded; the classes aren't applied by any component).
+
+### Letter-spacing & line-height
+
+Sparse, mostly on the shadcn `CardTitle` and a few headings: `leading-none` ×11, `leading-tight` ×9, `leading-relaxed` ×6, `leading-snug` ×2; `tracking-tight` ×3, `tracking-wide` ×2, `tracking-wider` ×1, `tracking-widest` ×1. Canonical pattern (stock shadcn): `CardTitle = text-2xl font-semibold leading-none tracking-tight`.
+
+### The real display type — two hand-rolled fluid clamp headings
+
+The only genuinely designed (non-default) type on the site is two fluid headings, both interpolated across a **360px → 1440px** viewport window:
+
+1. **Homepage "music nerd" title** — `HomePageSplash.tsx`, inline-styled (the largest type on the site):
+   - `font-size: clamp(32px, calc(32px + (84 - 32) * ((100vw - 360px) / (1440 - 360))), 84px)`
+   - `letter-spacing: clamp(-1px, …, -4px)` (tightens as it grows), `line-height: 1`, `lowercase font-bold`
+   - color `#ff9ce3` with `textShadow: 0 0 40px rgba(255,156,227,0.25)` — a **pink glow, not a gradient.**
+2. **`.home-text-h2`** — `globals.css:616`: `font-size: clamp(28px, …, 70px)`, `letter-spacing: clamp(-1px, …, -3px)`, `line-height: clamp(36px, …, 70px)`; colored `#9b83a0` (light) / `#a08ba8` (dark) as subtitle, or `#ff9ce3` as a title variant. **Legacy/dead** — referenced only inside `globals.css`, never applied by any `.tsx`.
+
+### Special text treatments
+
+- **Pink glow, not gradient text.** There is **no gradient-clipped text** anywhere (`bg-clip-text` / `text-transparent` = 0 hits). All `bg-gradient-*` usages are background gradients on `<div>` overlays, not type. The only text effect is the `#ff9ce3` glow on the homepage title, defended aggressively against dark-mode overrides via ~15 `!important` selectors (`globals.css:168–277`).
+- **Animated-text components exist but are unused (dead code):** `TypeWriter.tsx` (char-by-char, `startDelay=1000ms`, `typingDelay=80ms`) and `SlidingText.tsx` (vertical word-carousel, `interval=1000ms`, the only consumer of `.home-text-height`). **Neither is imported anywhere.**
+- **Marquee/spin keyframes** available to text/logo rows: `scroll-left`/`scroll-right` (`20s linear infinite`) and `slow-spin` (`10s`) — all currently unused.
+- **`.pink-btn`** (login button): declared KoHo (falls back to sans-serif), `18px` desktop / `16px` <768px, `color #422B46` on `#EDADF8`, `border-radius: 5px`.
+
+---
+
+## Layout & spacing
+
+MusicNerdWeb has **no shared page-container primitive**. The root layout is a flex column; each page defines its own centered column with an ad-hoc `max-w-* mx-auto` and its own padding. Tailwind's stock `container` config is present but **dead** — the `.container` class appears nowhere in `src/`. Breakpoints and the radius scale are unmodified defaults; the only bespoke layout logic is fluid `clamp()` typography and one hand-written SCSS media query.
+
+### Root shell (`src/app/layout.tsx`)
+
+```
+<body className="min-h-screen flex flex-col">
+  <Nav />
+  <main className="flex-grow flex flex-col min-h-0 w-full"> {children} </main>
+  <Toaster />
+  <Footer />   // mt-auto pins footer to bottom
+```
+
+A sticky-footer flex column. `<main>` imposes **no** max-width or padding — every page owns its own gutters.
+
+### Page container rules (the real convention)
+
+The dominant pattern is a **centered column** (`max-w-* mx-auto`) with padding that steps up at `sm:`, and vertical section stacking via `space-y-6`.
+
+| Page | Container className | Max width | H-pad | V-pad |
+|---|---|---|---|---|
+| Nav (`NavContent.tsx:11`) | `w-full px-3 py-3 sm:p-6 … max-w-[1000px] mx-auto` | `1000px` | `px-3 → sm:6` | `py-3 → sm:6` |
+| Home (`HomePageSplash.tsx:7`) | `px-6 sm:px-8 pt-0 pb-4 … w-full` + inner `max-w-2xl` | `2xl` (42rem) | `px-6 → sm:8` | `pt-0 pb-4` |
+| Artist (`artist/[id]/page.tsx:107`) | `w-full max-w-[800px] mx-auto px-4 py-5 space-y-6` | `800px` | `px-4` | `py-5` |
+| Admin (`admin/page.tsx:50`) | `admin-page px-4 sm:px-10 py-5 space-y-6` | none (full-bleed) | `px-4 → sm:10` | `py-5` |
+| Leaderboard/Profile (`leaderboard/ClientWrapper.tsx`) | `px-5 sm:px-10 py-10` | none | `px-5 → sm:10` | `py-10` |
+| Add-artist (`AddArtistContent.tsx`) | `min-h-screen flex items-center justify-center` + card `p-8 max-w-2xl w-full mx-4` | `2xl` | `mx-4` / card `p-8` | centered |
+| Footer (`Footer.tsx:3`) | `px-5 py-5 w-full text-center mt-auto` | none | `px-5` | `py-5` |
+
+Horizontal gutters cluster on **`px-4`/`px-5` → `sm:px-8`/`sm:px-10`**; vertical page padding is **`py-5`** (content pages) or **`py-10`** (leaderboard). Named max-widths are inconsistent — `800px` (artist), `2xl` (home, add-artist), `1000px` (nav) — with no shared token. The dead container config would have capped at **1400px**.
+
+### Section / card shell (artist page)
+
+The repeated content-section shell is a glass panel: **`glass p-4 sm:p-5 space-y-3`** (used 5× on the artist page). Page sections are separated by the parent's `space-y-6`; content inside each panel stacks on `space-y-3`.
+
+The shadcn `Card` primitive is **stock**: `rounded-lg border bg-card shadow-sm`, with `CardHeader`/`Content`/`Footer` all on **`p-6`**. The codebase mostly uses the custom `.glass p-4/p-5` panels rather than `Card` for primary layout — so **two padding conventions coexist** for card-like surfaces.
+
+### Breakpoints
+
+**No custom breakpoints** — `theme.screens` is never set, so all defaults apply.
+
+| Token | Value | Source |
+|---|---|---|
+| sm | 640px | Tailwind default |
+| md | 768px | Tailwind default |
+| lg | 1024px | Tailwind default |
+| xl | 1280px | Tailwind default |
+| 2xl | 1536px | Tailwind default |
+| container `2xl` | **1400px** | `tailwind.config.ts:20` (overrides container max only; **unused**) |
+
+Effective usage is a near-two-breakpoint system: `sm:` **157×**, `md:` **41×**, `lg:` **7×**, `xl:`/`2xl:` **0×**. One hand-written SCSS breakpoint at **`max-width: 768px`** (`globals.css:631`) governs `.nav-bar`, `.nav-grid`, `.home-text`, `.pink-btn` — duplicating Tailwind's `md` boundary in raw CSS. Fluid title sizing uses `clamp()` over **360px → 1440px**, independent of the breakpoint tokens.
+
+### Spacing & gutter conventions
+
+Drawn from Tailwind's 4px scale, with clear favorites:
+
+- **Flex/grid gap:** `gap-2` (0.5rem) dominant (**65×**), then `gap-4` (27×), `gap-1` (21×), `gap-3` (17×), `gap-1.5` (12×). `gap-2` is the default inline-cluster gutter.
+- **Vertical stacking:** `space-y-4` dominant (**24×**), `space-y-2` (17×), `space-y-3` (14×); page-level sections use `space-y-6`.
+- **Component padding (stock shadcn):** Button `default h-10 px-4 py-2`, `sm h-9 px-3`, `lg h-12 px-8`, `icon h-10 w-10`; Input/SelectTrigger `h-10 px-3 py-2`; Badge `px-2.5 py-0.5`; `Dialog p-6`.
+- **Custom off-scale utility:** `.pink-btn` uses `5px` vertical / `30px` horizontal padding (`4px` on mobile).
+
+### Border-radius scale
+
+Base token **`--radius: 0.5rem` (8px)**, not overridden in `.dark`. Tailwind derivations use the stock shadcn formula:
+
+| Class | Formula | Computed |
+|---|---|---|
+| `rounded-lg` | `var(--radius)` | 8px |
+| `rounded-md` | `calc(var(--radius) - 2px)` | 6px |
+| `rounded-sm` | `calc(var(--radius) - 4px)` | 4px |
+| `rounded-xl` | Tailwind default | 12px |
+| `rounded-2xl` | Tailwind default | 16px |
+| `rounded-full` | 9999px | pill |
+
+Usage: `rounded-full` **65×** (icons, avatars, badges, genre pills), `rounded-md` **53×** (buttons, inputs, selects), `rounded-lg` **28×**, `rounded` **14×**, `rounded-sm` **9×**, `rounded-xl` **7×**. **Off-scale hardcoded radii** live in `globals.css` and do not derive from `--radius`: `.glass` = **16px**, `.glass-subtle` = **12px**, `.search-bar` & `.pink-btn` = **5px**, glass scrollbar thumb = `9999px`.
+
+---
+
+## Components
+
+The UI is built on a **shadcn/ui + Radix** primitive layer in `src/components/ui/` (21 files), wrapped and extended by custom feature components in `src/app/_components/`. Most primitives are **stock shadcn defaults** (unmodified generated code); a handful were hand-edited, and **those edits are the load-bearing design facts.** Only **four** primitives use `cva` for variants — Button, Badge, Toast, Label — everything else is a fixed-className Radix wrapper.
+
+> **Record for future contributors:** brand identity is carried by the **custom components + global utilities**, not the primitives. Style at the custom-component layer; don't fork primitives.
+
+### Core primitives — variants & sizes (`cva`)
+
+| Component | File | Variants | Sizes | Default | Notes |
+|---|---|---|---|---|---|
+| **Button** | `button.tsx` | `default`, `destructive`, `outline`, `secondary`, `ghost`, `link` | `default` (h-10 px-4 py-2), `sm` (h-9 px-3), `lg` (h-12 px-8), `icon` (h-10 w-10) | `default`/`default` | `rounded-md text-sm font-medium transition-colors`, focus-visible ring-2. **Deviation:** the `default` variant is only `bg-primary text-primary-foreground` — stock `hover:bg-primary/90` was removed, so the primary button has **no hover feedback** |
+| **Badge** | `badge.tsx` | `default`, `secondary`, `destructive`, `outline` | — | `default` | `rounded-full border px-2.5 py-0.5 text-xs font-semibold`. Stock |
+| **Toast** | `toast.tsx` | `default`, `destructive` | — | `default` | `rounded-md border p-6 pr-8 shadow-lg`, swipe anims. Stock (Radix Toast) |
+| **Label** | `label.tsx` | none (cva with base string only) | — | — | `text-sm font-medium leading-none`. Stock |
+
+### Non-cva primitives (fixed styling, Radix-wrapped or plain)
+
+| Component | File | Notable styling | Stock or modified |
+|---|---|---|---|
+| **Card** (+ Header/Title/Description/Content/Footer) | `card.tsx` | `rounded-lg border bg-card text-card-foreground shadow-sm`; header `p-6 space-y-1.5`; title `text-2xl font-semibold tracking-tight`; content `p-6 pt-0` | Stock |
+| **Input** | `input.tsx` | `flex w-full rounded-md bg-background px-3 py-2 text-base … placeholder:text-muted-foreground disabled:opacity-50` | **Heavily stripped:** no `h-10`, **no `border border-input`**, **no `focus-visible:ring`**, uses `text-base` (stock uses `text-sm`). Renders borderless & height-less — forms must re-style via `className` |
+| **Textarea** | `textarea.tsx` | `min-h-[50px] w-full rounded-md border border-input bg-background text-base md:text-sm` | Modified: `min-h-[50px]` (stock 80px), and **`focus-visible:ring-2` is missing** (has `ring-ring`/`ring-offset-2` but no ring width) so the focus ring won't render |
+| **Select** (Radix) | `select.tsx` | `SelectTrigger h-10 border border-input focus:ring-2`; popper slide/zoom anims | Stock |
+| **Tabs** (Radix) | `tabs.tsx` | `TabsList h-10 rounded-md bg-muted`; `TabsTrigger data-[state=active]:bg-background data-[state=active]:shadow-sm` | Stock |
+| **Dialog** (Radix) | `dialog.tsx` | `DialogContent max-w-lg gap-4 border bg-background p-6 shadow-lg sm:rounded-lg`, overlay `bg-black/80` | **Modified:** className prefixed with `dark:bg-gray-900 text-foreground` (hardcoded dark surface instead of `bg-background`) |
+| **Table** (+ Header/Body/Footer/Row/Head/Cell/Caption) | `table.tsx` | `TableRow hover:bg-muted/50`; `TableHead h-10 px-2 text-muted-foreground` | **Modified:** `TableCell` adds `whitespace-nowrap overflow-hidden text-ellipsis` (truncating cells); padding `px-2`/`p-2` (stock `p-4`) |
+| **Tooltip** (Radix) | `tooltip.tsx` | `rounded-md border bg-popover px-3 py-1.5 text-sm shadow-md`, `sideOffset=4` | Stock |
+| **Checkbox** (Radix) | `checkbox.tsx` | `h-4 w-4 rounded-sm border border-primary data-[state=checked]:bg-primary` | Stock |
+| **DropdownMenu** (Radix, full set) | `dropdown-menu.tsx` | `bg-popover p-1 rounded-md shadow-md`, `inset` prop, Check/Circle/ChevronRight icons | Stock |
+
+Additional stock primitives present but not individually styled: `aspect-ratio`, `calendar`, `carousel`, `drawer`, `form`, `popover`, `toaster`.
+
+### Signature custom components (`src/app/_components/`)
+
+- **HomePageSplash** — homepage hero. Lowercase `music nerd` `<h1>` with fluid `clamp()` font-size (32px → 84px), negative letter-spacing, **hardcoded** `color: #ff9ce3` + pink `textShadow` glow, then mounts `ActivityFeed`. Uses raw hex, not the `pastypink` token.
+- **ArtistLinks** — async server component. Platform links as **list rows** (`StaticPlatformLink` / `EditablePlatformLink` when `canEdit`) using `.link-item-grid` + `.corners-rounded` globals; splits monetized "support" links from general links, injects Spotify/Deezer.
+- **ArtistLinksGrid** — the newer **grid-based** link renderer that coexists with `ArtistLinks`. Circular glassmorphism tiles: `w-12 h-12 rounded-full backdrop-blur-sm bg-white/70 dark:bg-white/10 border-white/40`, with `group-hover:scale-110` and a colored glow (pink `shadow-[0_0_15px_rgba(239,149,255,0.45)]`, blue for Deezer/listen).
+- **EditableLinkIcon** — editable glass tile; adds a red `-top-1 -right-1` delete `X` gated on `EditModeContext.isEditing`, posting to `/api/directEditLink`.
+- **ThemeToggle** — a **fully custom animated pill switch** (not Radix Switch). Mobile `w-12 h-12` circle and desktop `w-28 h-8` pill with sliding knob + "Dark Mode"/"Light Mode" labels; Moon/Sun icons. Colors hardcoded inline (`#2d3748`/`#f3f4f6` track, `#2ad4fc` moon = `pastyblue` value).
+- **EditModeToggle** — wraps shadcn `<Button variant="outline" size="sm">`, restyled with brand `pastypink` (`border-pastypink/50 text-pastypink hover:bg-pastypink hover:text-white`); Pencil/Check icons.
+- **BookmarkButton** — wraps shadcn `<Button variant="outline" size="sm">`, `localStorage`-backed toggle, fixed `w-[120px]`, `pastypink` fill/border states.
+- **SlidingText** — vertical text carousel cycling `ReactNode[]` via `translateY`. Uses `.home-text-height`. **Dead code (imported nowhere).**
+- **TypeWriter** — char-by-char typewriter (`startDelay=1000ms`, `typingDelay=80ms`). **Dead code (imported nowhere).**
+- **LoginBtn** (`buttons/LoginBtn/index.tsx`) — **legacy pre-shadcn button**: raw `<button className="pink-btn">` (`background #EDADF8`, maroon `#422B46` text, KoHo font, `5px` radius, 18px). Evidence of an older button system still in the tree.
+- **nav/** — top nav: spinning logo (`hover:animate-[spin_3s_linear_infinite]`), `SearchBar`, `AddArtist`, `Login`. `Login.tsx` branches to `NoWalletLogin` (admin gear) or `PrivyLogin` (email-first auth); also `LegacyAccountModal`.
+
+### Design facts to record
+
+- The shadcn primitives are **~70% stock generated code.** Meaningful hand-edits: Button (removed default hover), Input (stripped border/height/ring), Textarea (`min-h-[50px]`, missing ring width), Dialog (`dark:bg-gray-900`), Table (truncating cells, tighter padding).
+- **Three parallel button systems** coexist: the cva `Button`, the legacy `.pink-btn` global class, and the fully-custom `ThemeToggle` `<button>`.
+- **Two artist-link renderers** coexist: `ArtistLinks` (list rows) and `ArtistLinksGrid` (glass icon grid).
+- Brand color is applied **two ways**: via Tailwind tokens (`pastypink`, `pastyblue`) in `EditModeToggle`/`BookmarkButton`, and via hardcoded hex (`#ff9ce3`, `#2d3748`, `#EDADF8`) in `HomePageSplash`, `ThemeToggle`, `.pink-btn`.
+- **A dead pre-shadcn utility-class layer survives** in `globals.css:679–738`: `@apply`-based legacy classes `.navbar`, `.logo`, `.login-button` (`bg-purple-600`), `.support-button`/`.sound-button`/`.world-button` (`bg-green-500`), `.play-button` (`bg-pink-500`), `.support-input`, `.scroll-text`, and a duplicate `.search-bar { @apply p-2 border rounded }` that conflicts with the earlier `.search-bar { border-radius: 5px }`. Evidence of an older styling system predating shadcn, still in the tree.
+
+---
+
+## Motion & interaction
+
+The motion system is a **three-layer stack**: (1) `tailwindcss-animate` powering stock shadcn/Radix enter/exit transitions, (2) hand-written CSS `@keyframes` in `globals.css`, and (3) `framer-motion` (v12.36.0) used in exactly three artist-page components for scroll-driven and scroll-reveal effects. The signature gesture is a **pink-glow lift** on hover (scale + colored box-shadow). There is **no `prefers-reduced-motion` handling anywhere**, and several defined animations are dead code.
+
+### Animation tokens
+
+| Name | Duration | Easing | Definition | Status |
+|---|---|---|---|---|
+| `fadeSlideIn` | `0.3s` | `ease-out both` | opacity `0→1`, `translateY(-8px→0)` | **Live** — `ActivityFeed.tsx:230` |
+| `accordion-down` | `0.2s` | `ease-out` | height `0 → var(--radix-accordion-content-height)` | **Dead** — no Accordion exists |
+| `accordion-up` | `0.2s` | `ease-out` | height `var(...) → 0` | **Dead** — no Accordion exists |
+| `scroll-left` | `20s` | `linear infinite` | `translateX(0 → -50%)` (marquee) | **Dead** — zero usages |
+| `scroll-right` | `20s` | `linear infinite` | `translateX(0 → 50%)` | **Dead** — zero usages |
+| `slow-spin` | `10s` | `linear infinite` | `rotate(0 → 360deg)` | **Dead** — zero usages |
+
+`tailwindcss-animate` supplies the `animate-in`/`animate-out`/`fade-in-0`/`zoom-in-95`/`slide-in-from-*` utilities used by the shadcn primitives — **stock strings, unmodified.** Dialog content overrides the default to `duration-200`; everything else inherits the tailwindcss-animate default (~150ms).
+
+**Tailwind utility durations actually used (`.tsx`):** `duration-300` ×22 (de-facto standard), `duration-200` ×3, `duration-500` ×2, `duration-150` ×1, `duration-1000` ×1. **Only easing utility used:** `ease-in-out` ×6. There is **no tokenized duration/easing scale** — 300ms is convention by repetition, not definition.
+
+**Framer-motion transitions** (inline per-component, not tokenized):
+
+- `RevealSection.tsx` — `transition={{ duration: 0.5, ease: "easeOut", delay }}`, `initial={{opacity:0, y:30}} → whileInView={{opacity:1, y:0}}`, `viewport={{ once: true, margin: "-50px" }}`.
+- `HeroSection.tsx` — scroll-linked via `useScroll` + `useTransform`: parallax `bgY 0%→50%`, `bgOpacity 1→0`, `photoScale 1→0.65`, `photoOpacity 1→0`, `stickyOpacity 0→1`.
+
+### Interaction principles (as observed)
+
+- **Hover — the signature "pink-glow lift."** `transition-all duration-300` + `group-hover:scale-110` + a colored glow box-shadow, on circular link icons (`ArtistLinksGrid.tsx`, `EditableLinkIcon.tsx`): `group-hover:scale-110 group-hover:shadow-[0_0_15px_rgba(239,149,255,0.45)] group-hover:bg-white/90`. Cards echo it larger — `PressAndFeatures.tsx:65` `hover:shadow-[0_0_30px_rgba(239,149,255,0.35)]`; hero photo `hover:shadow-[0_0_25px_rgba(239,149,255,0.5)]`. The "listen"-platform variant swaps the glow to **blue** `rgba(0,199,242,0.45)`. ActivityFeed rows use a subtler `hover:bg-[var(--feed-hover-bg)]` + `group-hover:h-5` accent-bar growth.
+- **Hover — shadcn primitives.** Stock `transition-colors` tint-shifts (`hover:bg-secondary/80`, `hover:bg-accent`). **Deviation:** the `default` button variant has **no hover state** (stock ships `hover:bg-primary/90`).
+- **Focus.** Stock focus rings on button, tabs, checkbox (`focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`) and badge/dialog-close/toast (`focus:ring-2`). **Deviation:** `input.tsx` has **no border and no `focus-visible` ring** — text inputs have no default focus affordance.
+- **Active/press.** No `active:` classes anywhere — there is **no press-scale or tactile down-state feedback.**
+- **Theme toggle** is the most deliberately animated control: pill + sliding knob use `transition-all duration-300 ease-in-out`; labels cross-fade via `transition-opacity duration-300`.
+- **Loading/ambient.** `animate-spin` bordered rings (AgentWorkSection, ArtistDataSection, UserEntriesTable, UserSearch), `Loader2` (VaultManager); `animate-pulse` on the login placeholder and the "Ask" logo; `animate-ping` on the "Live" dot (`ActivityFeed.tsx:202`).
+- **Scrollbars.** `.scrollbar-glass` — bespoke 6px thin scrollbar, `rgba(255,255,255,0.18)` thumb → `0.32` on `:hover` (the only scrollbar hover transition, instantaneous). `.scrollbar-hide` fully hides.
+
+### Signature motion
+
+1. **Fade-slide-in feed (live).** The only bespoke keyframe wired up. `ActivityFeed` applies `animate-fadeSlideIn` with **staggered `animationDelay: i*30ms`** on first load and a **depth opacity decay** (`Math.max(0.45, 1 - i*0.035)`), plus the `animate-ping` "Live" pulse.
+2. **Scroll-driven hero (framer-motion).** `HeroSection` + `StickyHeroBar` layer a parallax: blurred bg drifts at half-speed and fades, the centered photo scales `1→0.65` and fades, a frosted sticky bar fades in — all pure `MotionValue`s ("no React state" per the code comment), so it's jank-free.
+3. **Reveal-on-scroll (framer-motion).** `RevealSection` — reusable `whileInView` fade-up (`opacity 0→1`, `y 30→0`, `0.5s easeOut`, fires `once`).
+4. **Orphaned signature motion (dead code).** `TypeWriter.tsx` and `SlidingText.tsx` are fully built but imported nowhere. `SlidingText.tsx:33` also uses `transition-max-height` — **not a valid Tailwind utility**, so the intended collapse/expand is un-animated (latent bug, dormant).
+
+---
+
+## Known inconsistencies to reconcile
+
+Each row is a design-debt decision: pick one source of truth and migrate. Ordered roughly by blast radius.
+
+| # | What diverges | Where | Suggested single source of truth |
+|---|---|---|---|
+| 1 | **Brand pink = 3 values.** `#ef95ff` (pastypink token / `$secondary` / hero gradient), `#ff9ce3` (wordmark + highlights + light checkbox + focus rings, 57 hardcoded uses, in no palette), `#EDADF8` (`.pink-btn` / `.text-color-primary`). | `tailwind.config.ts:28`, `globals.css:485/516/585`, `HomePageSplash.tsx:16` | One canonical `brand.pink` token in `tailwind.config.ts`; migrate the 57 `#ff9ce3` literals and `#EDADF8`. The palette pink (`#ef95ff`) isn't even the pink users see. |
+| 2 | **Brand palette never reaches the semantic layer.** `--primary`/`--secondary`/`--accent`/`--ring`/`--chart-*` are 100% stock shadcn slate in both `:root` and `.dark`; brand is applied only as one-off hex on top. | `globals.css:34–91`, `tailwind.config.ts:26–29` | Decide on purpose: either keep the semantic layer intentionally neutral, or map `--primary`/`--accent`/`--ring` onto the brand palette so components inherit brand color. |
+| 3 | **"Primary" means two opposite colors.** SCSS `$primary` = cyan `#2ad4fc`; shadcn `--primary` = navy slate `222.2 47.4% 11.2%`. Code reading "primary" gets different intent per system. | `_colors.scss:1`, `globals.css:42` | Rename SCSS `$primary/$secondary/$tertiary` → `$brand-*`, or feed the brand palette into the shadcn tokens so the two agree. |
+| 4 | **`_colors.scss` is dead code.** Imported nowhere; duplicates the brand under a second naming scheme; its `.text-color-primary` (`$primary` = `#2ad4fc`) conflicts with the live `globals.css:516` definition (`#EDADF8`). | `_colors.scss` | Delete it, or wire it in and remove the shadowing. Do not keep a second brand naming scheme. |
+| 5 | **Dark mode = ~330 lines of `!important` overrides**, not token swaps. Neutral ramp hardcoded as slate hex (`#1a1a1a`, `#2d3748`, `#4a5568`, `#f7fafc`, `#a0aec0`) bypassing `--background`/`--card`/`--muted`. | `globals.css:102–532` | Migrate to token swaps in the `.dark` block so new components inherit dark styling. Long-term this is the highest-leverage cleanup. |
+| 6 | **`--subtitle-color` re-typed as a literal.** `rgb(89,48,97,0.6)` is both the light token and a raw literal in ~8 leaderboard/FunFacts overrides. Also the token uses malformed 4-arg `rgb()` (light) and drops alpha (dark). | `globals.css:61/89/138/281–303` | Reference the token instead of re-typing; fix `rgb(...)` → `rgba(...)`. |
+| 7 | **KoHo never loads in the app.** No `next/font`, `<link>`, `@font-face`, or font package. `.koho-*` and `.pink-btn` fall back to system sans; KoHo only loads in `public/*privacy.html`. | `layout.tsx`, `globals.css:572/578/587`, `package.json` | Decide if KoHo is the brand font. If yes, load once via `next/font/google` in `layout.tsx` and set as Tailwind `font-sans`. If no, delete the dead `.koho-*` classes. |
+| 8 | **Three parallel button systems.** cva `Button`, legacy `.pink-btn` (`LoginBtn`), hand-rolled `ThemeToggle` `<button>`. | `button.tsx`, `globals.css:584`, `ThemeToggle.tsx` | Standardize on shadcn `Button`; retire `.pink-btn`/`LoginBtn`. Keep `ThemeToggle` bespoke (documented exception). |
+| 9 | **Default Button has no hover state.** Stock `hover:bg-primary/90` was removed; every other variant has a hover. | `button.tsx:12` | Restore `hover:bg-primary/90` (or document the removal as intentional). |
+| 10 | **Input primitive stripped bare.** No border, no fixed height, no focus-visible ring; `text-base` instead of `text-sm`. Every form must re-add chrome. Inconsistent with fully-styled Textarea/Select. | `input.tsx:13` | Restore stock border/`h-10`/focus ring, or document Input as intentionally bare. |
+| 11 | **Textarea focus ring won't render.** Has `ring-ring` + `ring-offset-2` but is missing `focus-visible:ring-2` (no ring width). | `textarea.tsx:12` | Add `focus-visible:ring-2` to match Select/Button (accessibility). |
+| 12 | **Dialog hardcodes `dark:bg-gray-900`** instead of `bg-background`/`bg-card`, diverging from token-driven theming. | `dialog.tsx:41` | Use the surface token. |
+| 13 | **Two artist-link renderers.** `ArtistLinks` (list rows) vs `ArtistLinksGrid` (glass icon grid) — different visual languages for the same data. | `ArtistLinks.tsx`, `ArtistLinksGrid.tsx` | Pick one canonical renderer; retire or clearly scope the other. |
+| 14 | **No shared page-container primitive.** Max-widths diverge with no token: `800px` (artist), `2xl` (home/add-artist), `1000px` (nav). | per-page wrappers | Extract a `<PageContainer>` (e.g. `max-w-[800px] mx-auto px-4 sm:px-8 py-5`); reconcile the max-widths. |
+| 15 | **Dead container config.** `tailwind.config.ts` defines center/padding-2rem/2xl-1400px, but `.container` is used nowhere; real content width is 800–1000px. | `tailwind.config.ts:20` | Adopt the container class, or delete the config. |
+| 16 | **Inconsistent horizontal gutters.** `px-3` (nav), `px-4` (artist/admin), `px-5` (leaderboard/footer), `px-6` (home), stepping to `sm:px-8`/`sm:px-10`/`sm:p-6`. | multiple pages | Pick one step (e.g. `px-4 → sm:px-8`) and apply uniformly. |
+| 17 | **768px breakpoint expressed twice.** Raw SCSS `@media (max-width:768px)` in `globals.css` **and** Tailwind `md:` utilities. | `globals.css:631` | Fold the SCSS rules into `md:` utilities, or document why nav needs hand-written CSS. |
+| 18 | **Off-scale radii.** `.glass` 16px, `.glass-subtle` 12px, `.search-bar`/`.pink-btn` 5px — none derive from `--radius` (4/6/8px). | `globals.css:28/546/560/569/588` | Bring onto the `--radius` scale, or record as intentional brand exceptions. |
+| 19 | **Two card padding conventions.** Custom `.glass p-4/p-5` (primary panels) vs shadcn `Card p-6`. | `globals.css`, `card.tsx` | Pick one primary panel and align padding. |
+| 20 | **No motion token scale.** `duration-300` (22×) is de-facto standard, but SlidingText 500/1000ms, ThemeToggle 300ms, shadcn 150/200ms, framer 0.5s — all ad hoc. | codebase-wide | Define `--motion-fast 150ms` / `--motion-base 300ms` / `--motion-slow 500ms` + a standard easing; reference them. |
+| 21 | **No `prefers-reduced-motion` guard.** Infinite spins, `animate-ping`, scroll parallax, staggered feed all run unconditionally. | codebase-wide | Add a global strategy; use framer's `useReducedMotion` for scroll effects. |
+| 22 | **Two pink-glow hexes.** Hover glows use `rgba(239,149,255,x)` (`#ef95ff`); title shadow + highlight box-shadow use `rgba(255,156,227,x)` (`#ff9ce3`). | `ArtistLinksGrid.tsx`, `HomePageSplash.tsx`, `globals.css:414` | One `brand-glow` token. |
+| 23 | **Two vocabularies for the pink→purple gradient.** HeroSection raw hex `from-[#ef95ff] to-[#7c3aed]`; PressAndFeatures tokens `from-pastypink via-purple-900`. | `HeroSection.tsx:79`, `PressAndFeatures.tsx:68` | One expression (prefer tokens). |
+| 24 | **Dead typography.** `.home-text-h2`, `.home-text-height`, ~15 `!important` `#ff9ce3` overrides, `SlidingText.tsx`, `TypeWriter.tsx` — all legacy/unapplied. | `globals.css`, `_components/` | Delete, or wire back in. If keeping SlidingText, fix the invalid `transition-max-height`. |
+| 25 | **Dead animation code.** `accordion-down`/`up` (no Accordion), `.animate-scroll-left`/`-right`, `.animate-slow-spin` — zero usages. | `tailwind.config.ts`, `globals.css` | Delete or wire up. |
+| 26 | **Two fluid-heading definitions.** HomePageSplash h1 (32–84px inline) vs `.home-text-h2` (28–70px CSS) both re-implement the 360–1440px clamp by hand. | `HomePageSplash.tsx:13`, `globals.css:617` | Extract the clamp into a shared utility/token. |
+| 27 | **No custom type scale or font tokens.** Every `text-*` is a stock Tailwind default; no single source of truth for the type system. | codebase-wide | Document a minimal named scale (which `text-*` + weight = H1/H2/body/caption). |
+| 28 | **Cyan under two names.** `pastyblue` (Tailwind) and `$primary` (SCSS) both = `#2ad4fc`; pink has token + untracked literals. | `tailwind.config.ts`, `_colors.scss` | Consolidate naming across the two color systems. |
+| 29 | **Theme uses custom `ThemeProvider`, not `next-themes`** (the documented convention). | `_components/ThemeProvider.tsx` | Document this so contributors don't assume next-themes APIs. |
+| 30 | **ActivityFeed `--feed-*` is a parallel token system** — a well-structured light/dark set duplicating brand hex the rest of the app hardcodes. | `ActivityFeed.tsx:69–115` | Consider promoting into the shared token layer. |
+
+---
+
+## Proposing design changes
+
+This system evolves by editing tokens, not by scattering more literals. When you propose a change:
+
+1. **Change the token first, in the right place.** Color lives in three places today — keep them in sync deliberately:
+   - **Brand palette** → `tailwind.config.ts` `theme.extend.colors` (`pastypink`/`pastyblue`/`jellygreen`/`maroon`).
+   - **Semantic tokens** → `globals.css` `:root` / `.dark` (`--background`, `--primary`, `--radius`, etc.). Remember these are still stock slate — rebranding them is a deliberate, high-leverage act, not a casual edit.
+   - **SCSS** (`_colors.scss`) is currently **dead** — don't add to it unless you're intentionally reviving it.
+   Radius → `--radius`. Motion → introduce the `--motion-*` scale (see #20) rather than another `duration-*` literal.
+
+2. **State the change against this doc.** Name the token/utility/component you're touching, whether you're following a convention (e.g. `.glass p-4 sm:p-5` panels, `gap-2` clusters, the pink-glow-lift hover) or introducing a new one, and — if diverging — why.
+
+3. **Don't add a new hex, pink, blue, breakpoint, or button system.** Three pinks, two cyan names, three button systems, and two link renderers already exist. Migrate toward the named tokens; consolidate rather than extend. If you must add a one-off, add a row to [Known inconsistencies](#known-inconsistencies-to-reconcile) so it's tracked, not lost.
+
+4. **Prefer token swaps over `!important` dark overrides.** The `.dark` override wall is the most brittle part of the system. New components should inherit dark styling from tokens; adding another `!important` patch is a regression, not a fix.
+
+5. **Style at the custom-component layer, not the primitives.** Brand identity lives in `src/app/_components/` and the global utilities. The shadcn primitives are mostly stock — fork them only to fix a documented deviation (Input focus ring, default Button hover), not to inject brand color.
+
+6. **Honor the personality.** Neon accents on quiet chrome; glass surfaces; round everything; calm ambient motion; lowercase friendly voice; pink identity in light, cyan/green in dark. When in doubt, the `music nerd` wordmark and the `.glass` panel are the templates.

--- a/design-system/colors/brand-palette.html
+++ b/design-system/colors/brand-palette.html
@@ -1,0 +1,365 @@
+<!-- @dsCard group="Colors" name="Brand palette" subtitle="maroon · pastyblue · pastypink · jellygreen + the 3 pinks" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Brand palette — MusicNerdWeb</title>
+<style>
+  :root {
+    --canvas: #ffffff;
+    --ink: #422b46;          /* maroon — the brand "ink" */
+    --hairline: #ece7ee;
+    --muted: #8a7f90;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--canvas);
+    color: var(--ink);
+    font-family: var(--sans);
+    line-height: 1.45;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 32px 28px 40px;
+  }
+
+  header { margin-bottom: 28px; }
+
+  h1 {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin: 0 0 6px;
+  }
+
+  .lede {
+    font-size: 13.5px;
+    color: var(--muted);
+    margin: 0;
+    max-width: 62ch;
+  }
+
+  .lede code {
+    font-family: var(--mono);
+    font-size: 12px;
+    background: #f5f1f6;
+    padding: 1px 5px;
+    border-radius: 4px;
+    color: #6f4b75;
+  }
+
+  .section-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
+    color: var(--muted);
+    margin: 30px 0 14px;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+  }
+  .section-label .count {
+    font-weight: 400;
+    text-transform: none;
+    letter-spacing: 0;
+    color: #b3a8ba;
+  }
+
+  /* ---- Brand swatch grid ---- */
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+  }
+
+  .swatch {
+    border-radius: 8px;                 /* --radius 0.5rem = 8px */
+    overflow: hidden;
+    border: 1px solid var(--hairline);
+    background: #fff;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .chip {
+    height: 118px;
+    display: flex;
+    align-items: flex-end;
+    padding: 12px;
+  }
+  .chip .role {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    padding: 3px 8px;
+    border-radius: 999px;
+    background: rgba(255,255,255,0.35);
+    backdrop-filter: blur(2px);
+  }
+
+  .meta {
+    padding: 12px 13px 14px;
+  }
+  .meta .name {
+    font-size: 15px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin: 0 0 2px;
+  }
+  .meta .cls {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    color: #6f4b75;
+    margin: 0 0 8px;
+  }
+  .meta .hex {
+    font-family: var(--mono);
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    margin: 0 0 3px;
+  }
+  .meta .use {
+    font-size: 11.5px;
+    color: var(--muted);
+    margin: 0;
+    line-height: 1.35;
+  }
+
+  /* ---- Pink fragmentation row ---- */
+  .pink-panel {
+    border: 1px solid var(--hairline);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .pink-head {
+    padding: 13px 16px;
+    background: #fbf7fc;
+    border-bottom: 1px solid var(--hairline);
+  }
+  .pink-head .title {
+    font-size: 14px;
+    font-weight: 700;
+    margin: 0 0 3px;
+  }
+  .pink-head .sub {
+    font-size: 12px;
+    color: var(--muted);
+    margin: 0;
+  }
+  .pink-row {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .pink-cell {
+    padding: 0;
+    border-right: 1px solid var(--hairline);
+    display: flex;
+    flex-direction: column;
+  }
+  .pink-cell:last-child { border-right: 0; }
+  .pink-bar {
+    height: 76px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .pink-bar .hexlabel {
+    font-family: var(--mono);
+    font-size: 13px;
+    font-weight: 700;
+    color: #422b46;
+    background: rgba(255,255,255,0.55);
+    padding: 3px 9px;
+    border-radius: 999px;
+  }
+  .pink-info {
+    padding: 11px 13px 14px;
+  }
+  .pink-info .tok {
+    font-size: 12.5px;
+    font-weight: 700;
+    margin: 0 0 3px;
+  }
+  .pink-info .where {
+    font-size: 11.5px;
+    color: var(--muted);
+    margin: 0 0 6px;
+    line-height: 1.35;
+  }
+  .pink-info .src {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    color: #9b83a0;
+    margin: 0;
+  }
+  .badge {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 600;
+    padding: 1px 6px;
+    border-radius: 4px;
+    margin-top: 6px;
+  }
+  .badge.palette { background: #e6f9f2; color: #0a8a63; }
+  .badge.orphan  { background: #ffeef8; color: #b23a86; }
+
+  footer {
+    margin-top: 26px;
+    padding-top: 16px;
+    border-top: 1px solid var(--hairline);
+    font-size: 11.5px;
+    color: var(--muted);
+    line-height: 1.5;
+  }
+  footer code {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: #6f4b75;
+  }
+
+  @media (max-width: 520px) {
+    .pink-row { grid-template-columns: 1fr; }
+    .pink-cell { border-right: 0; border-bottom: 1px solid var(--hairline); }
+    .pink-cell:last-child { border-bottom: 0; }
+  }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <h1>Brand palette</h1>
+      <p class="lede">
+        The four Tailwind brand colors from <code>tailwind.config.ts</code> (lines 26–29). These are
+        plain color extensions — <strong>not</strong> wired into the shadcn semantic
+        <code>--primary</code>/<code>--accent</code> tokens, which stay stock navy "slate."
+        Brand character is layered on top as ad-hoc hex.
+      </p>
+    </header>
+
+    <div class="section-label">The neon accent trio + the ink</div>
+
+    <div class="grid">
+      <!-- maroon -->
+      <div class="swatch">
+        <div class="chip" style="background:#422b46;">
+          <span class="role" style="color:#f3e9f4;">ink / body text</span>
+        </div>
+        <div class="meta">
+          <p class="name">maroon</p>
+          <p class="cls">text-maroon</p>
+          <p class="hex">#422b46</p>
+          <p class="use">Deep aubergine for footer + body text. Forced to white in dark mode.</p>
+        </div>
+      </div>
+
+      <!-- pastyblue -->
+      <div class="swatch">
+        <div class="chip" style="background:#2ad4fc;">
+          <span class="role" style="color:#0b3a45;">accent · cyan</span>
+        </div>
+        <div class="meta">
+          <p class="name">pastyblue</p>
+          <p class="cls">bg-pastyblue</p>
+          <p class="hex">#2ad4fc</p>
+          <p class="use">Takes over as the accent in dark mode (checkbox, moon icon).</p>
+        </div>
+      </div>
+
+      <!-- pastypink -->
+      <div class="swatch">
+        <div class="chip" style="background:#ef95ff;">
+          <span class="role" style="color:#5a2b66;">accent · pink</span>
+        </div>
+        <div class="meta">
+          <p class="name">pastypink</p>
+          <p class="cls">text-pastypink</p>
+          <p class="hex">#ef95ff</p>
+          <p class="use">Most-used brand token (~93 uses). The hero gradient pink.</p>
+        </div>
+      </div>
+
+      <!-- jellygreen -->
+      <div class="swatch">
+        <div class="chip" style="background:#19ffb8;">
+          <span class="role" style="color:#0a5c42;">accent · mint</span>
+        </div>
+        <div class="meta">
+          <p class="name">jellygreen</p>
+          <p class="cls">bg-jellygreen</p>
+          <p class="hex">#19ffb8</p>
+          <p class="use">Jelly mint-green. Appears mostly as raw hex in the activity feed.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="section-label">
+      Brand pink is fragmented into 3 values
+      <span class="count">— an honest signature of the current system</span>
+    </div>
+
+    <div class="pink-panel">
+      <div class="pink-head">
+        <p class="title">One pink, three hexes that never reconcile</p>
+        <p class="sub">The pink you actually see on screen (<code style="font-family:var(--mono);font-size:11px;">#ff9ce3</code>) is not the palette token — it lives outside <code style="font-family:var(--mono);font-size:11px;">tailwind.config.ts</code> as 57 hardcoded uses.</p>
+      </div>
+      <div class="pink-row">
+        <!-- #ef95ff -->
+        <div class="pink-cell">
+          <div class="pink-bar" style="background:#ef95ff;">
+            <span class="hexlabel">#ef95ff</span>
+          </div>
+          <div class="pink-info">
+            <p class="tok">pastypink token</p>
+            <p class="where">HeroSection gradient, general accent. The one that lives in the palette.</p>
+            <p class="src">tailwind.config.ts:28 · _colors.scss:2 ($secondary)</p>
+            <span class="badge palette">IN PALETTE</span>
+          </div>
+        </div>
+
+        <!-- #ff9ce3 -->
+        <div class="pink-cell">
+          <div class="pink-bar" style="background:#ff9ce3;">
+            <span class="hexlabel">#ff9ce3</span>
+          </div>
+          <div class="pink-info">
+            <p class="tok">on-screen pink · 57 uses</p>
+            <p class="where">"music nerd" title glow, highlight borders, light checked checkbox, focus rings, feed.</p>
+            <p class="src">globals.css:168–277, 485–488 · hardcoded</p>
+            <span class="badge orphan">NOT IN PALETTE</span>
+          </div>
+        </div>
+
+        <!-- #edadf8 -->
+        <div class="pink-cell">
+          <div class="pink-bar" style="background:#edadf8;">
+            <span class="hexlabel">#edadf8</span>
+          </div>
+          <div class="pink-info">
+            <p class="tok">.pink-btn pink</p>
+            <p class="where">Login button background + <code style="font-family:var(--mono);font-size:10.5px;">.text-color-primary</code>. A third distinct value.</p>
+            <p class="src">globals.css:516, 585</p>
+            <span class="badge orphan">NOT IN PALETTE</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <footer>
+      Values verified against <code>tailwind.config.ts</code>, <code>src/app/_colors.scss</code>, and DESIGN.md §Color.
+      Radius base <code>--radius: 0.5rem</code> (8px). Type renders in the system sans stack
+      (<code>-apple-system, …</code>) — the intended brand font <strong>KoHo</strong> is declared but never loads in the app.
+    </footer>
+  </div>
+</body>
+</html>

--- a/design-system/colors/semantic-tokens.html
+++ b/design-system/colors/semantic-tokens.html
@@ -1,0 +1,200 @@
+<!-- @dsCard group="Colors" name="Semantic tokens" subtitle="stock shadcn slate · light + dark" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  :root {
+    --radius: 0.5rem;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: var(--sans);
+    background: #ffffff;
+    color: hsl(222.2 84% 4.9%);
+    -webkit-font-smoothing: antialiased;
+    padding: 28px;
+  }
+  .wrap { max-width: 860px; margin: 0 auto; }
+
+  header { margin-bottom: 20px; }
+  h1 {
+    font-size: 19px;
+    font-weight: 650;
+    letter-spacing: -0.01em;
+    margin: 0 0 4px;
+  }
+  .sub {
+    font-size: 13px;
+    color: hsl(215.4 16.3% 46.9%);
+    margin: 0;
+  }
+  .sub code {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: hsl(222.2 47.4% 11.2%);
+    background: hsl(210 40% 96.1%);
+    padding: 1px 5px;
+    border-radius: 4px;
+  }
+
+  .cols {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+  @media (max-width: 620px) { .cols { grid-template-columns: 1fr; } }
+
+  .panel {
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid rgba(0,0,0,0.08);
+  }
+  .panel-light {
+    background: hsl(0 0% 100%);
+    color: hsl(222.2 84% 4.9%);
+  }
+  .panel-dark {
+    background: hsl(222.2 84% 4.9%);
+    color: hsl(210 40% 98%);
+    border-color: rgba(255,255,255,0.10);
+  }
+
+  .panel-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 11px 14px;
+    font-size: 11px;
+    font-weight: 650;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    border-bottom: 1px solid rgba(0,0,0,0.06);
+  }
+  .panel-dark .panel-head { border-bottom-color: rgba(255,255,255,0.08); }
+  .mode-dot {
+    width: 13px; height: 13px; border-radius: 50%;
+    box-shadow: inset 0 0 0 1px rgba(128,128,128,0.35);
+  }
+  .panel-light .mode-dot { background: #ffffff; }
+  .panel-dark  .mode-dot { background: hsl(222.2 84% 4.9%); box-shadow: inset 0 0 0 1px rgba(255,255,255,0.35); }
+
+  .row {
+    display: grid;
+    grid-template-columns: 30px 1fr auto;
+    align-items: center;
+    gap: 11px;
+    padding: 8px 14px;
+  }
+  .row + .row { border-top: 1px solid rgba(128,128,128,0.10); }
+
+  .swatch {
+    width: 30px; height: 30px;
+    border-radius: 6px;
+    /* hairline ring so pure-white / near-black swatches stay visible on either canvas */
+    box-shadow: inset 0 0 0 1px rgba(128,128,128,0.28);
+  }
+
+  .name {
+    font-family: var(--mono);
+    font-size: 12.5px;
+    font-weight: 500;
+  }
+  .val {
+    font-family: var(--mono);
+    font-size: 11px;
+    text-align: right;
+    opacity: 0.62;
+    white-space: nowrap;
+  }
+
+  .caption {
+    margin-top: 18px;
+    padding: 13px 15px;
+    border: 1px solid rgba(0,0,0,0.08);
+    border-radius: var(--radius);
+    background: hsl(210 40% 96.1%);
+    font-size: 12.5px;
+    line-height: 1.55;
+    color: hsl(222.2 47.4% 11.2%);
+  }
+  .caption strong { font-weight: 650; }
+  .caption .chip {
+    display: inline-block;
+    width: 10px; height: 10px;
+    border-radius: 3px;
+    vertical-align: -1px;
+    margin: 0 1px;
+    box-shadow: inset 0 0 0 1px rgba(0,0,0,0.12);
+  }
+  .caption code {
+    font-family: var(--mono);
+    font-size: 11.5px;
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>Semantic tokens</h1>
+    <p class="sub">Unmodified stock shadcn <code>slate</code> — <code>globals.css</code> <code>:root</code> / <code>.dark</code>, resolved from real HSL</p>
+  </header>
+
+  <div class="cols">
+    <!-- LIGHT -->
+    <div class="panel panel-light">
+      <div class="panel-head"><span class="mode-dot"></span>Light · :root</div>
+
+      <div class="row"><div class="swatch" style="background:hsl(0 0% 100%)"></div><div class="name">background</div><div class="val">0 0% 100%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(222.2 84% 4.9%)"></div><div class="name">foreground</div><div class="val">222.2 84% 4.9%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(0 0% 100%)"></div><div class="name">card</div><div class="val">0 0% 100%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(0 0% 100%)"></div><div class="name">popover</div><div class="val">0 0% 100%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(222.2 47.4% 11.2%)"></div><div class="name">primary</div><div class="val">222.2 47.4% 11.2%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(210 40% 96.1%)"></div><div class="name">secondary</div><div class="val">210 40% 96.1%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(210 40% 96.1%)"></div><div class="name">muted</div><div class="val">210 40% 96.1%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(210 40% 96.1%)"></div><div class="name">accent</div><div class="val">210 40% 96.1%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(0 84.2% 60.2%)"></div><div class="name">destructive</div><div class="val">0 84.2% 60.2%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(214.3 31.8% 91.4%)"></div><div class="name">border</div><div class="val">214.3 31.8% 91.4%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(214.3 31.8% 91.4%)"></div><div class="name">input</div><div class="val">214.3 31.8% 91.4%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(222.2 84% 4.9%)"></div><div class="name">ring</div><div class="val">222.2 84% 4.9%</div></div>
+    </div>
+
+    <!-- DARK -->
+    <div class="panel panel-dark">
+      <div class="panel-head"><span class="mode-dot"></span>Dark · .dark</div>
+
+      <div class="row"><div class="swatch" style="background:hsl(222.2 84% 4.9%)"></div><div class="name">background</div><div class="val">222.2 84% 4.9%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(210 40% 98%)"></div><div class="name">foreground</div><div class="val">210 40% 98%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(222.2 84% 4.9%)"></div><div class="name">card</div><div class="val">222.2 84% 4.9%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(222.2 84% 4.9%)"></div><div class="name">popover</div><div class="val">222.2 84% 4.9%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(210 40% 98%)"></div><div class="name">primary</div><div class="val">210 40% 98%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(217.2 32.6% 17.5%)"></div><div class="name">secondary</div><div class="val">217.2 32.6% 17.5%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(217.2 32.6% 17.5%)"></div><div class="name">muted</div><div class="val">217.2 32.6% 17.5%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(217.2 32.6% 17.5%)"></div><div class="name">accent</div><div class="val">217.2 32.6% 17.5%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(0 62.8% 30.6%)"></div><div class="name">destructive</div><div class="val">0 62.8% 30.6%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(217.2 32.6% 17.5%)"></div><div class="name">border</div><div class="val">217.2 32.6% 17.5%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(217.2 32.6% 17.5%)"></div><div class="name">input</div><div class="val">217.2 32.6% 17.5%</div></div>
+      <div class="row"><div class="swatch" style="background:hsl(212.7 26.8% 83.9%)"></div><div class="name">ring</div><div class="val">212.7 26.8% 83.9%</div></div>
+    </div>
+  </div>
+
+  <p class="caption">
+    These twelve tokens are <strong>unmodified stock shadcn/ui &ldquo;slate&rdquo;</strong> — navy
+    <code>primary 222.2&nbsp;47.4%&nbsp;11.2%</code>, cool-grey <code>secondary/muted/accent 210&nbsp;40%&nbsp;96.1%</code>,
+    red <code>destructive 0&nbsp;84.2%&nbsp;60.2%</code>. The semantic layer was scaffolded from shadcn and
+    <strong>never rebranded</strong>: none of them carry MusicNerd&rsquo;s identity. The brand palette lives
+    <strong>outside</strong> these tokens as hardcoded hex — pink
+    <span class="chip" style="background:#ff9ce3"></span><code>#ff9ce3</code> /
+    <span class="chip" style="background:#ef95ff"></span><code>#ef95ff</code> /
+    <span class="chip" style="background:#edadf8"></span><code>#edadf8</code>, blue
+    <span class="chip" style="background:#2ad4fc"></span><code>#2ad4fc</code>, green
+    <span class="chip" style="background:#19ffb8"></span><code>#19ffb8</code>, maroon
+    <span class="chip" style="background:#422b46"></span><code>#422b46</code> — applied via 200+ literal uses and
+    <code>!important</code> dark overrides, not through <code>hsl(var(--token))</code>.
+  </p>
+</div>
+</body>
+</html>

--- a/design-system/components/badge.html
+++ b/design-system/components/badge.html
@@ -1,0 +1,278 @@
+<!-- @dsCard group="Components" name="Badge" subtitle="all cva variants" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  :root {
+    /* shadcn "slate" light tokens, verbatim from globals.css :root */
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --radius: 0.5rem;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    /* Reality: KoHo is declared but never loads in the app -> system sans */
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: hsl(var(--background));       /* --background 0 0% 100% */
+    color: hsl(var(--foreground));            /* --foreground 222.2 84% 4.9% */
+    padding: 40px 44px 48px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap { max-width: 760px; margin: 0 auto; }
+
+  h1 {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin: 0 0 4px;
+  }
+
+  .lede {
+    font-size: 13.5px;
+    color: hsl(var(--muted-foreground));      /* --muted-foreground 215.4 16.3% 46.9% */
+    margin: 0 0 6px;
+    max-width: 620px;
+  }
+
+  .mono {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
+
+  /* ---- the actual Badge base recipe, resolved from cva ---- */
+  /* "inline-flex items-center rounded-full border px-2.5 py-0.5
+      text-xs font-semibold transition-colors" */
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 9999px;               /* rounded-full */
+    border: 1px solid transparent;        /* border */
+    padding: 2px 10px;                    /* py-0.5 px-2.5 */
+    font-size: 12px;                      /* text-xs */
+    line-height: 16px;
+    font-weight: 600;                     /* font-semibold */
+    white-space: nowrap;
+    transition: background-color .15s, color .15s, border-color .15s;
+  }
+
+  /* variant: default -> bg-primary / text-primary-foreground / border-transparent */
+  .badge--default {
+    background: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    border-color: transparent;
+  }
+  /* variant: secondary -> bg-secondary / text-secondary-foreground / border-transparent */
+  .badge--secondary {
+    background: hsl(var(--secondary));
+    color: hsl(var(--secondary-foreground));
+    border-color: transparent;
+  }
+  /* variant: destructive -> bg-destructive / text-destructive-foreground / border-transparent */
+  .badge--destructive {
+    background: hsl(var(--destructive));
+    color: hsl(var(--destructive-foreground));
+    border-color: transparent;
+  }
+  /* variant: outline -> text-foreground only (transparent bg, default --border ring) */
+  .badge--outline {
+    background: transparent;
+    color: hsl(var(--foreground));
+    border-color: hsl(var(--border));    /* inherits base `border` -> --border */
+  }
+
+  /* ---- specimen rows ---- */
+  .rows {
+    margin-top: 26px;
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);         /* 0.5rem = 8px */
+    overflow: hidden;
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: 170px 1fr;
+    gap: 20px;
+    align-items: center;
+    padding: 20px 22px;
+    border-top: 1px solid hsl(var(--border));
+  }
+  .row:first-child { border-top: none; }
+
+  .specimen {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .vname {
+    font-size: 13px;
+    font-weight: 600;
+  }
+  .vsub {
+    display: block;
+    margin-top: 3px;
+    font-size: 11px;
+    color: hsl(var(--muted-foreground));
+  }
+
+  .tokens {
+    font-size: 11.5px;
+    color: hsl(var(--muted-foreground));
+    line-height: 1.7;
+  }
+  .tokens .k { color: hsl(var(--foreground)); }
+  .sw {
+    display: inline-block;
+    width: 9px; height: 9px;
+    border-radius: 2px;
+    vertical-align: middle;
+    margin-right: 5px;
+    border: 1px solid rgba(0,0,0,.12);
+  }
+
+  .base {
+    margin-top: 22px;
+    font-size: 11.5px;
+    color: hsl(var(--muted-foreground));
+    background: hsl(var(--secondary));
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    padding: 12px 14px;
+    line-height: 1.75;
+  }
+  .base b { color: hsl(var(--foreground)); font-weight: 600; }
+
+  .note {
+    margin-top: 16px;
+    font-size: 11.5px;
+    color: hsl(var(--muted-foreground));
+    border-left: 3px solid hsl(var(--destructive));
+    padding: 4px 0 4px 12px;
+  }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Badge</h1>
+    <p class="lede">
+      Every <span class="mono">badgeVariants</span> cva variant from
+      <span class="mono">src/components/ui/badge.tsx</span>, resolved to literal CSS
+      from the stock shadcn &ldquo;slate&rdquo; tokens. No brand pink/blue/green reaches
+      these &mdash; the semantic layer was never rebranded.
+    </p>
+
+    <div class="rows">
+
+      <!-- DEFAULT -->
+      <div class="row">
+        <div>
+          <span class="vname">default</span>
+          <span class="vsub mono">variant="default" (defaultVariant)</span>
+        </div>
+        <div>
+          <div class="specimen">
+            <span class="badge badge--default">Verified</span>
+            <span class="badge badge--default">new</span>
+            <span class="badge badge--default">2ad4fc</span>
+          </div>
+          <div class="tokens mono" style="margin-top:12px">
+            <div><span class="sw" style="background:hsl(222.2 47.4% 11.2%)"></span><span class="k">bg-primary</span> &rarr; hsl(222.2 47.4% 11.2%) &middot; #0f172a</div>
+            <div><span class="sw" style="background:hsl(210 40% 98%)"></span><span class="k">text-primary-foreground</span> &rarr; hsl(210 40% 98%) &middot; #f8fafc</div>
+            <div>border-transparent &middot; hover:bg-primary/80</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- SECONDARY -->
+      <div class="row">
+        <div>
+          <span class="vname">secondary</span>
+          <span class="vsub mono">variant="secondary"</span>
+        </div>
+        <div>
+          <div class="specimen">
+            <span class="badge badge--secondary">Draft</span>
+            <span class="badge badge--secondary">social</span>
+            <span class="badge badge--secondary">pending</span>
+          </div>
+          <div class="tokens mono" style="margin-top:12px">
+            <div><span class="sw" style="background:hsl(210 40% 96.1%)"></span><span class="k">bg-secondary</span> &rarr; hsl(210 40% 96.1%) &middot; #f1f5f9</div>
+            <div><span class="sw" style="background:hsl(222.2 47.4% 11.2%)"></span><span class="k">text-secondary-foreground</span> &rarr; hsl(222.2 47.4% 11.2%) &middot; #0f172a</div>
+            <div>border-transparent &middot; hover:bg-secondary/80</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- DESTRUCTIVE -->
+      <div class="row">
+        <div>
+          <span class="vname">destructive</span>
+          <span class="vsub mono">variant="destructive"</span>
+        </div>
+        <div>
+          <div class="specimen">
+            <span class="badge badge--destructive">Removed</span>
+            <span class="badge badge--destructive">error</span>
+            <span class="badge badge--destructive">revoked</span>
+          </div>
+          <div class="tokens mono" style="margin-top:12px">
+            <div><span class="sw" style="background:hsl(0 84.2% 60.2%)"></span><span class="k">bg-destructive</span> &rarr; hsl(0 84.2% 60.2%) &middot; #ef4444</div>
+            <div><span class="sw" style="background:hsl(210 40% 98%)"></span><span class="k">text-destructive-foreground</span> &rarr; hsl(210 40% 98%) &middot; #f8fafc</div>
+            <div>border-transparent &middot; hover:bg-destructive/80</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- OUTLINE -->
+      <div class="row">
+        <div>
+          <span class="vname">outline</span>
+          <span class="vsub mono">variant="outline"</span>
+        </div>
+        <div>
+          <div class="specimen">
+            <span class="badge badge--outline">Listen</span>
+            <span class="badge badge--outline">web3</span>
+            <span class="badge badge--outline">optional</span>
+          </div>
+          <div class="tokens mono" style="margin-top:12px">
+            <div><span class="sw" style="background:transparent"></span>bg &rarr; transparent (no bg utility)</div>
+            <div><span class="sw" style="background:hsl(222.2 84% 4.9%)"></span><span class="k">text-foreground</span> &rarr; hsl(222.2 84% 4.9%) &middot; #020817</div>
+            <div><span class="sw" style="background:hsl(214.3 31.8% 91.4%)"></span>border &rarr; base <span class="k">border</span> = hsl(214.3 31.8% 91.4%) &middot; #e2e8f0</div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <div class="base">
+      <b>Base recipe</b> (applies to all variants):
+      <span class="mono">inline-flex items-center <b>rounded-full</b> (9999px) border
+      <b>px-2.5</b> (10px) <b>py-0.5</b> (2px) <b>text-xs</b> (12/16px)
+      <b>font-semibold</b> (600) transition-colors</span>. Focus ring:
+      <span class="mono">focus:ring-2 focus:ring-ring focus:ring-offset-2</span>.
+      Note badges use full pill rounding, not <span class="mono">--radius: 0.5rem</span>.
+    </div>
+
+    <div class="note">
+      Font reality: the badge text renders in the system sans stack. KoHo is the declared
+      brand typeface but never loads in the React app, so all <span class="mono">text-xs</span>
+      badges fall back to <span class="mono">-apple-system / Segoe UI / Roboto</span>.
+    </div>
+  </div>
+</body>
+</html>

--- a/design-system/components/button.html
+++ b/design-system/components/button.html
@@ -1,0 +1,365 @@
+<!-- @dsCard group="Buttons" name="Button" subtitle="6 cva variants × 4 sizes + legacy pink-btn" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  :root {
+    /* Resolved light-mode semantic tokens (stock shadcn slate, globals.css :root) */
+    --primary: #0f172a;             /* hsl(222.2 47.4% 11.2%) */
+    --primary-foreground: #f8fafc;  /* hsl(210 40% 98%)       */
+    --destructive: #ef4444;         /* hsl(0 84.2% 60.2%)     */
+    --destructive-foreground: #f8fafc;
+    --secondary: #f1f5f9;           /* hsl(210 40% 96.1%)     */
+    --secondary-foreground: #0f172a;
+    --accent: #f1f5f9;              /* hsl(210 40% 96.1%)     */
+    --accent-foreground: #0f172a;
+    --background: #ffffff;          /* hsl(0 0% 100%)         */
+    --foreground: #020817;          /* hsl(222.2 84% 4.9%)    */
+    --input: #e2e8f0;               /* hsl(214.3 31.8% 91.4%) */
+    --ring: #020817;                /* hsl(222.2 84% 4.9%)    */
+    --md-radius: 6px;               /* rounded-md = calc(--radius[.5rem] - 2px) */
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    padding: 32px;
+    background: var(--background);
+    color: var(--foreground);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    line-height: 1.4;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap { max-width: 860px; margin: 0 auto; }
+
+  header { margin-bottom: 28px; }
+  h1 {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin: 0 0 4px;
+  }
+  .sub { font-size: 13px; color: #64748b; margin: 0 0 6px; }
+  .src {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 11px;
+    color: #94a3b8;
+  }
+
+  section { margin-top: 34px; }
+  .sec-title {
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #475569;
+    margin: 0 0 4px;
+  }
+  .sec-note {
+    font-size: 12px;
+    color: #94a3b8;
+    margin: 0 0 18px;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 16px;
+  }
+
+  .cell {
+    border: 1px solid #eef2f6;
+    border-radius: 10px;
+    padding: 18px 16px 14px;
+    background: #fbfcfd;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .cell .stage {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+  }
+  .cell .name {
+    font-size: 12px;
+    font-weight: 600;
+    color: #0f172a;
+  }
+  .cell .cap {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 10.5px;
+    line-height: 1.55;
+    color: #64748b;
+    word-break: break-word;
+  }
+  .cap .k { color: #94a3b8; }
+
+  /* ── shared cva base: real classes from button.tsx line 8 ── */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+    border-radius: var(--md-radius);       /* rounded-md */
+    font-size: 14px;                        /* text-sm    */
+    line-height: 20px;
+    font-weight: 500;                       /* font-medium */
+    /* font-sans → system stack (KoHo never loads); see note */
+    font-family: inherit;
+    transition: background-color .15s, color .15s;
+    cursor: pointer;
+    border: 1px solid transparent;
+    /* default size: h-10 px-4 py-2 */
+    height: 40px;
+    padding: 8px 16px;
+  }
+  .btn:focus-visible {                      /* focus-visible:ring-2 ring-ring ring-offset-2 */
+    outline: none;
+    box-shadow: 0 0 0 2px var(--background), 0 0 0 4px var(--ring);
+  }
+
+  /* ── variants (resolved) ── */
+  .v-default {
+    background: var(--primary);
+    color: var(--primary-foreground);
+    /* NB: no hover — stock hover:bg-primary/90 was removed */
+  }
+  .v-destructive {
+    background: var(--destructive);
+    color: var(--destructive-foreground);
+  }
+  .v-destructive:hover { background: #f15656; } /* destructive/90 over white */
+  .v-outline {
+    border-color: var(--input);
+    background: var(--background);
+    color: var(--foreground);
+  }
+  .v-outline:hover { background: var(--accent); color: var(--accent-foreground); }
+  .v-secondary {
+    background: var(--secondary);
+    color: var(--secondary-foreground);
+  }
+  .v-secondary:hover { background: #e8eef4; }   /* secondary/80 over white */
+  .v-ghost {
+    background: transparent;
+    color: var(--foreground);
+  }
+  .v-ghost:hover { background: var(--accent); color: var(--accent-foreground); }
+  .v-link {
+    background: transparent;
+    color: var(--primary);
+    text-underline-offset: 4px;
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .v-link:hover { text-decoration: underline; }
+
+  /* ── size scale (default variant) ── */
+  .s-sm    { height: 36px; padding: 0 12px; }   /* h-9  px-3 */
+  .s-lg    { height: 48px; padding: 0 32px; }   /* h-12 px-8 */
+  .s-icon  { height: 40px; width: 40px; padding: 0; }  /* h-10 w-10 */
+
+  .row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 18px;
+  }
+  .sizecell { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+  .sizecell .lab {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 11px;
+    color: #64748b;
+    text-align: center;
+  }
+  .sizecell .lab b { color: #0f172a; font-weight: 600; }
+
+  /* ── legacy pink-btn (globals.css:584) ── */
+  .pink-btn {
+    background-color: #EDADF8;
+    color: #422B46;
+    /* font-family: "KoHo" declared → falls back to system sans (never loads) */
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    border-radius: 5px;                     /* off-scale, not from --radius */
+    padding: 5px 30px;
+    font-size: 18px;
+    border: none;
+    cursor: pointer;
+    line-height: 1.4;
+  }
+  .legacy {
+    border: 1px solid #f0dbf5;
+    background: #fdf7ff;
+    border-radius: 10px;
+    padding: 20px 18px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    max-width: 420px;
+  }
+  .tag {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #7c3a86;
+    background: #f6e4fb;
+    border-radius: 999px;
+    padding: 3px 9px;
+    align-self: flex-start;
+  }
+
+  .notes {
+    margin-top: 36px;
+    border-top: 1px solid #eef2f6;
+    padding-top: 16px;
+  }
+  .notes ul { margin: 0; padding-left: 18px; }
+  .notes li { font-size: 12px; color: #64748b; margin-bottom: 6px; }
+  .notes code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 11px;
+    background: #f1f5f9;
+    padding: 1px 5px;
+    border-radius: 4px;
+    color: #334155;
+  }
+  .swatch {
+    display: inline-block;
+    width: 9px; height: 9px;
+    border-radius: 2px;
+    vertical-align: middle;
+    margin-right: 3px;
+    border: 1px solid rgba(0,0,0,.08);
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>Button</h1>
+    <p class="sub">6 cva variants × 4 sizes + legacy pink-btn — <code style="font-family:ui-monospace,monospace;font-size:12px">buttonVariants</code> resolved to literal CSS from stock shadcn slate tokens.</p>
+    <p class="src">src/components/ui/button.tsx&nbsp;·&nbsp;globals.css :root / .pink-btn</p>
+  </header>
+
+  <!-- ── VARIANTS ── -->
+  <section>
+    <p class="sec-title">6 cva variants</p>
+    <p class="sec-note">Default size (h-10 px-4 py-2), rounded-md 6px, text-sm/font-medium. Rendered on white <span style="font-family:ui-monospace,monospace">--background</span>.</p>
+    <div class="grid">
+
+      <div class="cell">
+        <div class="stage"><button class="btn v-default">Default</button></div>
+        <div class="name">default</div>
+        <div class="cap"><span class="k">bg</span> bg-primary <span class="swatch" style="background:#0f172a"></span>#0f172a<br>
+        <span class="k">text</span> primary-foreground <span class="swatch" style="background:#f8fafc"></span>#f8fafc<br>
+        <span class="k">hover</span> none <span style="color:#b45309">(stock hover removed)</span></div>
+      </div>
+
+      <div class="cell">
+        <div class="stage"><button class="btn v-destructive">Destructive</button></div>
+        <div class="name">destructive</div>
+        <div class="cap"><span class="k">bg</span> bg-destructive <span class="swatch" style="background:#ef4444"></span>#ef4444<br>
+        <span class="k">text</span> destructive-foreground <span class="swatch" style="background:#f8fafc"></span>#f8fafc<br>
+        <span class="k">hover</span> bg-destructive/90</div>
+      </div>
+
+      <div class="cell">
+        <div class="stage"><button class="btn v-outline">Outline</button></div>
+        <div class="name">outline</div>
+        <div class="cap"><span class="k">bd</span> border-input <span class="swatch" style="background:#e2e8f0"></span>#e2e8f0<br>
+        <span class="k">bg</span> background <span class="swatch" style="background:#ffffff"></span>#ffffff · <span class="k">text</span> #020817<br>
+        <span class="k">hover</span> bg-accent <span class="swatch" style="background:#f1f5f9"></span>#f1f5f9</div>
+      </div>
+
+      <div class="cell">
+        <div class="stage"><button class="btn v-secondary">Secondary</button></div>
+        <div class="name">secondary</div>
+        <div class="cap"><span class="k">bg</span> bg-secondary <span class="swatch" style="background:#f1f5f9"></span>#f1f5f9<br>
+        <span class="k">text</span> secondary-foreground <span class="swatch" style="background:#0f172a"></span>#0f172a<br>
+        <span class="k">hover</span> bg-secondary/80</div>
+      </div>
+
+      <div class="cell">
+        <div class="stage"><button class="btn v-ghost">Ghost</button></div>
+        <div class="name">ghost</div>
+        <div class="cap"><span class="k">bg</span> transparent · <span class="k">text</span> #020817<br>
+        <span class="k">hover</span> bg-accent <span class="swatch" style="background:#f1f5f9"></span>#f1f5f9 + accent-foreground</div>
+      </div>
+
+      <div class="cell">
+        <div class="stage"><button class="btn v-link">Link</button></div>
+        <div class="name">link</div>
+        <div class="cap"><span class="k">text</span> text-primary <span class="swatch" style="background:#0f172a"></span>#0f172a<br>
+        underline-offset-4 · <span class="k">hover</span> underline</div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ── SIZES ── -->
+  <section>
+    <p class="sec-title">Size scale — default variant</p>
+    <p class="sec-note">Heights h-9 / h-10 / h-12 = 36 / 40 / 48px; icon is a 40×40 square.</p>
+    <div class="row">
+
+      <div class="sizecell">
+        <button class="btn v-default s-sm">Small</button>
+        <div class="lab"><b>sm</b><br>h-9 px-3<br>36px</div>
+      </div>
+
+      <div class="sizecell">
+        <button class="btn v-default">Default</button>
+        <div class="lab"><b>default</b><br>h-10 px-4 py-2<br>40px</div>
+      </div>
+
+      <div class="sizecell">
+        <button class="btn v-default s-lg">Large</button>
+        <div class="lab"><b>lg</b><br>h-12 px-8<br>48px</div>
+      </div>
+
+      <div class="sizecell">
+        <button class="btn v-default s-icon" aria-label="icon">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
+        </button>
+        <div class="lab"><b>icon</b><br>h-10 w-10<br>40×40</div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ── LEGACY ── -->
+  <section>
+    <p class="sec-title">Legacy · .pink-btn</p>
+    <p class="sec-note">Pre-shadcn global class (the "Log In" button, <span style="font-family:ui-monospace,monospace">LoginBtn</span>). One of three parallel button systems still in the tree.</p>
+    <div class="legacy">
+      <span class="tag">older button system</span>
+      <div><button class="pink-btn">Log In</button></div>
+      <div class="cap" style="font-size:11px">
+        <span class="k">bg</span> <span class="swatch" style="background:#EDADF8"></span>#EDADF8 (third brand pink) ·
+        <span class="k">text</span> <span class="swatch" style="background:#422B46"></span>#422B46 maroon<br>
+        <span class="k">radius</span> 5px (off-scale, not from --radius) ·
+        <span class="k">size</span> 18px · <span class="k">pad</span> 5px 30px<br>
+        <span class="k">font</span> "KoHo" declared → <b>falls back to system sans</b> (KoHo never loads)
+      </div>
+    </div>
+  </section>
+
+  <!-- ── HONEST NOTES ── -->
+  <div class="notes">
+    <ul>
+      <li><b>Reality vs intent — font:</b> all buttons declare <code>font-sans</code> / <code>"KoHo"</code>, but KoHo is never loaded (no <code>next/font</code>, no <code>@font-face</code>), so every specimen here renders in the <b>system sans stack</b> — which is what ships.</li>
+      <li><b>Deviation — no hover on <code>default</code>:</b> stock shadcn ships <code>hover:bg-primary/90</code>; it was removed in <code>button.tsx:12</code>, so the primary button has no hover feedback. Every other variant keeps its hover.</li>
+      <li><b>Semantic layer is 100% stock slate:</b> <code>--primary/--secondary/--accent/--destructive</code> are unmodified shadcn values in both <code>:root</code> and <code>.dark</code> — brand color (maroon/pastypink/pastyblue) never reaches these tokens.</li>
+      <li><b>Three parallel button systems:</b> this cva <code>Button</code>, the legacy <code>.pink-btn</code>, and a hand-rolled <code>ThemeToggle</code> <code>&lt;button&gt;</code>.</li>
+    </ul>
+  </div>
+</div>
+</body>
+</html>

--- a/design-system/components/card.html
+++ b/design-system/components/card.html
@@ -1,0 +1,341 @@
+<!-- @dsCard group="Components" name="Card" subtitle="header/content/footer + glass variant" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root {
+    /* ---- resolved shadcn "slate" tokens (globals.css :root) ---- */
+    --background: hsl(0, 0%, 100%);
+    --card: hsl(0, 0%, 100%);
+    --card-foreground: hsl(222.2, 84%, 4.9%);
+    --muted-foreground: hsl(215.4, 16.3%, 46.9%);
+    --border: hsl(214.3, 31.8%, 91.4%);
+    --primary: hsl(222.2, 47.4%, 11.2%);
+    --primary-foreground: hsl(210, 40%, 98%);
+    --radius: 0.5rem; /* 8px, not overridden in .dark */
+    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    --sys: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
+
+  * { box-sizing: border-box; }
+
+  html, body { margin: 0; }
+
+  body {
+    background: var(--background);
+    color: var(--card-foreground);
+    font-family: var(--sys);
+    -webkit-font-smoothing: antialiased;
+    padding: 40px 32px 56px;
+  }
+
+  .wrap { max-width: 860px; margin: 0 auto; }
+
+  .doc-title {
+    font-size: 22px;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    margin: 0 0 6px;
+  }
+  .doc-sub {
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--muted-foreground);
+    margin: 0 0 32px;
+    max-width: 620px;
+  }
+  .doc-sub code { font-family: var(--mono); font-size: 12.5px; }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 28px;
+    align-items: start;
+  }
+
+  .specimen { min-width: 0; }
+  .specimen-label {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    margin: 0 0 10px;
+  }
+  .specimen-label .badge {
+    font-family: var(--mono);
+    font-weight: 500;
+    font-size: 10.5px;
+    color: var(--muted-foreground);
+    margin-left: 8px;
+  }
+
+  /* ---- a "stage" so each specimen's surface reads ---- */
+  .stage {
+    border-radius: 14px;
+    padding: 34px 30px;
+  }
+  .stage--neutral { background: #f1f5f9; } /* slate-100, so shadow-sm reads */
+  .stage--candy {
+    position: relative;
+    overflow: hidden;
+    background:
+      linear-gradient(135deg, #ff9ce3 0%, #2ad4fc 55%, #19ffb8 100%);
+  }
+  /* blurred brand blobs behind the glass so blur(20px) is visible */
+  .stage--candy::before,
+  .stage--candy::after {
+    content: "";
+    position: absolute;
+    border-radius: 9999px;
+    filter: blur(2px);
+  }
+  .stage--candy::before {
+    width: 150px; height: 150px;
+    background: #ef95ff;
+    top: -30px; left: -20px;
+  }
+  .stage--candy::after {
+    width: 120px; height: 120px;
+    background: #19ffb8;
+    bottom: -24px; right: 10px;
+  }
+
+  /* ============================================================
+     STANDARD CARD  — card.tsx, resolved literally
+     rounded-lg border bg-card text-card-foreground shadow-sm
+     ============================================================ */
+  .card {
+    position: relative;
+    background: var(--card);
+    color: var(--card-foreground);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);      /* 8px */
+    box-shadow: var(--shadow-sm);
+  }
+  .card__header { display: flex; flex-direction: column; gap: 6px; padding: 24px; }  /* space-y-1.5 p-6 */
+  .card__title {
+    font-size: 24px;                   /* text-2xl */
+    line-height: 1;                    /* leading-none */
+    font-weight: 600;                  /* font-semibold */
+    letter-spacing: -0.025em;          /* tracking-tight */
+    margin: 0;
+  }
+  .card__desc {
+    font-size: 14px;                   /* text-sm */
+    line-height: 1.35;
+    color: var(--muted-foreground);
+    margin: 0;
+  }
+  .card__content { padding: 0 24px 24px; }   /* p-6 pt-0 */
+  .card__footer { display: flex; align-items: center; padding: 0 24px 24px; }
+
+  .meta-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 14px;
+  }
+  .pill {
+    font-size: 12px;
+    line-height: 1;
+    padding: 6px 10px;
+    border-radius: 9999px;             /* genre pills use rounded-full */
+    background: hsl(210, 40%, 96.1%);  /* --secondary */
+    color: hsl(222.2, 47.4%, 11.2%);   /* --secondary-foreground */
+  }
+  .stat-line {
+    font-size: 13px;
+    line-height: 1.55;
+    color: var(--muted-foreground);
+  }
+  .stat-line strong { color: var(--card-foreground); font-weight: 600; }
+
+  /* shadcn default Button: bg-primary rounded-md h-10 px-4 text-sm font-medium */
+  .btn-primary {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    height: 40px;
+    padding: 0 16px;
+    border: 0;
+    border-radius: calc(var(--radius) - 2px); /* rounded-md, 6px */
+    background: var(--primary);
+    color: var(--primary-foreground);
+    font-family: var(--sys);
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+  }
+  .btn-primary svg { width: 15px; height: 15px; }
+
+  /* ============================================================
+     GLASS CARD  — .glass recipe from globals.css (off-token)
+     ============================================================ */
+  .glass {
+    position: relative;
+    background: rgba(255, 255, 255, 0.55);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    backdrop-filter: blur(20px) saturate(180%);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 1rem;               /* 16px — hardcoded, NOT from --radius */
+    padding: 20px;                     /* the app's real panel: glass p-4/p-5 */
+    color: #1e1024;
+  }
+  .glass__title {
+    font-size: 24px;
+    line-height: 1;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin: 0 0 6px;
+    color: #2a1330;
+  }
+  .glass__desc {
+    font-size: 14px;
+    line-height: 1.4;
+    margin: 0 0 14px;
+    color: rgba(66, 43, 70, 0.75);     /* maroon #422b46 at ~75% */
+  }
+  .glass .meta-row { margin-bottom: 16px; }
+  .glass .pill {
+    background: rgba(255, 255, 255, 0.55);
+    color: #422b46;                    /* maroon */
+    border: 1px solid rgba(255, 255, 255, 0.6);
+  }
+
+  /* .pink-btn from globals.css (third brand pink, KoHo never loads) */
+  .pink-btn {
+    display: inline-block;
+    background-color: #EDADF8;
+    color: #422B46;                    /* maroon */
+    font-family: "KoHo", var(--sys);   /* KoHo declared; falls back to system */
+    border: 0;
+    border-radius: 5px;                /* off-scale */
+    padding: 5px 30px;
+    font-size: 18px;
+    cursor: pointer;
+  }
+
+  /* ---- shared value captions ---- */
+  .notes {
+    margin-top: 12px;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 4px;
+  }
+  .notes li {
+    font-family: var(--mono);
+    font-size: 11px;
+    line-height: 1.45;
+    color: var(--muted-foreground);
+  }
+  .notes b { color: var(--card-foreground); font-weight: 600; }
+
+  .footnote {
+    margin-top: 34px;
+    padding-top: 18px;
+    border-top: 1px solid var(--border);
+    font-size: 12.5px;
+    line-height: 1.6;
+    color: var(--muted-foreground);
+  }
+  .footnote code { font-family: var(--mono); font-size: 11.5px; color: var(--card-foreground); }
+  .footnote strong { color: var(--card-foreground); font-weight: 600; }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <h1 class="doc-title">Card</h1>
+    <p class="doc-sub">
+      Two card-like surfaces coexist in MusicNerdWeb. Left: the stock shadcn
+      <code>Card</code> primitive (<code>card.tsx</code>) — an opaque slate token
+      surface. Right: the brand's real workhorse, the off-token <code>.glass</code>
+      panel used across 13+ artist-page components. Every class below is resolved
+      to the literal CSS it compiles to.
+    </p>
+
+    <div class="grid">
+      <!-- ===================== STANDARD CARD ===================== -->
+      <div class="specimen">
+        <p class="specimen-label">Standard Card<span class="badge">card.tsx</span></p>
+        <div class="stage stage--neutral">
+          <div class="card">
+            <div class="card__header">
+              <h3 class="card__title">Phoebe Bridgers</h3>
+              <p class="card__desc">Indie &middot; Singer-songwriter &middot; Los Angeles</p>
+            </div>
+            <div class="card__content">
+              <div class="meta-row">
+                <span class="pill">indie</span>
+                <span class="pill">folk</span>
+                <span class="pill">emo</span>
+              </div>
+              <p class="stat-line">
+                <strong>14</strong> platform links &middot;
+                added by <strong>@clt</strong><br>
+                4.2M monthly listeners on Spotify
+              </p>
+            </div>
+            <div class="card__footer">
+              <button class="btn-primary">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+                View artist
+              </button>
+            </div>
+          </div>
+        </div>
+        <ul class="notes">
+          <li><b>radius</b> rounded-lg = var(--radius) = 8px</li>
+          <li><b>border</b> hsl(214.3 31.8% 91.4%)</li>
+          <li><b>bg-card</b> hsl(0 0% 100%) &middot; opaque</li>
+          <li><b>shadow-sm</b> 0 1px 2px 0 rgb(0 0 0/.05)</li>
+          <li><b>header / content / footer</b> p-6 = 24px</li>
+          <li><b>title</b> text-2xl/600, leading-none, tracking-tight</li>
+        </ul>
+      </div>
+
+      <!-- ===================== GLASS CARD ===================== -->
+      <div class="specimen">
+        <p class="specimen-label">Glass variant<span class="badge">.glass (globals.css)</span></p>
+        <div class="stage stage--candy">
+          <div class="glass">
+            <h3 class="glass__title">Jamie xx</h3>
+            <p class="glass__desc">Electronic &middot; Producer &middot; London</p>
+            <div class="meta-row">
+              <span class="pill">house</span>
+              <span class="pill">uk garage</span>
+            </div>
+            <p class="stat-line" style="color:rgba(66,43,70,.72);margin-bottom:16px;">
+              9 platform links &middot; last edited 2d ago
+            </p>
+            <button class="pink-btn">Support artist</button>
+          </div>
+        </div>
+        <ul class="notes">
+          <li><b>bg</b> rgba(255,255,255,0.55) &middot; translucent</li>
+          <li><b>filter</b> blur(20px) saturate(180%)</li>
+          <li><b>border</b> 1px rgba(255,255,255,0.3)</li>
+          <li><b>radius</b> 1rem = 16px &middot; hardcoded, not --radius</li>
+          <li><b>padding</b> real usage: glass p-4/p-5 (16&ndash;20px)</li>
+          <li><b>.pink-btn</b> #EDADF8 on #422B46, radius 5px</li>
+        </ul>
+      </div>
+    </div>
+
+    <p class="footnote">
+      <strong>Reality notes.</strong>
+      The app mostly reaches for <code>.glass</code> panels, not the stock
+      <code>Card</code> — so <strong>two padding conventions coexist</strong>
+      (Card's rigid <code>p-6</code> vs. glass <code>p-4/p-5</code>) and two radii
+      (<code>8px</code> token vs. glass <code>16px</code> literal).
+      The <code>.pink-btn</code> declares <code>font-family:"KoHo"</code>, but
+      KoHo is never actually loaded in the app, so all text here renders in the
+      real system sans stack (<code>-apple-system, "Segoe UI", Roboto</code>) —
+      shown faithfully. Semantic colors are unmodified shadcn "slate";
+      the brand's candy-neon pink/blue/green live outside the tokens as hex literals.
+    </p>
+  </div>
+</body>
+</html>

--- a/design-system/components/form-controls.html
+++ b/design-system/components/form-controls.html
@@ -1,0 +1,372 @@
+<!-- @dsCard group="Forms" name="Form controls" subtitle="input · textarea · select · checkbox · label" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Form controls</title>
+<style>
+  /* ---- Resolved design tokens (from src/app/globals.css :root / .dark) ---- */
+  :root{
+    /* LIGHT — stock shadcn "slate" */
+    --background:      hsl(0 0% 100%);         /* #ffffff */
+    --foreground:      hsl(222.2 84% 4.9%);    /* #020817 */
+    --muted:           hsl(210 40% 96.1%);     /* #f1f5f9 */
+    --muted-foreground:hsl(215.4 16.3% 46.9%); /* #64748b */
+    --input:           hsl(214.3 31.8% 91.4%); /* #e2e8f0 */
+    --ring:            hsl(222.2 84% 4.9%);    /* #020817 */
+    --primary:         hsl(222.2 47.4% 11.2%); /* #0f172a */
+    --radius: 0.5rem;                          /* 8px  */
+    --radius-md: calc(var(--radius) - 2px);    /* 6px  → rounded-md */
+    --radius-sm: calc(var(--radius) - 4px);    /* 4px  → rounded-sm */
+    --checked: #ff9ce3;                        /* light checkbox accent */
+  }
+  /* DARK surface tokens, used only inside .dark-surface below */
+  .dark-surface{
+    --background:      hsl(222.2 84% 4.9%);    /* #020817 */
+    --foreground:      hsl(210 40% 98%);       /* #f8fafc */
+    --muted:           hsl(217.2 32.6% 17.5%); /* #1e293b */
+    --muted-foreground:hsl(215 20.2% 65.1%);   /* #94a3b8 */
+    --input:           hsl(217.2 32.6% 17.5%); /* #1e293b */
+    --ring:            hsl(212.7 26.8% 83.9%); /* #cbd5e1 */
+    --primary:         hsl(210 40% 98%);       /* #f8fafc */
+    --checked: #2ad4fc;                        /* dark checkbox accent */
+  }
+
+  *{ box-sizing:border-box; }
+  html,body{ margin:0; }
+  body{
+    background:#ffffff;
+    color:var(--foreground);
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+    line-height:1.5;
+    -webkit-font-smoothing:antialiased;
+    padding:32px 28px 40px;
+  }
+  .wrap{ max-width:920px; margin:0 auto; }
+
+  h1{ font-size:22px; font-weight:650; letter-spacing:-0.02em; margin:0 0 2px; }
+  .sub{ font-size:13px; color:var(--muted-foreground); margin:0 0 4px;
+        font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
+  .lead{ font-size:13px; color:var(--muted-foreground); margin:10px 0 26px; max-width:640px; }
+
+  .grid{ display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); gap:18px; }
+
+  .card{
+    border:1px solid var(--input);
+    border-radius:12px;
+    background:#ffffff;
+    padding:18px 18px 16px;
+    display:flex; flex-direction:column; gap:14px;
+  }
+  .card.span2{ grid-column:1 / -1; }
+  .card-h{ display:flex; align-items:baseline; justify-content:space-between; gap:10px; flex-wrap:wrap; }
+  .card-h .name{ font-size:14px; font-weight:650; letter-spacing:-0.01em; }
+  .card-h .file{ font-size:11px; color:var(--muted-foreground);
+                 font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; }
+
+  .row{ display:flex; flex-direction:column; gap:6px; }
+  .row-label{ display:flex; align-items:center; gap:8px; }
+  .state{ font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:0.06em;
+          color:var(--muted-foreground); }
+  .mono{ font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; font-size:11px;
+         color:var(--muted-foreground); }
+  .mono b{ color:var(--foreground); font-weight:600; }
+
+  /* ------------------------------------------------------------------ */
+  /*  Real primitives — every class resolved to literal token values     */
+  /* ------------------------------------------------------------------ */
+
+  /* Label — text-sm font-medium leading-none */
+  .ui-label{ font-size:14px; font-weight:500; line-height:1; color:var(--foreground); }
+
+  /* Input, form-restyled (border-input + h-10 + focus ring the primitive omits) */
+  .ui-input{
+    display:flex; width:100%; height:40px;              /* h-10 */
+    border:1px solid var(--input);                       /* border border-input */
+    border-radius:var(--radius-md);                      /* rounded-md 6px */
+    background:var(--background);                         /* bg-background */
+    padding:8px 12px;                                    /* px-3 py-2 */
+    font:inherit; font-size:16px;                        /* text-base */
+    color:var(--foreground);
+    outline:none;
+  }
+  .ui-input::placeholder{ color:var(--muted-foreground); }/* placeholder:text-muted-foreground */
+  .ui-input.is-focused{
+    /* ring-offset-background(2) + focus-visible:ring-2 ring-ring */
+    box-shadow:0 0 0 2px var(--background), 0 0 0 4px var(--ring);
+  }
+  .ui-input.is-disabled{ opacity:.5; cursor:not-allowed; }/* disabled:opacity-50 */
+
+  /* Input primitive AS-IS — stripped: no border, no height, no ring */
+  .ui-input-bare{
+    display:flex; width:100%;
+    border:0;
+    border-radius:var(--radius-md);
+    background:var(--background);
+    padding:8px 12px;
+    font:inherit; font-size:16px; color:var(--foreground);
+    outline:none;
+  }
+  .ui-input-bare::placeholder{ color:var(--muted-foreground); }
+  .bare-field{ background:var(--muted); border-radius:var(--radius-md); }
+
+  /* Textarea — min-h-[50px] border-input, focus ring is MISSING in source */
+  .ui-textarea{
+    display:block; width:100%; min-height:50px;          /* min-h-[50px] */
+    border:1px solid var(--input);
+    border-radius:var(--radius-md);
+    background:var(--background);
+    padding:8px 12px;
+    font:inherit; font-size:14px;                        /* md:text-sm */
+    color:var(--foreground);
+    resize:none; outline:none;
+  }
+  .ui-textarea::placeholder{ color:var(--muted-foreground); }
+
+  /* Select trigger — h-10 border-input, focus:ring-2 (this one DOES ring) */
+  .ui-select{
+    display:flex; align-items:center; justify-content:space-between;
+    width:100%; height:40px;                             /* h-10 */
+    border:1px solid var(--input);
+    border-radius:var(--radius-md);
+    background:var(--background);
+    padding:8px 12px;
+    font:inherit; font-size:14px;                        /* text-sm */
+    color:var(--foreground);
+    outline:none;
+  }
+  .ui-select.is-focused{ box-shadow:0 0 0 2px var(--background), 0 0 0 4px var(--ring); }
+  .ui-select svg{ width:16px; height:16px; opacity:.5; }  /* ChevronDown h-4 w-4 opacity-50 */
+
+  /* Checkbox — h-4 w-4 rounded-sm border border-primary */
+  .ui-check{
+    display:inline-flex; align-items:center; justify-content:center;
+    width:16px; height:16px;                             /* h-4 w-4 */
+    border:1px solid var(--primary);                     /* border-primary */
+    border-radius:var(--radius-sm);                      /* rounded-sm 4px */
+    background:var(--background);
+    flex:0 0 auto;
+  }
+  .ui-check svg{ width:14px; height:14px; color:#fff; display:none; }
+  .ui-check.checked{
+    background:var(--checked);                            /* [data-state=checked] */
+    border-color:var(--checked);
+  }
+  .ui-check.checked svg{ display:block; }
+  .check-line{ display:flex; align-items:center; gap:10px; }
+  .check-line span{ font-size:14px; }
+
+  /* dark surface panel */
+  .dark-surface{
+    background:var(--background);
+    border:1px solid var(--input);
+    border-radius:10px;
+    padding:16px;
+    color:var(--foreground);
+    display:flex; flex-direction:column; gap:14px;
+  }
+  .dark-surface .ui-label{ color:var(--foreground); }
+  .dark-surface .mono{ color:var(--muted-foreground); }
+  .dark-surface .mono b{ color:var(--foreground); }
+  .dark-surface .state{ color:var(--muted-foreground); }
+
+  .swatchrow{ display:flex; flex-wrap:wrap; gap:10px; margin-top:2px; }
+  .chip{ display:flex; align-items:center; gap:7px; font-size:11px;
+         font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; color:var(--muted-foreground); }
+  .chip i{ width:13px; height:13px; border-radius:3px; display:inline-block;
+           border:1px solid rgba(0,0,0,.12); }
+
+  .note{ font-size:12px; color:var(--muted-foreground);
+         border-left:2px solid var(--input); padding:2px 0 2px 12px; margin-top:2px; }
+  .note b{ color:var(--foreground); font-weight:600; }
+  .warn{ color:#b45309; }
+
+  .legend{ display:flex; flex-wrap:wrap; gap:14px 22px; margin:26px 0 0;
+           padding-top:18px; border-top:1px solid var(--input); }
+  .legend .chip i{ width:14px; height:14px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Form controls</h1>
+  <p class="sub">input · textarea · select · checkbox · label</p>
+  <p class="lead">
+    Primitives from <b style="font-family:inherit">src/components/ui/</b>, resolved to literal CSS.
+    Border = <code style="font-family:ui-monospace,monospace">--input</code>, focus ring =
+    <code style="font-family:ui-monospace,monospace">--ring</code>, radius from
+    <code style="font-family:ui-monospace,monospace">--radius: 0.5rem</code>. Semantic tokens are
+    stock shadcn <b style="font-family:inherit">slate</b> — brand color never reaches this layer.
+  </p>
+
+  <div class="grid">
+
+    <!-- LABEL + INPUT -->
+    <div class="card">
+      <div class="card-h">
+        <span class="name">Label + Input</span>
+        <span class="file">label.tsx · input.tsx</span>
+      </div>
+
+      <div class="row">
+        <label class="ui-label" for="a">Email address</label>
+        <div class="row-label"><span class="state">default</span></div>
+        <input id="a" class="ui-input" placeholder="you@example.com">
+      </div>
+      <div class="mono">
+        Label <b>text-sm 14px · font-medium 500 · leading-none</b><br>
+        Input restyled: border <b>--input #e2e8f0</b> · h-10 <b>40px</b> · rounded-md <b>6px</b> · text-base <b>16px</b>
+      </div>
+
+      <div class="row">
+        <div class="row-label"><span class="state">focused</span></div>
+        <input class="ui-input is-focused" value="you@example.com">
+      </div>
+      <div class="mono">Ring <b>0 0 0 2px --background</b> + <b>0 0 0 4px --ring #020817</b> &nbsp;(ring-offset-2 + ring-2)</div>
+
+      <div class="row">
+        <div class="row-label"><span class="state">disabled</span></div>
+        <input class="ui-input is-disabled" placeholder="you@example.com" disabled>
+      </div>
+      <div class="mono">disabled:opacity-50 &nbsp;→&nbsp; <b>opacity: .5</b></div>
+    </div>
+
+    <!-- INPUT PRIMITIVE AS-IS -->
+    <div class="card">
+      <div class="card-h">
+        <span class="name">Input — the primitive as-is</span>
+        <span class="file">input.tsx</span>
+      </div>
+      <div class="row">
+        <div class="row-label"><span class="state">stripped</span></div>
+        <div class="bare-field">
+          <input class="ui-input-bare" placeholder="search…">
+        </div>
+      </div>
+      <p class="note">
+        The real <b>Input</b> is heavily stripped: <b>no <code style="font-family:ui-monospace,monospace">border border-input</code></b>,
+        no fixed height, and <b class="warn">no <code style="font-family:ui-monospace,monospace">focus-visible</code> ring</b> — so it renders
+        borderless with no focus affordance (shown on a <code style="font-family:ui-monospace,monospace">--muted</code> field so the box is visible).
+        It also uses <code style="font-family:ui-monospace,monospace">text-base</code> where stock shadcn uses <code style="font-family:ui-monospace,monospace">text-sm</code>.
+        Every form must re-add chrome via <code style="font-family:ui-monospace,monospace">className</code> — that's the restyled input on the left.
+      </p>
+    </div>
+
+    <!-- TEXTAREA -->
+    <div class="card">
+      <div class="card-h">
+        <span class="name">Textarea</span>
+        <span class="file">textarea.tsx</span>
+      </div>
+      <div class="row">
+        <div class="row-label"><span class="state">default</span></div>
+        <textarea class="ui-textarea" placeholder="Add context for this artist…" rows="3"></textarea>
+      </div>
+      <div class="mono">
+        min-h-[50px] <b>50px</b> · border <b>--input #e2e8f0</b> · rounded-md <b>6px</b> · md:text-sm <b>14px</b>
+      </div>
+      <p class="note">
+        <b class="warn">Focus ring never renders:</b> the source has <code style="font-family:ui-monospace,monospace">ring-ring</code>
+        + <code style="font-family:ui-monospace,monospace">ring-offset-2</code> but is <b>missing <code style="font-family:ui-monospace,monospace">focus-visible:ring-2</code></b>
+        (no ring width). Unlike Select/Button, it stays un-ringed on focus.
+      </p>
+    </div>
+
+    <!-- SELECT -->
+    <div class="card">
+      <div class="card-h">
+        <span class="name">Select — trigger</span>
+        <span class="file">select.tsx</span>
+      </div>
+      <div class="row">
+        <div class="row-label"><span class="state">default</span></div>
+        <button class="ui-select" type="button">
+          <span>Sort by contributions</span>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+        </button>
+      </div>
+      <div class="row">
+        <div class="row-label"><span class="state">focused</span></div>
+        <button class="ui-select is-focused" type="button">
+          <span>Sort by contributions</span>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+        </button>
+      </div>
+      <div class="mono">
+        h-10 <b>40px</b> · border <b>--input</b> · text-sm <b>14px</b> · ChevronDown <b>16px opacity-.5</b><br>
+        focus:ring-2 ring-ring <b>--ring #020817</b> &nbsp;(this one <b>does</b> ring)
+      </div>
+    </div>
+
+    <!-- CHECKBOX -->
+    <div class="card span2">
+      <div class="card-h">
+        <span class="name">Checkbox</span>
+        <span class="file">checkbox.tsx · globals.css [data-state=checked]</span>
+      </div>
+
+      <div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:16px; align-items:start;">
+        <!-- light -->
+        <div class="row">
+          <span class="state">light theme</span>
+          <div class="check-line">
+            <span class="ui-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span>
+            <span>Unchecked</span>
+          </div>
+          <div class="check-line">
+            <span class="ui-check checked"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span>
+            <span>Checked</span>
+          </div>
+          <div class="mono">
+            h-4 w-4 <b>16px</b> · rounded-sm <b>4px</b><br>
+            border <b>--primary #0f172a</b><br>
+            checked fill <b style="color:#d81b9b">#ff9ce3</b> · check <b>#fff</b>
+          </div>
+        </div>
+
+        <!-- dark -->
+        <div class="dark-surface">
+          <span class="state">dark theme</span>
+          <div class="check-line">
+            <span class="ui-check"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span>
+            <span>Unchecked</span>
+          </div>
+          <div class="check-line">
+            <span class="ui-check checked"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span>
+            <span>Checked</span>
+          </div>
+          <div class="mono">
+            border <b>--primary #f8fafc</b><br>
+            checked fill <b style="color:#2ad4fc">#2ad4fc</b> · check <b>#fff</b>
+          </div>
+        </div>
+      </div>
+
+      <p class="note">
+        <b>Light → dark accent swap.</b> The checked box is <b style="color:#d81b9b">pink #ff9ce3</b> in light and
+        <b style="color:#0891b2">cyan #2ad4fc</b> in dark — hardcoded in <code style="font-family:ui-monospace,monospace">globals.css</code>
+        as <code style="font-family:ui-monospace,monospace">[data-state="checked"]</code> overrides, <b>not</b> from the semantic
+        <code style="font-family:ui-monospace,monospace">--primary</code> token (which stays slate). The unchecked border still
+        follows <code style="font-family:ui-monospace,monospace">--primary</code>. #ff9ce3 is the real on-screen pink (57 uses); it isn't in any palette.
+      </p>
+    </div>
+
+  </div>
+
+  <div class="legend">
+    <div class="chip"><i style="background:#e2e8f0"></i> --input <b style="color:#020817;font-weight:600">#e2e8f0</b> / dark #1e293b</div>
+    <div class="chip"><i style="background:#020817"></i> --ring <b style="color:#020817;font-weight:600">#020817</b> / dark #cbd5e1</div>
+    <div class="chip"><i style="background:#0f172a"></i> --primary <b style="color:#020817;font-weight:600">#0f172a</b> / dark #f8fafc</div>
+    <div class="chip"><i style="background:#ff9ce3"></i> checked-light <b style="color:#020817;font-weight:600">#ff9ce3</b></div>
+    <div class="chip"><i style="background:#2ad4fc"></i> checked-dark <b style="color:#020817;font-weight:600">#2ad4fc</b></div>
+    <div class="chip"><i style="background:#f1f5f9"></i> --muted <b style="color:#020817;font-weight:600">#f1f5f9</b></div>
+    <div class="chip"><i style="border-color:#cbd5e1;background:#fff"></i> radius <b style="color:#020817;font-weight:600">8 · md 6 · sm 4px</b></div>
+  </div>
+
+  <p class="lead" style="margin-top:22px">
+    Font: KoHo is declared for <code style="font-family:ui-monospace,monospace">.koho-*</code>/<code style="font-family:ui-monospace,monospace">.pink-btn</code>
+    but never loads in the app, so all control text renders in the <b>system sans</b> stack shown here — that's the reality this card documents.
+  </p>
+</div>
+</body>
+</html>

--- a/design-system/components/tabs.html
+++ b/design-system/components/tabs.html
@@ -1,0 +1,283 @@
+<!-- @dsCard group="Components" name="Tabs" subtitle="list + active/inactive triggers" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  :root {
+    /* Resolved shadcn "slate" semantic tokens — light (globals.css :root) */
+    --background: hsl(0 0% 100%);          /* #ffffff */
+    --foreground: hsl(222.2 84% 4.9%);     /* ~#020817 */
+    --muted: hsl(210 40% 96.1%);           /* ~#f1f5f9 */
+    --muted-foreground: hsl(215.4 16.3% 46.9%); /* ~#64748b */
+    --ring: hsl(222.2 84% 4.9%);
+    --radius: 0.5rem;                       /* 8px base */
+    /* Resolved dark tokens (globals.css .dark) */
+    --d-background: hsl(222.2 84% 4.9%);    /* ~#020817 */
+    --d-foreground: hsl(210 40% 98%);       /* ~#f8fafc */
+    --d-muted: hsl(217.2 32.6% 17.5%);      /* ~#1e293b */
+    --d-muted-foreground: hsl(215 20.2% 65.1%); /* ~#94a3b8 */
+
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: #ffffff;
+    color: var(--foreground);
+    font-family: var(--sans);
+    -webkit-font-smoothing: antialiased;
+    padding: 40px 36px 48px;
+  }
+
+  .wrap { max-width: 760px; margin: 0 auto; }
+
+  h1 {
+    font-size: 20px;
+    font-weight: 650;
+    letter-spacing: -0.01em;
+    margin: 0 0 6px;
+  }
+  .lede {
+    font-size: 13.5px;
+    line-height: 1.55;
+    color: #475569;
+    margin: 0 0 8px;
+    max-width: 60ch;
+  }
+  code.k {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    background: #f1f5f9;
+    color: #334155;
+    padding: 1px 5px;
+    border-radius: 4px;
+  }
+
+  .section-label {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #94a3b8;
+    margin: 34px 0 12px;
+    font-weight: 600;
+  }
+
+  /* ---- Real Tabs component, resolved to literal CSS ---- */
+
+  /* TabsList: inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground */
+  .tabs-list {
+    display: inline-flex;
+    height: 40px;                 /* h-10 */
+    align-items: center;
+    justify-content: center;
+    border-radius: 6px;           /* rounded-md = calc(0.5rem - 2px) */
+    background: var(--muted);
+    padding: 4px;                 /* p-1 */
+    color: var(--muted-foreground);
+  }
+
+  /* TabsTrigger base: rounded-sm px-3 py-1.5 text-sm font-medium transition-all */
+  .tabs-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+    border-radius: 4px;           /* rounded-sm = calc(0.5rem - 4px) */
+    padding: 6px 12px;            /* py-1.5 px-3 */
+    font-size: 14px;             /* text-sm */
+    line-height: 20px;
+    font-weight: 500;            /* font-medium */
+    font-family: var(--sans);
+    background: transparent;      /* inactive: no bg, inherits list color */
+    color: inherit;              /* inactive → muted-foreground */
+    border: 0;
+    cursor: pointer;
+    transition: all .15s ease;
+  }
+
+  /* data-[state=active]: bg-background text-foreground shadow-sm */
+  .tabs-trigger[data-state="active"] {
+    background: var(--background);
+    color: var(--foreground);
+    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);   /* shadow-sm */
+  }
+
+  /* TabsContent: mt-2 */
+  .tabs-content {
+    margin-top: 8px;             /* mt-2 */
+    font-size: 14px;
+    line-height: 1.6;
+    color: #334155;
+    border: 1px solid hsl(214.3 31.8% 91.4%);   /* --border, for panel framing only */
+    border-radius: 6px;
+    padding: 16px 18px;
+    max-width: 420px;
+  }
+  .tabs-content h4 {
+    margin: 0 0 4px;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--foreground);
+  }
+  .tabs-content p { margin: 0; color: var(--muted-foreground); }
+
+  /* Callout markers pointing at active vs inactive */
+  .specimen { margin: 4px 0 0; }
+
+  .legend {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14px;
+    margin-top: 22px;
+  }
+  .leg {
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    padding: 13px 15px;
+    background: #fff;
+  }
+  .leg .tag {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    padding: 2px 7px;
+    border-radius: 999px;
+    margin-bottom: 9px;
+  }
+  .leg.active .tag { background: #020817; color: #fff; }
+  .leg.inactive .tag { background: #f1f5f9; color: #64748b; }
+  .leg ul { margin: 0; padding: 0; list-style: none; }
+  .leg li {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    line-height: 1.9;
+    color: #475569;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .sw {
+    width: 13px; height: 13px;
+    border-radius: 3px;
+    border: 1px solid rgba(0,0,0,0.12);
+    flex: none;
+  }
+  .leg li b { color: #0f172a; font-weight: 600; }
+
+  /* Dark specimen block */
+  .dark-stage {
+    margin-top: 12px;
+    background: var(--d-background);
+    border-radius: 10px;
+    padding: 22px 22px 24px;
+    border: 1px solid #1e293b;
+  }
+  .dark-stage .tabs-list {
+    background: var(--d-muted);
+    color: var(--d-muted-foreground);
+  }
+  .dark-stage .tabs-trigger[data-state="active"] {
+    background: var(--d-background);
+    color: var(--d-foreground);
+    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.4);
+  }
+  .dark-stage .tabs-content {
+    border-color: #1e293b;
+    color: #cbd5e1;
+  }
+  .dark-stage .tabs-content h4 { color: var(--d-foreground); }
+  .dark-stage .tabs-content p { color: var(--d-muted-foreground); }
+  .dark-cap { color: #64748b; }
+
+  .note {
+    margin-top: 30px;
+    border-left: 3px solid #cbd5e1;
+    background: #f8fafc;
+    padding: 11px 14px;
+    border-radius: 0 6px 6px 0;
+    font-size: 12.5px;
+    line-height: 1.6;
+    color: #475569;
+  }
+  .note b { color: #0f172a; }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Tabs</h1>
+    <p class="lede">
+      Radix <code class="k">TabsPrimitive</code> wrapped in <code class="k">tabs.tsx</code>. Stock shadcn treatment:
+      a <code class="k">bg-muted</code> track holds triggers; the active trigger lifts to <code class="k">bg-background</code>
+      with <code class="k">text-foreground</code> and <code class="k">shadow-sm</code>. Inactive triggers stay transparent and
+      inherit <code class="k">text-muted-foreground</code> from the list. All classes below are resolved to literal CSS from
+      the real slate tokens.
+    </p>
+
+    <div class="section-label">Light — TabsList · 3 triggers · content panel</div>
+
+    <div class="specimen">
+      <div class="tabs-list" role="tablist">
+        <button class="tabs-trigger" data-state="active" role="tab">Overview</button>
+        <button class="tabs-trigger" role="tab">Links</button>
+        <button class="tabs-trigger" role="tab">Activity</button>
+      </div>
+      <div class="tabs-content" role="tabpanel">
+        <h4>Overview</h4>
+        <p>Content for the active tab renders here (<code class="k" style="background:#f1f5f9">mt-2</code> below the list).</p>
+      </div>
+    </div>
+
+    <div class="legend">
+      <div class="leg active">
+        <span class="tag">Active trigger</span>
+        <ul>
+          <li><span class="sw" style="background:#ffffff"></span> bg <b>#ffffff</b> — bg-background</li>
+          <li><span class="sw" style="background:#020817"></span> text <b>hsl(222 84% 4.9%)</b> — foreground</li>
+          <li><span class="sw" style="background:linear-gradient(#fff,#e8eaee)"></span> shadow-sm <b>0 1px 2px /.05</b></li>
+          <li><span class="sw" style="border-radius:4px;background:#eef2f7"></span> radius <b>4px</b> — rounded-sm</li>
+        </ul>
+      </div>
+      <div class="leg inactive">
+        <span class="tag">Inactive triggers</span>
+        <ul>
+          <li><span class="sw" style="background:transparent;border-style:dashed"></span> bg <b>transparent</b></li>
+          <li><span class="sw" style="background:#64748b"></span> text <b>hsl(215 16% 47%)</b> — muted-fg</li>
+          <li><span class="sw" style="background:#f1f5f9"></span> track <b>hsl(210 40% 96%)</b> — bg-muted</li>
+          <li><span class="sw" style="border-radius:6px;background:#eef2f7"></span> list radius <b>6px</b> — rounded-md</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="section-label">Dark — same tokens, <code class="k" style="background:#1e293b;color:#cbd5e1">.dark</code> scope</div>
+    <div class="dark-stage">
+      <div class="tabs-list" role="tablist">
+        <button class="tabs-trigger" data-state="active" role="tab">Overview</button>
+        <button class="tabs-trigger" role="tab">Links</button>
+        <button class="tabs-trigger" role="tab">Activity</button>
+      </div>
+      <div class="tabs-content" role="tabpanel">
+        <h4>Overview</h4>
+        <p>Active lifts to <span style="font-family:var(--mono);font-size:12px">bg #020817</span> on a
+        <span style="font-family:var(--mono);font-size:12px">#1e293b</span> track.</p>
+      </div>
+    </div>
+
+    <div class="note">
+      <b>Reality note.</b> DESIGN.md marks Tabs <b>&ldquo;Stock&rdquo;</b> — no brand color touches this component.
+      Type renders in the <b>system sans</b> stack (KoHo is declared project-wide but never actually loads),
+      not a custom face. Radius derives from <code class="k">--radius: 0.5rem</code>:
+      list <code class="k">rounded-md</code> = 6px, trigger <code class="k">rounded-sm</code> = 4px. The content-panel
+      border here is only for framing the specimen; <code class="k">TabsContent</code> itself ships with just
+      <code class="k">mt-2</code> and a focus ring.
+    </div>
+  </div>
+</body>
+</html>

--- a/design-system/foundations/glass.html
+++ b/design-system/foundations/glass.html
@@ -1,0 +1,349 @@
+<!-- @dsCard group="Surfaces" name="Glass surfaces" subtitle=".glass / .glass-subtle · blur(20px) saturate(180%)" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  :root {
+    --bg: #ffffff;
+    --ink: #1a1420;
+    --muted: #6b6472;
+    --hairline: #ece7f0;
+    --maroon: #422b46;
+    --pastyblue: #2ad4fc;
+    --pastypink: #ef95ff;
+    --jellygreen: #19ffb8;
+    --screenpink: #ff9ce3;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--sans);
+    -webkit-font-smoothing: antialiased;
+    padding: 32px;
+  }
+
+  .wrap { max-width: 920px; margin: 0 auto; }
+
+  header { margin-bottom: 26px; }
+  h1 {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin: 0 0 6px;
+  }
+  .sub {
+    font-family: var(--mono);
+    font-size: 12.5px;
+    color: var(--muted);
+  }
+  .lede {
+    margin-top: 12px;
+    font-size: 13.5px;
+    line-height: 1.55;
+    color: #4a4451;
+    max-width: 640px;
+  }
+  .lede code {
+    font-family: var(--mono);
+    font-size: 12px;
+    background: #f4f0f7;
+    padding: 1px 5px;
+    border-radius: 4px;
+  }
+
+  .section-label {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin: 30px 0 12px;
+  }
+
+  /* ---- Neon stage: the colorful backdrop that makes blur visible ---- */
+  .stage {
+    position: relative;
+    border-radius: 18px;
+    padding: 34px;
+    overflow: hidden;
+    display: flex;
+    gap: 22px;
+    flex-wrap: wrap;
+  }
+  .stage.light {
+    background:
+      radial-gradient(circle at 12% 20%, var(--pastypink) 0%, transparent 42%),
+      radial-gradient(circle at 88% 15%, var(--pastyblue) 0%, transparent 45%),
+      radial-gradient(circle at 25% 95%, var(--jellygreen) 0%, transparent 48%),
+      radial-gradient(circle at 85% 90%, var(--screenpink) 0%, transparent 46%),
+      linear-gradient(135deg, #fff4fd 0%, #eefcff 100%);
+  }
+  .stage.dark {
+    background:
+      radial-gradient(circle at 15% 18%, rgba(239,149,255,0.85) 0%, transparent 42%),
+      radial-gradient(circle at 85% 12%, rgba(42,212,252,0.8) 0%, transparent 44%),
+      radial-gradient(circle at 30% 92%, rgba(25,255,184,0.75) 0%, transparent 46%),
+      radial-gradient(circle at 90% 88%, rgba(255,156,227,0.7) 0%, transparent 44%),
+      linear-gradient(135deg, #2a1c2d 0%, #1a1420 100%);
+  }
+
+  /* Crisp elements BEHIND the panels so the backdrop blur is obvious */
+  .behind {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    font-family: var(--sans);
+  }
+  .behind .stripe {
+    position: absolute;
+    font-weight: 800;
+    font-size: 15px;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+    opacity: 0.9;
+  }
+  .stage.light .behind .stripe { color: var(--maroon); }
+  .stage.dark  .behind .stripe { color: #fff; }
+  .behind .s1 { top: 30px;  left: -10px; }
+  .behind .s2 { top: 128px; left: -30px; }
+  .behind .s3 { top: 226px; left: 40px; }
+  .behind .dots {
+    position: absolute;
+    inset: 0;
+    background-image: radial-gradient(currentColor 1.5px, transparent 1.6px);
+    background-size: 16px 16px;
+    opacity: 0.18;
+  }
+  .stage.light .behind .dots { color: var(--maroon); }
+  .stage.dark  .behind .dots { color: #ffffff; }
+
+  /* ---- The glass panels ---- */
+  .panel {
+    position: relative;
+    z-index: 1;
+    width: 250px;
+    min-height: 176px;
+    padding: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .glass {
+    background: rgba(255, 255, 255, 0.55);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    backdrop-filter: blur(20px) saturate(180%);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 1rem;
+  }
+  .glass-subtle {
+    background: rgba(255, 255, 255, 0.35);
+    -webkit-backdrop-filter: blur(12px) saturate(150%);
+    backdrop-filter: blur(12px) saturate(150%);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 0.75rem;
+  }
+  /* dark stage overrides — mirror ".dark .glass" in globals.css */
+  .stage.dark .glass {
+    background: rgba(30, 30, 30, 0.55);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+  }
+  .stage.dark .glass-subtle {
+    background: rgba(40, 40, 40, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  .p-name {
+    font-family: var(--mono);
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+  }
+  .stage.dark .p-name { color: #fff; }
+  .p-css {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    line-height: 1.5;
+    color: #33313a;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .stage.dark .p-css { color: rgba(255,255,255,0.82); }
+  .p-tag {
+    margin-top: auto;
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #7b7482;
+  }
+  .stage.dark .p-tag { color: rgba(255,255,255,0.55); }
+
+  /* ---- scrollbar-glass sample ---- */
+  .scroll-panel {
+    position: relative;
+    z-index: 1;
+    width: 250px;
+    padding: 16px 8px 16px 16px;
+    display: flex;
+    flex-direction: column;
+  }
+  .scroll-box {
+    height: 108px;
+    overflow-y: scroll;
+    padding-right: 10px;
+    margin-top: 8px;
+  }
+  .scrollbar-glass {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+  }
+  .scrollbar-glass::-webkit-scrollbar { width: 6px; height: 6px; }
+  .scrollbar-glass::-webkit-scrollbar-track { background: transparent; }
+  .scrollbar-glass::-webkit-scrollbar-thumb {
+    background-color: rgba(255, 255, 255, 0.18);
+    border-radius: 9999px;
+  }
+  .scrollbar-glass::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(255, 255, 255, 0.32);
+  }
+  .scroll-row {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: rgba(255,255,255,0.9);
+    padding: 5px 0;
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+  }
+
+  .note {
+    margin-top: 12px;
+    font-size: 12px;
+    line-height: 1.55;
+    color: var(--muted);
+    display: flex;
+    gap: 8px;
+    align-items: flex-start;
+  }
+  .note b { color: #4a4451; font-weight: 600; }
+  .note .ic { flex: none; margin-top: 1px; }
+  .note code {
+    font-family: var(--mono);
+    font-size: 11px;
+    background: #f4f0f7;
+    padding: 1px 4px;
+    border-radius: 4px;
+    color: #5a3f60;
+  }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <h1>Glass surfaces</h1>
+      <div class="sub">.glass / .glass-subtle · blur(20px) saturate(180%)</div>
+      <p class="lede">
+        The primary surface language. Translucent white over a <code>backdrop-filter</code> blur —
+        no semantic token involved. Defined by hand in <code>globals.css</code>, used across 13+
+        artist-page components and admin. Panels float over color so the blur reads.
+      </p>
+    </header>
+
+    <div class="section-label">Light — over neon brand gradient</div>
+    <div class="stage light">
+      <div class="behind">
+        <div class="dots"></div>
+        <div class="stripe s1">music nerd ✦ pastypink ✦ pastyblue</div>
+        <div class="stripe s2">jellygreen ✦ #ff9ce3 ✦ maroon ✦ candy-neon</div>
+        <div class="stripe s3">frosted ✦ blur ✦ saturate ✦ glassy</div>
+      </div>
+
+      <div class="panel glass">
+        <div class="p-name">.glass</div>
+        <div class="p-css">background: rgba(255,255,255,.55);
+backdrop-filter:
+  blur(20px) saturate(180%);
+border: 1px solid
+  rgba(255,255,255,.3);
+border-radius: 1rem;</div>
+        <div class="p-tag">radius 16px · primary panel</div>
+      </div>
+
+      <div class="panel glass-subtle">
+        <div class="p-name">.glass-subtle</div>
+        <div class="p-css">background: rgba(255,255,255,.35);
+backdrop-filter:
+  blur(12px) saturate(150%);
+border: 1px solid
+  rgba(255,255,255,.25);
+border-radius: .75rem;</div>
+        <div class="p-tag">radius 12px · nested panel</div>
+      </div>
+    </div>
+
+    <div class="section-label">Dark — .dark .glass overrides + .scrollbar-glass thumb</div>
+    <div class="stage dark">
+      <div class="behind">
+        <div class="dots"></div>
+        <div class="stripe s1">music nerd ✦ pastypink ✦ pastyblue</div>
+        <div class="stripe s2">jellygreen ✦ #ff9ce3 ✦ maroon ✦ candy-neon</div>
+        <div class="stripe s3">frosted ✦ blur ✦ saturate ✦ glassy</div>
+      </div>
+
+      <div class="panel glass">
+        <div class="p-name">.dark .glass</div>
+        <div class="p-css">background: rgba(30,30,30,.55);
+border: 1px solid
+  rgba(255,255,255,.08);
+/* blur/saturate/radius
+   inherited from .glass */</div>
+        <div class="p-tag">radius 16px · dark surface</div>
+      </div>
+
+      <div class="panel glass-subtle">
+        <div class="p-name">.dark .glass-subtle</div>
+        <div class="p-css">background: rgba(40,40,40,.4);
+border: 1px solid
+  rgba(255,255,255,.06);
+/* blur(12px) saturate(150%)
+   inherited */</div>
+        <div class="p-tag">radius 12px · dark nested</div>
+      </div>
+
+      <div class="panel glass scroll-panel">
+        <div class="p-name">.scrollbar-glass</div>
+        <div class="p-css" style="color:rgba(255,255,255,.82)">thumb rgba(255,255,255,.18)
+hover 0.32 · track transparent
+6px · radius 9999px ↓ scroll</div>
+        <div class="scroll-box scrollbar-glass">
+          <div class="scroll-row">deezer id</div>
+          <div class="scroll-row">apple music</div>
+          <div class="scroll-row">musicbrainz</div>
+          <div class="scroll-row">wikidata</div>
+          <div class="scroll-row">tidal</div>
+          <div class="scroll-row">amazon music</div>
+          <div class="scroll-row">youtube music</div>
+          <div class="scroll-row">spotify</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="note">
+      <span class="ic">ℹ</span>
+      <span><b>Fidelity notes.</b> This is the exact recipe from <code>globals.css</code>.
+      The glass utilities define <b>no box-shadow</b> — only a translucent border — so panels read as
+      edges, not drop-shadows. Their radii (16px / 12px) are <b>off the <code>--radius</code> scale</b>
+      (which is 8/6/4px) — hardcoded brand exceptions. The <code>.scrollbar-glass</code> thumb is near-invisible
+      on light surfaces by design; it's tuned for dark/glass. WebKit renders the 6px pill; Firefox uses the
+      thin <code>scrollbar-color</code> fallback.</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/design-system/foundations/gradients.html
+++ b/design-system/foundations/gradients.html
@@ -1,0 +1,267 @@
+<!-- @dsCard group="Surfaces" name="Gradients" subtitle="hero / accent gradients" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  :root {
+    --bg: #ffffff;
+    --ink: #1a1420;
+    --muted: #6b6472;
+    --line: #ece7ef;
+    --card: #faf8fb;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    --radius: 0.5rem; /* real --radius base */
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    line-height: 1.5;
+  }
+  .wrap { max-width: 760px; margin: 0 auto; padding: 40px 28px 56px; }
+
+  header { margin-bottom: 8px; }
+  h1 {
+    margin: 0 0 4px;
+    font-size: 26px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+  .sub { margin: 0; color: var(--muted); font-size: 14px; }
+  .intro {
+    margin: 16px 0 30px;
+    font-size: 13.5px;
+    color: var(--muted);
+    border-left: 3px solid #ef95ff;
+    padding: 8px 0 8px 14px;
+    background: linear-gradient(90deg, rgba(239,149,255,.07), transparent 70%);
+  }
+  .intro code { font-family: var(--mono); font-size: 12px; color: var(--ink); }
+
+  .stack { display: flex; flex-direction: column; gap: 26px; }
+
+  .card {
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    overflow: hidden;
+    background: var(--card);
+  }
+
+  /* ---- swatch panel ---- */
+  .swatch {
+    height: 190px;
+    position: relative;
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-start;
+  }
+  .swatch .tag {
+    margin: 12px;
+    font-family: var(--mono);
+    font-size: 10.5px;
+    letter-spacing: .02em;
+    background: rgba(255,255,255,.86);
+    color: #2a2230;
+    padding: 4px 8px;
+    border-radius: 6px;
+    box-shadow: 0 1px 3px rgba(0,0,0,.18);
+  }
+
+  /* simulated dark, blurred artist photo (hero context) */
+  .photo-dark {
+    background:
+      radial-gradient(60% 80% at 74% 18%, rgba(37,99,235,.55), transparent 60%),
+      radial-gradient(70% 75% at 18% 82%, rgba(16,185,129,.42), transparent 62%),
+      linear-gradient(135deg, #3b4453, #131820);
+  }
+  /* simulated lighter photo so darkening reads */
+  .photo-light {
+    background:
+      radial-gradient(60% 80% at 28% 22%, #fde68a, transparent 60%),
+      radial-gradient(70% 72% at 82% 72%, #93c5fd, transparent 60%),
+      linear-gradient(135deg, #e8ebf0, #9aa2ae);
+  }
+  /* transparency checkerboard — signals a translucent fallback fill */
+  .checker {
+    background-color: #ffffff;
+    background-image:
+      linear-gradient(45deg, #e7e2ea 25%, transparent 25%),
+      linear-gradient(-45deg, #e7e2ea 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, #e7e2ea 75%),
+      linear-gradient(-45deg, transparent 75%, #e7e2ea 75%);
+    background-size: 18px 18px;
+    background-position: 0 0, 0 9px, 9px -9px, -9px 0;
+  }
+
+  /* the REAL gradients, as an overlay layer above the backdrop */
+  .g-hero-wash::before {
+    content: "";
+    position: absolute; inset: 0;
+    background: linear-gradient(to bottom right,
+      rgba(239,149,255,.20), transparent, rgba(124,58,237,.15));
+  }
+  .g-hero-dark::before {
+    content: "";
+    position: absolute; inset: 0;
+    background: linear-gradient(to bottom,
+      rgba(0,0,0,.20), rgba(0,0,0,.50));
+  }
+  .g-press::before {
+    content: "";
+    position: absolute; inset: 0;
+    background: linear-gradient(to bottom right,
+      rgba(239,149,255,.10), rgba(88,28,135,.20), transparent);
+  }
+
+  /* ---- meta block under each swatch ---- */
+  .meta { padding: 14px 16px 16px; }
+  .meta .name {
+    font-size: 14.5px; font-weight: 650; margin: 0 0 2px;
+  }
+  .meta .where {
+    font-family: var(--mono); font-size: 11px; color: var(--muted); margin: 0 0 12px;
+  }
+
+  .chips { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-family: var(--mono); font-size: 10.5px; color: #2a2230;
+    background: #fff; border: 1px solid var(--line);
+    padding: 3px 7px 3px 4px; border-radius: 20px;
+  }
+  .dot {
+    width: 14px; height: 14px; border-radius: 50%;
+    border: 1px solid rgba(0,0,0,.12);
+    /* alpha dots sit on their own mini-checker so opacity reads */
+    background-color: #fff;
+    background-image:
+      linear-gradient(45deg, #ddd 25%, transparent 25%),
+      linear-gradient(-45deg, #ddd 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, #ddd 75%),
+      linear-gradient(-45deg, transparent 75%, #ddd 75%);
+    background-size: 8px 8px;
+    background-position: 0 0, 0 4px, 4px -4px, -4px 0;
+    position: relative;
+  }
+  .dot::after { content:""; position:absolute; inset:0; border-radius:50%; background: var(--c); }
+
+  .code {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    line-height: 1.65;
+    color: #2a2230;
+    background: #fff;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 10px 12px;
+    overflow-x: auto;
+    white-space: pre;
+  }
+  .code .k { color: #a3369b; }
+  .code .lbl { display:block; color: var(--muted); font-size: 10px; letter-spacing:.04em; text-transform: uppercase; margin: 0 0 4px; }
+  .code + .code { margin-top: 8px; }
+
+  footer {
+    margin-top: 34px;
+    padding-top: 18px;
+    border-top: 1px solid var(--line);
+    font-size: 12.5px;
+    color: var(--muted);
+  }
+  footer b { color: var(--ink); font-weight: 650; }
+  footer code { font-family: var(--mono); font-size: 11.5px; color:#2a2230; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>Gradients</h1>
+    <p class="sub">Surfaces &middot; hero / accent gradients</p>
+  </header>
+
+  <p class="intro">
+    Every gradient in the app is a <b>translucent overlay on a <code>&lt;div&gt;</code></b> — composited over
+    artist imagery, never gradient-clipped text (<code>bg-clip-text</code> = 0 hits). Three exist, all authored
+    as Tailwind <code>bg-gradient-*</code> utilities. Backdrops below are simulated to reveal the low-alpha stops.
+  </p>
+
+  <div class="stack">
+
+    <!-- 1. Hero brand wash -->
+    <div class="card">
+      <div class="swatch photo-dark g-hero-wash">
+        <span class="tag">over blurred artist photo</span>
+      </div>
+      <div class="meta">
+        <p class="name">Hero brand wash</p>
+        <p class="where">artist/[id]/_components/HeroSection.tsx:79</p>
+        <div class="chips">
+          <span class="chip"><span class="dot" style="--c:rgba(239,149,255,.20)"></span>#ef95ff / 20%</span>
+          <span class="chip"><span class="dot" style="--c:transparent"></span>transparent</span>
+          <span class="chip"><span class="dot" style="--c:rgba(124,58,237,.15)"></span>#7c3aed / 15%</span>
+        </div>
+        <div class="code"><span class="lbl">Tailwind</span>bg-gradient-to-br from-[#ef95ff]/20 via-transparent to-[#7c3aed]/15</div>
+        <div class="code"><span class="lbl">Resolved CSS</span><span class="k">linear-gradient(</span>to bottom right,
+  rgba(239,149,255,.20),
+  transparent,
+  rgba(124,58,237,.15)<span class="k">)</span></div>
+      </div>
+    </div>
+
+    <!-- 2. Hero dark overlay -->
+    <div class="card">
+      <div class="swatch photo-light g-hero-dark">
+        <span class="tag">over lighter photo — bottom darkens</span>
+      </div>
+      <div class="meta">
+        <p class="name">Hero dark overlay</p>
+        <p class="where">artist/[id]/_components/HeroSection.tsx:82</p>
+        <div class="chips">
+          <span class="chip"><span class="dot" style="--c:rgba(0,0,0,.20)"></span>black / 20%</span>
+          <span class="chip"><span class="dot" style="--c:rgba(0,0,0,.50)"></span>black / 50%</span>
+        </div>
+        <div class="code"><span class="lbl">Tailwind</span>bg-gradient-to-b from-black/20 to-black/50</div>
+        <div class="code"><span class="lbl">Resolved CSS</span><span class="k">linear-gradient(</span>to bottom,
+  rgba(0,0,0,.20),
+  rgba(0,0,0,.50)<span class="k">)</span></div>
+      </div>
+    </div>
+
+    <!-- 3. Press thumb fallback -->
+    <div class="card">
+      <div class="swatch checker g-press">
+        <span class="tag">translucent fallback fill (no image)</span>
+      </div>
+      <div class="meta">
+        <p class="name">Press thumb fallback</p>
+        <p class="where">artist/[id]/_components/PressAndFeatures.tsx:68</p>
+        <div class="chips">
+          <span class="chip"><span class="dot" style="--c:rgba(239,149,255,.10)"></span>pastypink #ef95ff / 10%</span>
+          <span class="chip"><span class="dot" style="--c:rgba(88,28,135,.20)"></span>purple-900 #581c87 / 20%</span>
+          <span class="chip"><span class="dot" style="--c:transparent"></span>transparent</span>
+        </div>
+        <div class="code"><span class="lbl">Tailwind</span>bg-gradient-to-br from-pastypink/10 via-purple-900/20 to-transparent</div>
+        <div class="code"><span class="lbl">Resolved CSS</span><span class="k">linear-gradient(</span>to bottom right,
+  rgba(239,149,255,.10),
+  rgba(88,28,135,.20),
+  transparent<span class="k">)</span></div>
+      </div>
+    </div>
+
+  </div>
+
+  <footer>
+    <b>Two vocabularies for the same pink&rarr;purple wash.</b> The hero uses raw hex
+    (<code>from-[#ef95ff] to-[#7c3aed]</code>); the press thumb uses the <code>pastypink</code> token
+    + Tailwind <code>purple-900</code>. Note the palette pink here is <code>#ef95ff</code> — not the
+    <code>#ff9ce3</code> pink users actually see on the wordmark. Base <code>--radius: 0.5rem</code>;
+    swatch corners are illustrative. KoHo is declared but never loads, so all type renders in the
+    system sans stack.
+  </footer>
+</div>
+</body>
+</html>

--- a/design-system/foundations/motion.html
+++ b/design-system/foundations/motion.html
@@ -1,0 +1,293 @@
+<!-- @dsCard group="Motion" name="Motion" subtitle="fadeSlideIn · accordion · spin · live ping" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root{
+    /* Resolved from globals.css :root (shadcn "slate") */
+    --background: hsl(0 0% 100%);
+    --foreground: hsl(222.2 84% 4.9%);
+    --muted-foreground: hsl(215.4 16.3% 46.9%);
+    --border: hsl(214.3 31.8% 91.4%);
+    --card: hsl(0 0% 100%);
+    --primary: hsl(222.2 47.4% 11.2%);
+    /* Brand */
+    --maroon:#422b46;
+    --pastyblue:#2ad4fc;
+    --pastypink:#ef95ff;
+    --jellygreen:#19ffb8;
+    --radius:0.5rem;
+    --mono:"SF Mono",ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+  }
+  *{box-sizing:border-box}
+  body{
+    margin:0;
+    background:var(--background);
+    color:var(--foreground);
+    font-family:var(--sans);
+    -webkit-font-smoothing:antialiased;
+    padding:28px 24px 32px;
+  }
+  .wrap{max-width:920px;margin:0 auto}
+  header{margin-bottom:22px}
+  h1{
+    font-size:26px;
+    letter-spacing:-0.02em;
+    margin:0 0 6px;
+    font-weight:650;
+  }
+  .lede{
+    color:var(--muted-foreground);
+    font-size:14px;
+    margin:0;
+    max-width:640px;
+    line-height:1.5;
+  }
+  .lede code{font-family:var(--mono);font-size:12.5px;color:var(--maroon)}
+
+  .grid{
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(210px,1fr));
+    gap:16px;
+    margin-top:22px;
+  }
+  .demo{
+    border:1px solid var(--border);
+    border-radius:var(--radius);
+    background:var(--card);
+    overflow:hidden;
+    display:flex;
+    flex-direction:column;
+  }
+  .stage{
+    position:relative;
+    height:150px;
+    background:
+      radial-gradient(120% 120% at 50% 0%, #fbfcfe 0%, #f4f6fa 100%);
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    padding:16px;
+    overflow:hidden;
+  }
+  .meta{
+    padding:12px 14px 14px;
+    border-top:1px solid var(--border);
+  }
+  .name{
+    font-family:var(--mono);
+    font-size:13px;
+    font-weight:600;
+    color:var(--foreground);
+    letter-spacing:-0.01em;
+  }
+  .spec{
+    font-family:var(--mono);
+    font-size:11px;
+    color:var(--muted-foreground);
+    margin-top:4px;
+    line-height:1.5;
+  }
+  .spec b{color:var(--maroon);font-weight:600}
+  .src{
+    display:inline-block;
+    margin-top:8px;
+    font-family:var(--mono);
+    font-size:10px;
+    color:#8a93a3;
+  }
+
+  /* ---------- 1. fadeSlideIn : fadeSlideIn 0.3s ease-out both ---------- */
+  .fsi-card{
+    width:150px;
+    border-radius:var(--radius);
+    background:#fff;
+    border:1px solid var(--border);
+    box-shadow:0 6px 18px -10px rgba(66,43,70,0.35);
+    padding:12px 13px;
+    animation:fsi-loop 2.6s infinite;
+  }
+  .fsi-card .bar{height:8px;border-radius:4px;background:var(--pastypink);width:70%;margin-bottom:8px}
+  .fsi-card .bar.two{background:#e7ebf1;width:100%}
+  .fsi-card .bar.three{background:#e7ebf1;width:45%;margin-bottom:0}
+  @keyframes fsi-loop{
+    0%   {opacity:0;transform:translateY(-8px);animation-timing-function:ease-out}
+    11.5%{opacity:1;transform:translateY(0)}
+    85%  {opacity:1;transform:translateY(0)}
+    100% {opacity:0;transform:translateY(-8px)}
+  }
+
+  /* ---------- 2. accordion : accordion-down/up 0.2s ease-out ---------- */
+  .acc{width:160px;border:1px solid var(--border);border-radius:var(--radius);background:#fff;overflow:hidden}
+  .acc .trigger{
+    display:flex;align-items:center;justify-content:space-between;
+    padding:9px 12px;font-family:var(--sans);font-size:12px;font-weight:600;color:var(--foreground);
+  }
+  .acc .chev{
+    width:9px;height:9px;border-right:2px solid var(--maroon);border-bottom:2px solid var(--maroon);
+    transform:rotate(45deg);transform-origin:55% 55%;
+    animation:chev-loop 2.8s infinite;
+  }
+  .acc .panel{
+    height:0;overflow:hidden;
+    animation:acc-loop 2.8s infinite;
+  }
+  .acc .panel .inner{padding:0 12px 11px;font-family:var(--sans);font-size:11px;line-height:1.55;color:var(--muted-foreground)}
+  @keyframes acc-loop{
+    0%  {height:0;animation-timing-function:ease-out}
+    7%  {height:60px}
+    50% {height:60px;animation-timing-function:ease-out}
+    57% {height:0}
+    100%{height:0}
+  }
+  @keyframes chev-loop{
+    0%  {transform:rotate(45deg);animation-timing-function:ease-out}
+    7%  {transform:rotate(-135deg)}
+    50% {transform:rotate(-135deg);animation-timing-function:ease-out}
+    57% {transform:rotate(45deg)}
+    100%{transform:rotate(45deg)}
+  }
+
+  /* ---------- 3. spin (hover logo) : spin 3s linear infinite ---------- */
+  .disc{
+    width:74px;height:74px;border-radius:50%;position:relative;
+    background:
+      radial-gradient(circle at 50% 50%, #5a3f60 0 17%, transparent 17%),
+      repeating-radial-gradient(circle at 50% 50%, #2c1c30 0 3px, #3a2740 3px 6px);
+    box-shadow:0 4px 14px -4px rgba(66,43,70,0.5);
+    animation:spin360 3s linear infinite;
+  }
+  .disc::before{
+    content:"";position:absolute;inset:0;margin:auto;
+    width:22px;height:22px;border-radius:50%;
+    background:radial-gradient(circle at 50% 40%,var(--pastypink),var(--maroon));
+  }
+  .disc::after{
+    content:"";position:absolute;top:9px;left:50%;width:4px;height:4px;border-radius:50%;
+    background:var(--jellygreen);transform:translateX(-50%);box-shadow:0 0 6px var(--jellygreen);
+  }
+  @keyframes spin360{to{transform:rotate(360deg)}}
+
+  /* ---------- 4. Live ping : Tailwind animate-ping ---------- */
+  .pings{display:flex;gap:26px;align-items:center}
+  .pingcol{display:flex;flex-direction:column;align-items:center;gap:9px}
+  .chip{
+    padding:10px 14px;border-radius:var(--radius);display:flex;align-items:center;gap:8px;
+  }
+  .chip.light{background:#fff;border:1px solid var(--border)}
+  .chip.dark{background:#221226;border:1px solid #3a2740}
+  .ping{position:relative;display:inline-flex;height:8px;width:8px}
+  .ping .wave{position:absolute;inset:0;border-radius:50%;opacity:.75;animation:ping 1s cubic-bezier(0,0,.2,1) infinite}
+  .ping .dot{position:relative;display:inline-flex;border-radius:50%;height:8px;width:8px}
+  .light .wave,.light .dot{background:#059669}
+  .dark  .wave,.dark  .dot{background:var(--jellygreen)}
+  .livelabel{font-family:var(--sans);font-size:10px;letter-spacing:0.2em;text-transform:uppercase;font-weight:600}
+  .light .livelabel{color:rgba(90,77,94,0.75)}
+  .dark  .livelabel{color:rgba(198,191,199,0.75)}
+  .cap{font-family:var(--mono);font-size:10px;color:var(--muted-foreground)}
+  @keyframes ping{75%,100%{transform:scale(2.2);opacity:0}}
+
+  footer{
+    margin-top:24px;padding-top:14px;border-top:1px dashed var(--border);
+    font-family:var(--mono);font-size:11px;color:var(--muted-foreground);line-height:1.6;
+  }
+  footer b{color:var(--maroon);font-weight:600}
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <h1>Motion</h1>
+      <p class="lede">
+        The real animation tokens shipped in <code>tailwind.config.ts</code> and <code>globals.css</code>.
+        Slow, eased, ambient — motion that feels alive but calm. Demos loop for preview; in the app each
+        fires once (or on hover / when live).
+      </p>
+    </header>
+
+    <div class="grid">
+
+      <!-- fadeSlideIn -->
+      <div class="demo">
+        <div class="stage">
+          <div class="fsi-card">
+            <div class="bar"></div>
+            <div class="bar two"></div>
+            <div class="bar three"></div>
+          </div>
+        </div>
+        <div class="meta">
+          <div class="name">fadeSlideIn</div>
+          <div class="spec"><b>0.3s ease-out both</b><br>opacity 0→1 · translateY(−8px)→0</div>
+          <span class="src">tailwind.config.ts › keyframes.fadeSlideIn</span>
+        </div>
+      </div>
+
+      <!-- accordion -->
+      <div class="demo">
+        <div class="stage">
+          <div class="acc">
+            <div class="trigger">Details <span class="chev"></span></div>
+            <div class="panel"><div class="inner">crowd-sourced links, verified across 40+ platforms.</div></div>
+          </div>
+        </div>
+        <div class="meta">
+          <div class="name">accordion-down / -up</div>
+          <div class="spec"><b>0.2s ease-out</b><br>height 0 ⇄ var(--radix-accordion-content-height)</div>
+          <span class="src">tailwind.config.ts › keyframes.accordion-*</span>
+        </div>
+      </div>
+
+      <!-- spin -->
+      <div class="demo">
+        <div class="stage">
+          <div class="disc"></div>
+        </div>
+        <div class="meta">
+          <div class="name">spin (hover logo)</div>
+          <div class="spec"><b>spin 3s linear infinite</b><br>rotate 0deg→360deg · on <b>:hover</b></div>
+          <span class="src">NavContent.tsx › hover:animate-[spin_3s_linear_infinite]</span>
+        </div>
+      </div>
+
+      <!-- live ping -->
+      <div class="demo">
+        <div class="stage">
+          <div class="pings">
+            <div class="pingcol">
+              <div class="chip light">
+                <span class="ping"><span class="wave"></span><span class="dot"></span></span>
+                <span class="livelabel">Live</span>
+              </div>
+              <span class="cap">light #059669</span>
+            </div>
+            <div class="pingcol">
+              <div class="chip dark">
+                <span class="ping"><span class="wave"></span><span class="dot"></span></span>
+                <span class="livelabel">Live</span>
+              </div>
+              <span class="cap">dark #19ffb8</span>
+            </div>
+          </div>
+        </div>
+        <div class="meta">
+          <div class="name">animate-ping (Live dot)</div>
+          <div class="spec"><b>ping 1s cubic-bezier(0,0,.2,1) ∞</b><br>scale→2 · opacity 0.75→0 · accent swaps light→dark</div>
+          <span class="src">ActivityFeed.tsx › --feed-live-dot</span>
+        </div>
+      </div>
+
+    </div>
+
+    <footer>
+      Notes: <b>spin</b> and <b>ping</b> reuse Tailwind's built-in keyframes (nav overrides spin's duration to 3s).
+      Also present: <b>slow-spin 10s linear infinite</b> (profile avatar hover) and marquee
+      <b>scroll-left / scroll-right 20s linear infinite</b>. Labels render in system sans — the app declares
+      <b>KoHo</b> but it never loads, so type falls back to the platform font.
+    </footer>
+  </div>
+</body>
+</html>

--- a/design-system/foundations/spacing-radius.html
+++ b/design-system/foundations/spacing-radius.html
@@ -1,0 +1,308 @@
+<!-- @dsCard group="Spacing" name="Spacing & radius" subtitle="container 1400px/2rem · breakpoints · radius scale" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Spacing &amp; radius</title>
+<style>
+  :root{
+    --maroon:#422b46;
+    --pastyblue:#2ad4fc;
+    --pastypink:#ff9ce3;
+    --jellygreen:#19ffb8;
+    --ink:#1c1420;
+    --muted:#7a6f80;
+    --line:#e7e2ea;
+    --canvas:#ffffff;
+    --panel:#faf8fb;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+    --mono:ui-monospace,SFMono-Regular,Menlo,Monaco,"Cascadia Code",monospace;
+  }
+  *{box-sizing:border-box}
+  body{
+    margin:0;
+    background:var(--canvas);
+    color:var(--ink);
+    font-family:var(--sans);
+    -webkit-font-smoothing:antialiased;
+    line-height:1.5;
+    padding:32px;
+  }
+  .wrap{max-width:960px;margin:0 auto}
+  header.hd{margin-bottom:28px}
+  .kicker{
+    font-family:var(--mono);
+    font-size:11px;
+    letter-spacing:.14em;
+    text-transform:uppercase;
+    color:var(--pastyblue);
+    filter:saturate(.7) brightness(.72);
+    margin:0 0 6px;
+  }
+  h1{font-size:26px;letter-spacing:-.02em;margin:0 0 6px;color:var(--maroon)}
+  .sub{margin:0;color:var(--muted);font-size:14px}
+  .sub code{font-family:var(--mono);font-size:12.5px;background:var(--panel);border:1px solid var(--line);border-radius:4px;padding:1px 5px;color:var(--maroon)}
+
+  section.block{margin-top:30px}
+  .blkhead{display:flex;align-items:baseline;gap:10px;margin:0 0 14px;flex-wrap:wrap}
+  .blkhead h2{font-size:15px;margin:0;color:var(--ink);letter-spacing:-.01em}
+  .blkhead .note{font-family:var(--mono);font-size:11.5px;color:var(--muted)}
+
+  /* ---- Radius scale ---- */
+  .radii{
+    display:grid;
+    grid-template-columns:repeat(5,1fr);
+    gap:14px;
+  }
+  @media(max-width:640px){.radii{grid-template-columns:repeat(2,1fr)}}
+  .rcell{
+    background:var(--panel);
+    border:1px solid var(--line);
+    border-radius:10px;
+    padding:16px 14px 14px;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    text-align:center;
+  }
+  .swatch{
+    width:74px;height:74px;
+    background:linear-gradient(135deg,#f6d9ff 0%, #d7f3ff 100%);
+    border:2px solid var(--maroon);
+    position:relative;
+    margin-bottom:14px;
+  }
+  /* corner tick to make rounding legible */
+  .swatch::after{
+    content:"";
+    position:absolute;
+    inset:0;
+    border-top:6px solid var(--pastypink);
+    border-left:6px solid var(--pastypink);
+    border-radius:inherit;
+    -webkit-mask:linear-gradient(135deg,#000 0 34%,transparent 40%);
+            mask:linear-gradient(135deg,#000 0 34%,transparent 40%);
+    opacity:.9;
+  }
+  .r-sm{border-radius:calc(0.5rem - 4px)}   /* 4px */
+  .r-md{border-radius:calc(0.5rem - 2px)}   /* 6px */
+  .r-lg{border-radius:0.5rem}               /* 8px */
+  .r-2xl{border-radius:1rem}                /* 16px */
+  .r-full{border-radius:9999px}
+  .rname{font-weight:600;font-size:13px;color:var(--maroon)}
+  .rval{font-family:var(--mono);font-size:11px;color:var(--muted);margin-top:3px}
+  .rpx{font-family:var(--mono);font-size:11px;color:var(--ink);margin-top:2px;font-weight:600}
+
+  /* ---- Container diagram ---- */
+  .viewport{
+    border:1px solid var(--line);
+    border-radius:12px;
+    background:
+      repeating-linear-gradient(45deg,#f2ecf5 0 6px,#faf8fb 6px 12px);
+    padding:0;
+    position:relative;
+    overflow:hidden;
+  }
+  .vp-bar{
+    background:var(--maroon);
+    color:#fff;
+    font-family:var(--mono);
+    font-size:11px;
+    padding:6px 12px;
+    display:flex;
+    justify-content:space-between;
+    align-items:center;
+  }
+  .vp-bar .dot{display:inline-block;width:9px;height:9px;border-radius:9999px;background:var(--pastypink);margin-right:5px;vertical-align:middle}
+  .vp-body{position:relative;padding:22px 0 26px}
+  .content-col{
+    max-width:520px;
+    margin:0 auto;
+    background:#fff;
+    border:1.5px dashed var(--pastyblue);
+    border-radius:8px;
+    min-height:96px;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    text-align:center;
+    padding:16px 18px;
+  }
+  .content-col .ctitle{font-size:13px;font-weight:600;color:var(--maroon)}
+  .content-col .cval{font-family:var(--mono);font-size:11px;color:var(--muted);margin-top:4px}
+  .gutter-tag{
+    position:absolute;top:50%;transform:translateY(-50%);
+    font-family:var(--mono);font-size:10.5px;color:var(--maroon);
+    background:rgba(255,255,255,.85);
+    border:1px solid var(--line);border-radius:4px;
+    padding:2px 6px;white-space:nowrap;
+  }
+  .gutter-tag.l{left:14px}
+  .gutter-tag.r{right:14px}
+  .cap-max{
+    text-align:center;
+    font-family:var(--mono);
+    font-size:11px;
+    color:var(--muted);
+    margin-top:10px;
+  }
+  .cap-max b{color:var(--maroon)}
+  .deadnote{
+    margin-top:12px;
+    font-size:12.5px;
+    color:var(--muted);
+    background:#fff7ed;
+    border:1px solid #f4dcc0;
+    border-left:3px solid #e0993f;
+    border-radius:6px;
+    padding:9px 12px;
+  }
+  .deadnote code{font-family:var(--mono);font-size:11.5px;color:var(--maroon)}
+
+  /* ---- lower grid: breakpoints + ramp ---- */
+  .lower{display:grid;grid-template-columns:1fr 1fr;gap:22px}
+  @media(max-width:640px){.lower{grid-template-columns:1fr}}
+
+  table.bp{border-collapse:collapse;width:100%;font-size:13px}
+  table.bp th,table.bp td{text-align:left;padding:7px 8px;border-bottom:1px solid var(--line)}
+  table.bp th{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);font-weight:600}
+  table.bp td.tok{font-family:var(--mono);font-weight:600;color:var(--maroon)}
+  table.bp td.val{font-family:var(--mono);color:var(--ink)}
+  table.bp .track{height:8px;background:var(--panel);border:1px solid var(--line);border-radius:9999px;position:relative;overflow:hidden;min-width:60px}
+  table.bp .fill{position:absolute;left:0;top:0;bottom:0;background:linear-gradient(90deg,var(--pastyblue),var(--pastypink));border-radius:9999px}
+  .bp-foot{font-family:var(--mono);font-size:10.5px;color:var(--muted);margin-top:8px}
+
+  .ramp{display:flex;flex-direction:column;gap:9px}
+  .rrow{display:flex;align-items:center;gap:10px}
+  .rbar{height:16px;border-radius:4px;background:var(--jellygreen);border:1px solid #12d69a}
+  .rlabel{font-family:var(--mono);font-size:11px;color:var(--ink);white-space:nowrap}
+  .rlabel b{color:var(--maroon)}
+  .rtok{font-family:var(--mono);font-size:10.5px;color:var(--muted)}
+  .ramp-foot{font-family:var(--mono);font-size:10.5px;color:var(--muted);margin-top:10px}
+
+  footer.ft{
+    margin-top:30px;padding-top:16px;border-top:1px solid var(--line);
+    font-family:var(--mono);font-size:11px;color:var(--muted);line-height:1.7;
+  }
+  footer.ft b{color:var(--maroon)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="hd">
+    <p class="kicker">Foundations · Spacing</p>
+    <h1>Spacing &amp; radius</h1>
+    <p class="sub">Stock shadcn scale on <code>--radius: 0.5rem</code>. Container config (<code>center · 2rem · 1400px</code>) exists in <code>tailwind.config.ts</code> but the <code>.container</code> class is unused — real columns are 800–1000px.</p>
+  </header>
+
+  <!-- Block 1: Radius scale -->
+  <section class="block">
+    <div class="blkhead">
+      <h2>Radius scale</h2>
+      <span class="note">tailwind.config.ts · borderRadius</span>
+    </div>
+    <div class="radii">
+      <div class="rcell">
+        <div class="swatch r-sm"></div>
+        <div class="rname">rounded-sm</div>
+        <div class="rval">calc(0.5rem − 4px)</div>
+        <div class="rpx">4px</div>
+      </div>
+      <div class="rcell">
+        <div class="swatch r-md"></div>
+        <div class="rname">rounded-md</div>
+        <div class="rval">calc(0.5rem − 2px)</div>
+        <div class="rpx">6px</div>
+      </div>
+      <div class="rcell">
+        <div class="swatch r-lg"></div>
+        <div class="rname">rounded-lg</div>
+        <div class="rval">var(--radius)</div>
+        <div class="rpx">8px</div>
+      </div>
+      <div class="rcell">
+        <div class="swatch r-2xl"></div>
+        <div class="rname">rounded-2xl</div>
+        <div class="rval">1rem (default)</div>
+        <div class="rpx">16px</div>
+      </div>
+      <div class="rcell">
+        <div class="swatch r-full"></div>
+        <div class="rname">rounded-full</div>
+        <div class="rval">9999px</div>
+        <div class="rpx">pill</div>
+      </div>
+    </div>
+    <p class="bp-foot" style="margin-top:12px">sm/md/lg derive from <b style="color:var(--maroon)">--radius</b>. Off-scale hardcoded radii in globals.css bypass the token: <b style="color:var(--maroon)">.glass</b> 16px · <b style="color:var(--maroon)">.glass-subtle</b> 12px · <b style="color:var(--maroon)">.search-bar / .pink-btn</b> 5px.</p>
+  </section>
+
+  <!-- Block 2: Container rules -->
+  <section class="block">
+    <div class="blkhead">
+      <h2>Container rules</h2>
+      <span class="note">theme.container · centered · padded · capped</span>
+    </div>
+    <div class="viewport">
+      <div class="vp-bar">
+        <span><span class="dot"></span>2xl viewport — <b>1400px</b> cap</span>
+        <span>center: true</span>
+      </div>
+      <div class="vp-body">
+        <span class="gutter-tag l">padding 2rem</span>
+        <span class="gutter-tag r">padding 2rem</span>
+        <div class="content-col">
+          <div>
+            <div class="ctitle">centered content column</div>
+            <div class="cval">margin-inline: auto · max-width 1400px @ 2xl</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <p class="cap-max">screens: { <b>"2xl": "1400px"</b> } &nbsp;·&nbsp; padding: <b>"2rem"</b> &nbsp;·&nbsp; center: <b>true</b></p>
+    <p class="deadnote"><b>Reality:</b> this config is <b>dead</b> — <code>.container</code> is used nowhere in <code>src/</code>. Each page rolls its own centered column: <code>max-w-[800px]</code> (artist), <code>max-w-[1000px]</code> (nav), <code>max-w-2xl</code> (home / add-artist). Gutters cluster on <code>px-4/px-5 → sm:px-8/sm:px-10</code>.</p>
+  </section>
+
+  <!-- Block 3: breakpoints + ramp -->
+  <section class="block">
+    <div class="blkhead">
+      <h2>Breakpoints &amp; spacing ramp</h2>
+      <span class="note">stock Tailwind screens · 4px base scale</span>
+    </div>
+    <div class="lower">
+      <div>
+        <table class="bp">
+          <thead>
+            <tr><th>Token</th><th>Min-width</th><th style="width:34%">Scale</th></tr>
+          </thead>
+          <tbody>
+            <tr><td class="tok">sm</td><td class="val">640px</td><td><div class="track"><div class="fill" style="width:42%"></div></div></td></tr>
+            <tr><td class="tok">md</td><td class="val">768px</td><td><div class="track"><div class="fill" style="width:50%"></div></div></td></tr>
+            <tr><td class="tok">lg</td><td class="val">1024px</td><td><div class="track"><div class="fill" style="width:67%"></div></div></td></tr>
+            <tr><td class="tok">xl</td><td class="val">1280px</td><td><div class="track"><div class="fill" style="width:83%"></div></div></td></tr>
+            <tr><td class="tok">2xl</td><td class="val">1536px</td><td><div class="track"><div class="fill" style="width:100%"></div></div></td></tr>
+          </tbody>
+        </table>
+        <p class="bp-foot">All defaults — <b style="color:var(--maroon)">theme.screens</b> is never overridden. The 2xl <b style="color:var(--maroon)">breakpoint</b> is 1536px; the container's 2xl <b style="color:var(--maroon)">max-width</b> cap (1400px, above) is separate. Effective use is near-two-breakpoint: sm 157× · md 41×. One raw SCSS <code style="font-family:var(--mono)">@media (max-width:768px)</code> duplicates <b style="color:var(--maroon)">md</b>.</p>
+      </div>
+      <div>
+        <div class="ramp">
+          <div class="rrow"><div class="rbar" style="width:12px"></div><span class="rlabel"><b>4px</b></span><span class="rtok">gap-1 · space-1</span></div>
+          <div class="rrow"><div class="rbar" style="width:24px"></div><span class="rlabel"><b>8px</b></span><span class="rtok">gap-2 · space-2</span></div>
+          <div class="rrow"><div class="rbar" style="width:36px"></div><span class="rlabel"><b>12px</b></span><span class="rtok">gap-3 · space-3</span></div>
+          <div class="rrow"><div class="rbar" style="width:48px"></div><span class="rlabel"><b>16px</b></span><span class="rtok">gap-4 · space-y-4</span></div>
+          <div class="rrow"><div class="rbar" style="width:72px"></div><span class="rlabel"><b>24px</b></span><span class="rtok">space-y-6 (sections)</span></div>
+          <div class="rrow"><div class="rbar" style="width:96px"></div><span class="rlabel"><b>32px</b></span><span class="rtok">gap-8 · p-8</span></div>
+        </div>
+        <p class="ramp-foot">4px base grid. Favorites: <b style="color:var(--maroon)">gap-2</b> (65×) inline · <b style="color:var(--maroon)">space-y-4</b> (24×) stacks · <b style="color:var(--maroon)">space-y-6</b> page sections.</p>
+      </div>
+    </div>
+  </section>
+
+  <footer class="ft">
+    <b>Sources:</b> tailwind.config.ts (container, borderRadius) · src/app/globals.css (--radius: 0.5rem) · DESIGN.md §Layout &amp; spacing<br>
+    <b>Honest note:</b> KoHo never loads → captions render in system sans. Container config &amp; the 2xl 1400px cap are declared but unused; radius scale &amp; breakpoints are unmodified shadcn/Tailwind defaults.
+  </footer>
+</div>
+</body>
+</html>

--- a/design-system/foundations/typography.html
+++ b/design-system/foundations/typography.html
@@ -1,0 +1,442 @@
+<!-- @dsCard group="Type" name="Typography" subtitle="system sans (KoHo intended, never loads) · scale + display" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root{
+    /* real --background / --foreground from globals.css :root (stock shadcn slate) */
+    --bg: hsl(0 0% 100%);
+    --fg: hsl(222.2 84% 4.9%);
+    --muted-fg: hsl(215.4 16.3% 46.9%);
+    --border: hsl(214.3 31.8% 91.4%);
+    --card: hsl(210 40% 98%);
+    --radius: 0.5rem; /* base radius token */
+    /* the real on-screen pink (57 hardcoded uses, in no palette) */
+    --wordmark-pink: #ff9ce3;
+    /* home-text-h2 subtitle colors */
+    --h2-light: #9b83a0;
+    --h2-dark: #a08ba8;
+    /* the real Tailwind default font-sans stack the app actually renders in */
+    --sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  }
+  *{box-sizing:border-box;}
+  html,body{margin:0;}
+  body{
+    background:var(--bg);
+    color:var(--fg);
+    font-family:var(--sans);
+    -webkit-font-smoothing:antialiased;
+    line-height:1.4;
+    padding:40px clamp(20px,4vw,56px) 56px;
+  }
+  .wrap{max-width:1040px;margin:0 auto;}
+
+  header.head{margin-bottom:36px;}
+  .eyebrow{
+    font-family:var(--mono);
+    font-size:11px;
+    letter-spacing:.14em;
+    text-transform:uppercase;
+    color:var(--muted-fg);
+    margin:0 0 10px;
+  }
+  h1.title{
+    font-size:34px;
+    font-weight:700;
+    letter-spacing:-.02em;
+    margin:0 0 8px;
+  }
+  .subtitle{
+    color:var(--muted-fg);
+    font-size:15px;
+    margin:0;
+    max-width:62ch;
+  }
+
+  section{margin-top:44px;}
+  .sec-head{
+    display:flex;
+    align-items:baseline;
+    gap:12px;
+    border-bottom:1px solid var(--border);
+    padding-bottom:10px;
+    margin-bottom:20px;
+    flex-wrap:wrap;
+  }
+  .sec-head h2{
+    font-size:13px;
+    font-weight:600;
+    text-transform:uppercase;
+    letter-spacing:.09em;
+    margin:0;
+  }
+  .sec-head .note{
+    font-family:var(--mono);
+    font-size:11.5px;
+    color:var(--muted-fg);
+  }
+
+  /* ---- honest KoHo caption banner ---- */
+  .honest{
+    display:flex;
+    gap:12px;
+    align-items:flex-start;
+    background:var(--card);
+    border:1px solid var(--border);
+    border-left:3px solid var(--wordmark-pink);
+    border-radius:var(--radius);
+    padding:14px 16px;
+    margin-top:24px;
+    font-size:13.5px;
+    color:#4a4152;
+    line-height:1.5;
+  }
+  .honest .icon{
+    flex:0 0 auto;
+    width:18px;height:18px;
+    border-radius:50%;
+    background:var(--wordmark-pink);
+    color:#422b46;
+    font-weight:700;
+    font-size:12px;
+    display:flex;align-items:center;justify-content:center;
+    margin-top:1px;
+  }
+  .honest code{font-family:var(--mono);font-size:12px;background:rgba(66,43,70,.07);padding:1px 5px;border-radius:4px;}
+
+  /* ---- scale table ---- */
+  .scale-scroll{overflow-x:auto;}
+  .scale{
+    display:grid;
+    grid-template-columns:max-content 1fr;
+    gap:0;
+    min-width:520px;
+    border:1px solid var(--border);
+    border-radius:var(--radius);
+    overflow:hidden;
+  }
+  .row{display:contents;}
+  .cell-meta,.cell-spec{
+    border-top:1px solid var(--border);
+    padding:14px 18px;
+    display:flex;
+    align-items:center;
+  }
+  .row:first-child .cell-meta,.row:first-child .cell-spec{border-top:none;}
+  .cell-meta{
+    flex-direction:column;
+    align-items:flex-start;
+    justify-content:center;
+    gap:5px;
+    background:var(--card);
+    min-width:210px;
+    border-right:1px solid var(--border);
+  }
+  .cls{
+    font-family:var(--mono);
+    font-size:12.5px;
+    font-weight:600;
+    color:var(--fg);
+  }
+  .dims{font-family:var(--mono);font-size:11px;color:var(--muted-fg);}
+  .use{
+    font-family:var(--mono);
+    font-size:10.5px;
+    color:var(--muted-fg);
+  }
+  .tag{
+    display:inline-block;
+    font-family:var(--mono);
+    font-size:10px;
+    padding:1px 6px;
+    border-radius:999px;
+    letter-spacing:.02em;
+  }
+  .tag-used{background:rgba(25,255,184,.16);color:#0b7d5a;}
+  .tag-unused{background:hsl(210 40% 92%);color:var(--muted-fg);}
+  .cell-spec{
+    overflow:hidden;
+    white-space:nowrap;
+    color:var(--fg);
+  }
+  .cell-spec .sample{line-height:1.05;font-weight:400;}
+
+  /* ---- weights ---- */
+  .weights{
+    display:grid;
+    grid-template-columns:repeat(auto-fill,minmax(160px,1fr));
+    gap:14px;
+  }
+  .w-card{
+    border:1px solid var(--border);
+    border-radius:var(--radius);
+    padding:16px 16px 14px;
+    background:var(--bg);
+  }
+  .w-card.dead{background:var(--card);border-style:dashed;}
+  .w-sample{font-size:30px;line-height:1;margin-bottom:12px;}
+  .w-name{font-family:var(--mono);font-size:12px;font-weight:600;}
+  .w-sub{font-family:var(--mono);font-size:10.5px;color:var(--muted-fg);margin-top:4px;line-height:1.45;}
+
+  /* ---- display / fluid headings ---- */
+  .display{
+    display:flex;
+    flex-direction:column;
+    gap:22px;
+  }
+  .disp-card{
+    border:1px solid var(--border);
+    border-radius:12px; /* off-scale, matches glass family */
+    padding:26px 26px 22px;
+    background:var(--bg);
+    overflow:hidden;
+  }
+  .disp-label{
+    font-family:var(--mono);
+    font-size:11px;
+    color:var(--muted-fg);
+    margin-bottom:16px;
+    letter-spacing:.02em;
+  }
+  .disp-label b{color:var(--fg);font-weight:600;}
+
+  /* the real homepage wordmark, faithful to HomePageSplash.tsx */
+  .wordmark{
+    text-transform:lowercase;
+    font-weight:700;
+    color:var(--wordmark-pink);
+    line-height:1;
+    margin:0;
+    font-size:clamp(32px, calc(32px + (84 - 32) * ((100vw - 360px) / (1440 - 360))), 84px);
+    letter-spacing:clamp(-1px, calc(-1px + (-4 - -1) * ((100vw - 360px) / (1440 - 360))), -4px);
+    text-shadow:0 0 40px rgba(255,156,227,0.25);
+  }
+  /* the legacy .home-text-h2 (dead code — only referenced inside globals.css) */
+  .h2legacy{
+    margin:0;
+    font-weight:700;
+    color:var(--h2-light);
+    font-size:clamp(28px, calc(28px + (78 - 28) * ((100vw - 360px) / (1440 - 360))), 70px);
+    letter-spacing:clamp(-1px, calc(-1px + (-3 - -1) * ((100vw - 360px) / (1440 - 360))), -3px);
+    line-height:clamp(36px, calc(36px + (78 - 36) * ((100vw - 360px) / (1440 - 360))), 70px);
+  }
+  .disp-meta{
+    margin-top:18px;
+    font-family:var(--mono);
+    font-size:11px;
+    color:var(--muted-fg);
+    line-height:1.7;
+    border-top:1px dashed var(--border);
+    padding-top:12px;
+  }
+  .disp-meta .k{color:#7a5c7f;}
+  .swatch{
+    display:inline-block;width:10px;height:10px;border-radius:2px;
+    vertical-align:middle;margin-right:5px;border:1px solid rgba(0,0,0,.12);
+  }
+
+  /* dark chip: wordmark stays pink in both modes; h2 subtitle shifts */
+  .darkchip{
+    margin-top:22px;
+    background:#141414;
+    border:1px solid rgba(255,255,255,.09);
+    border-radius:12px;
+    padding:22px 24px;
+    color:#e7e0ea;
+    overflow:hidden;
+  }
+  .darkchip .disp-label{color:#9b8aa0;}
+  .darkchip .disp-label b{color:#e7e0ea;}
+  .darkchip .wordmark{color:var(--wordmark-pink);}
+  .darkchip .h2legacy{color:var(--h2-dark);}
+  .darkchip .darknote{
+    font-family:var(--mono);font-size:11px;color:#9b8aa0;margin-top:14px;line-height:1.6;
+  }
+
+  .foot{
+    margin-top:40px;
+    font-family:var(--mono);
+    font-size:11px;
+    color:var(--muted-fg);
+    border-top:1px solid var(--border);
+    padding-top:14px;
+    line-height:1.7;
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="head">
+    <p class="eyebrow">Foundations · Type</p>
+    <h1 class="title">Typography</h1>
+    <p class="subtitle">Stock Tailwind type scale rendered in the system sans stack the app actually ships. No custom <code style="font-family:var(--mono);font-size:13px">fontSize</code> scale, no font tokens — the only bespoke type is two hand-rolled fluid <code style="font-family:var(--mono);font-size:13px">clamp()</code> display headings.</p>
+  </header>
+
+  <!-- honest KoHo caption -->
+  <div class="honest">
+    <span class="icon">i</span>
+    <div>
+      <b>KoHo is declared but never loads.</b> <code>.koho-extralight</code> (200), <code>.koho-light</code> (300) and the shipping <code>.pink-btn</code> all declare <code>font-family: "KoHo", sans-serif</code> — but there is no <code>next/font</code>, <code>&lt;link&gt;</code>, <code>@font-face</code> or font package anywhere in the app, so every one silently falls back to <b>system sans-serif</b>. Everything below renders in the real fallback stack. (KoHo only loads on two standalone <code>public/*privacy.html</code> legal pages.)
+    </div>
+  </div>
+
+  <!-- TYPE SCALE -->
+  <section>
+    <div class="sec-head">
+      <h2>Type scale</h2>
+      <span class="note">stock Tailwind defaults · 16px root (never overridden) · px + rem · line-height</span>
+    </div>
+    <div class="scale-scroll">
+      <div class="scale">
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-xs</span><span class="dims">12px · 0.75rem / lh 16px</span><span class="use"><span class="tag tag-used">108×</span> badges · captions · meta</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:12px">music nerd — discover artists</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-sm</span><span class="dims">14px · 0.875rem / lh 20px</span><span class="use"><span class="tag tag-used">138×</span> de-facto body / UI</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:14px">music nerd — discover artists</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-base</span><span class="dims">16px · 1rem / lh 24px</span><span class="use"><span class="tag tag-used">22×</span> Input default</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:16px">music nerd — discover artists</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-lg</span><span class="dims">18px · 1.125rem / lh 28px</span><span class="use"><span class="tag tag-used">40×</span> sub-headings</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:18px">music nerd — discover artists</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-xl</span><span class="dims">20px · 1.25rem / lh 28px</span><span class="use"><span class="tag tag-used">22×</span> section headings</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:20px">music nerd — discover</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-2xl</span><span class="dims">24px · 1.5rem / lh 32px</span><span class="use"><span class="tag tag-used">14×</span> CardTitle · artist name</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:24px;font-weight:600">music nerd — discover</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-3xl</span><span class="dims">30px · 1.875rem / lh 36px</span><span class="use"><span class="tag tag-used">5×</span> page H1s · font-bold</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:30px;font-weight:700">music nerd</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-4xl</span><span class="dims">36px · 2.25rem / lh 40px</span><span class="use"><span class="tag tag-used">1×</span> .artist-name only</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:36px;font-weight:700">music nerd</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-5xl</span><span class="dims">48px · 3rem / lh 1</span><span class="use"><span class="tag tag-unused">0×</span> unused in src/</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:48px;line-height:1;font-weight:700;color:var(--muted-fg)">music nerd</span></div>
+        </div>
+
+        <div class="row">
+          <div class="cell-meta"><span class="cls">text-6xl</span><span class="dims">60px · 3.75rem / lh 1</span><span class="use"><span class="tag tag-unused">0×</span> unused in src/</span></div>
+          <div class="cell-spec"><span class="sample" style="font-size:60px;line-height:1;font-weight:700;color:var(--muted-fg)">music nerd</span></div>
+        </div>
+
+      </div>
+    </div>
+    <p style="font-family:var(--mono);font-size:11px;color:var(--muted-fg);margin:12px 2px 0;line-height:1.6">The app tops out at <b>text-4xl</b> — <b>text-5xl / text-6xl</b> (greyed) are stock Tailwind but appear nowhere in <code style="font-family:var(--mono)">src/</code>. All display type at that scale is hand-rolled clamp, below.</p>
+  </section>
+
+  <!-- WEIGHTS -->
+  <section>
+    <div class="sec-head">
+      <h2>Weights</h2>
+      <span class="note">rendered at 30px · same fallback stack</span>
+    </div>
+    <div class="weights">
+      <div class="w-card dead">
+        <div class="w-sample" style="font-weight:200">Aa nerd</div>
+        <div class="w-name">.koho-extralight</div>
+        <div class="w-sub">weight 200 · KoHo intended<br>never renders (falls back)</div>
+      </div>
+      <div class="w-card dead">
+        <div class="w-sample" style="font-weight:300">Aa nerd</div>
+        <div class="w-name">.koho-light</div>
+        <div class="w-sub">weight 300 · KoHo intended<br>never renders (falls back)</div>
+      </div>
+      <div class="w-card">
+        <div class="w-sample" style="font-weight:400">Aa nerd</div>
+        <div class="w-name">font-normal</div>
+        <div class="w-sub">weight 400 · 8×<br>occasional body reset</div>
+      </div>
+      <div class="w-card">
+        <div class="w-sample" style="font-weight:500">Aa nerd</div>
+        <div class="w-name">font-medium</div>
+        <div class="w-sub">weight 500 · 41×<br>buttons · labels</div>
+      </div>
+      <div class="w-card">
+        <div class="w-sample" style="font-weight:600">Aa nerd</div>
+        <div class="w-name">font-semibold</div>
+        <div class="w-sub">weight 600 · 62×<br>dominant heading weight</div>
+      </div>
+      <div class="w-card">
+        <div class="w-sample" style="font-weight:700">Aa nerd</div>
+        <div class="w-name">font-bold</div>
+        <div class="w-sub">weight 700 · 33×<br>page H1s</div>
+      </div>
+    </div>
+    <p style="font-family:var(--mono);font-size:11px;color:var(--muted-fg);margin:14px 2px 0;line-height:1.6">The two light weights the brand cares about — <b>200</b> &amp; <b>300</b> — are the KoHo weights that never render (dashed cards). What you see for them is whatever the system font supplies at that weight.</p>
+  </section>
+
+  <!-- DISPLAY / FLUID CLAMP -->
+  <section>
+    <div class="sec-head">
+      <h2>Display type — two hand-rolled fluid clamp headings</h2>
+      <span class="note">clamp() over 360px → 1440px viewport · resize this card to watch them scale</span>
+    </div>
+    <div class="display">
+
+      <!-- 1. the pink wordmark -->
+      <div class="disp-card">
+        <div class="disp-label"><b>1 · "music nerd" wordmark</b> — HomePageSplash.tsx (largest type on the site, inline-styled)</div>
+        <h1 class="wordmark">music nerd</h1>
+        <div class="disp-meta">
+          <span class="k">font-size</span>&nbsp;&nbsp;clamp(32px, …, 84px)<br>
+          <span class="k">letter-spacing</span>&nbsp;&nbsp;clamp(-1px, …, -4px) &nbsp;·&nbsp; <span class="k">line-height</span> 1 &nbsp;·&nbsp; lowercase font-bold<br>
+          <span class="k">color</span>&nbsp;&nbsp;<span class="swatch" style="background:#ff9ce3"></span>#ff9ce3 &nbsp;·&nbsp; <span class="k">text-shadow</span> 0 0 40px rgba(255,156,227,.25) &nbsp;— a pink glow, <b>not</b> a gradient<br>
+          <span style="color:#7a5c7f">note</span>&nbsp;&nbsp;#ff9ce3 is the on-screen pink (57 hardcoded uses) — defined in no palette, ≠ pastypink #ef95ff. Forced pink in both light &amp; dark.
+        </div>
+      </div>
+
+      <!-- 2. .home-text-h2 legacy -->
+      <div class="disp-card">
+        <div class="disp-label"><b>2 · .home-text-h2</b> — globals.css:616 &nbsp;<span style="color:#b08; background:hsl(210 40% 92%); padding:1px 6px; border-radius:999px; font-size:10px">legacy / dead</span> (referenced only inside globals.css, never applied by any .tsx)</div>
+        <h2 class="h2legacy">crowd-sourced directory</h2>
+        <div class="disp-meta">
+          <span class="k">font-size</span>&nbsp;&nbsp;clamp(28px, …, 70px)<br>
+          <span class="k">letter-spacing</span>&nbsp;&nbsp;clamp(-1px, …, -3px) &nbsp;·&nbsp; <span class="k">line-height</span> clamp(36px, …, 70px)<br>
+          <span class="k">color</span>&nbsp;&nbsp;<span class="swatch" style="background:#9b83a0"></span>#9b83a0 (light subtitle) / <span class="swatch" style="background:#a08ba8"></span>#a08ba8 (dark) &nbsp;·&nbsp; or #ff9ce3 as a title variant
+        </div>
+      </div>
+
+    </div>
+
+    <!-- dark chip -->
+    <div class="darkchip">
+      <div class="disp-label"><b>Dark mode</b> — the wordmark is the one element forced to stay pink; the h2 subtitle shifts #9b83a0 → #a08ba8</div>
+      <h1 class="wordmark">music nerd</h1>
+      <h2 class="h2legacy" style="margin-top:10px">crowd-sourced directory</h2>
+      <div class="darknote">wordmark <span class="swatch" style="background:#ff9ce3"></span>#ff9ce3 (unchanged) &nbsp;·&nbsp; h2 <span class="swatch" style="background:#a08ba8"></span>#a08ba8</div>
+    </div>
+  </section>
+
+  <p class="foot">
+    Font stack (real, Tailwind default font-sans):<br>
+    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif<br>
+    Semantic tokens: stock shadcn slate · --radius 0.5rem · body font-family: unset (no override) · sources: globals.css, HomePageSplash.tsx, DESIGN.md §Typography
+  </p>
+
+</div>
+</body>
+</html>

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -1,0 +1,113 @@
+<!-- Local review gallery for the design-system preview bundle. Not a @dsCard — exclude from design-sync. -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MusicNerd — Design System Preview Bundle</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: #0f1115;
+    color: #e7e7ea;
+    padding: 32px clamp(16px, 4vw, 56px) 96px;
+  }
+  header { max-width: 1200px; margin: 0 auto 8px; }
+  h1 { font-size: clamp(24px, 4vw, 40px); margin: 0 0 6px; letter-spacing: -0.02em; }
+  h1 .pink { color: #ff9ce3; text-shadow: 0 0 18px rgba(255,156,227,.5); }
+  .sub { color: #9aa0aa; font-size: 15px; margin: 0 0 4px; }
+  .meta { color: #6d7481; font-size: 13px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+  .group { max-width: 1200px; margin: 40px auto 0; }
+  .group > h2 {
+    font-size: 13px; text-transform: uppercase; letter-spacing: .14em;
+    color: #8a90fb; margin: 0 0 14px; padding-bottom: 8px; border-bottom: 1px solid #23262e;
+  }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)); gap: 20px; }
+  .card { background: #161922; border: 1px solid #23262e; border-radius: 14px; overflow: hidden; }
+  .card .cap { padding: 12px 14px 10px; border-bottom: 1px solid #23262e; }
+  .card .name { font-weight: 650; font-size: 15px; }
+  .card .st { color: #8b93a1; font-size: 12.5px; margin-top: 2px; }
+  .card .pth { color: #5f6773; font-size: 11.5px; font-family: ui-monospace, Menlo, monospace; margin-top: 4px; }
+  .card iframe { width: 100%; height: 460px; border: 0; background: #fff; display: block; }
+  .pill { display:inline-block; font-size:11px; color:#0f1115; background:#19ffb8; border-radius:999px; padding:2px 8px; font-weight:700; margin-left:8px; vertical-align:middle;}
+</style>
+</head>
+<body>
+<header>
+  <h1><span class="pink">music nerd</span> — Design System <span class="pill">13 cards</span></h1>
+  <p class="sub">Self-contained preview cards generated from DESIGN.md and real source. This is the payload for Claude Design / design-sync.</p>
+  <p class="meta">Each tile is one <code>@dsCard</code> preview file · all offline / no external requests</p>
+</header>
+
+<section class="group">
+  <h2>Colors</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Brand palette</div><div class="st">maroon · pastyblue · pastypink · jellygreen + the 3 pinks</div><div class="pth">colors/brand-palette.html</div></div><iframe src="colors/brand-palette.html"></iframe></div>
+    <div class="card"><div class="cap"><div class="name">Semantic tokens</div><div class="st">stock shadcn slate · light + dark</div><div class="pth">colors/semantic-tokens.html</div></div><iframe src="colors/semantic-tokens.html"></iframe></div>
+  </div>
+</section>
+
+<section class="group">
+  <h2>Type</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Typography</div><div class="st">system sans (KoHo intended, never loads) · scale + display</div><div class="pth">foundations/typography.html</div></div><iframe src="foundations/typography.html"></iframe></div>
+  </div>
+</section>
+
+<section class="group">
+  <h2>Spacing</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Spacing &amp; radius</div><div class="st">container 1400px/2rem · breakpoints · radius scale</div><div class="pth">foundations/spacing-radius.html</div></div><iframe src="foundations/spacing-radius.html"></iframe></div>
+  </div>
+</section>
+
+<section class="group">
+  <h2>Surfaces</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Glass surfaces</div><div class="st">.glass / .glass-subtle · blur(20px) saturate(180%)</div><div class="pth">foundations/glass.html</div></div><iframe src="foundations/glass.html"></iframe></div>
+    <div class="card"><div class="cap"><div class="name">Gradients</div><div class="st">hero / accent gradients</div><div class="pth">foundations/gradients.html</div></div><iframe src="foundations/gradients.html"></iframe></div>
+  </div>
+</section>
+
+<section class="group">
+  <h2>Motion</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Motion</div><div class="st">fadeSlideIn · accordion · spin · live ping</div><div class="pth">foundations/motion.html</div></div><iframe src="foundations/motion.html"></iframe></div>
+  </div>
+</section>
+
+<section class="group">
+  <h2>Buttons</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Button</div><div class="st">6 cva variants × 4 sizes + legacy pink-btn</div><div class="pth">components/button.html</div></div><iframe src="components/button.html"></iframe></div>
+  </div>
+</section>
+
+<section class="group">
+  <h2>Components</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Badge</div><div class="st">all cva variants</div><div class="pth">components/badge.html</div></div><iframe src="components/badge.html"></iframe></div>
+    <div class="card"><div class="cap"><div class="name">Card</div><div class="st">header/content/footer + glass variant</div><div class="pth">components/card.html</div></div><iframe src="components/card.html"></iframe></div>
+    <div class="card"><div class="cap"><div class="name">Tabs</div><div class="st">list + active/inactive triggers</div><div class="pth">components/tabs.html</div></div><iframe src="components/tabs.html"></iframe></div>
+  </div>
+</section>
+
+<section class="group">
+  <h2>Forms</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Form controls</div><div class="st">input · textarea · select · checkbox · label</div><div class="pth">components/form-controls.html</div></div><iframe src="components/form-controls.html"></iframe></div>
+  </div>
+</section>
+
+<section class="group">
+  <h2>Patterns</h2>
+  <div class="grid">
+    <div class="card"><div class="cap"><div class="name">Artist links grid</div><div class="st">signature neon platform-link icons</div><div class="pth">patterns/artist-links.html</div></div><iframe src="patterns/artist-links.html"></iframe></div>
+  </div>
+</section>
+
+</body>
+</html>

--- a/design-system/patterns/artist-links.html
+++ b/design-system/patterns/artist-links.html
@@ -1,0 +1,192 @@
+<!-- @dsCard group="Patterns" name="Artist links grid" subtitle="signature neon platform-link icons" -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  :root{
+    /* resolved shadcn "slate" tokens from globals.css :root (light) */
+    --background: hsl(0 0% 100%);
+    --muted-foreground: hsl(215.4 16.3% 46.9%);
+    --foreground: hsl(222.2 84% 4.9%);
+    /* brand */
+    --maroon:#422b46;
+    --pink-glow: 239,149,255;   /* #ef95ff — ArtistLinksGrid hover glow */
+    --blue-glow: 0,199,242;     /* #00c7f2 — "listen" (Deezer) variant glow */
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0}
+  body{
+    background:var(--background);
+    color:var(--foreground);
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+    -webkit-font-smoothing:antialiased;
+    padding:32px 28px 40px;
+    line-height:1.5;
+  }
+  .wrap{max-width:860px;margin:0 auto}
+  h1{font-size:22px;font-weight:650;letter-spacing:-.01em;margin:0 0 4px}
+  .lede{font-size:13.5px;color:var(--muted-foreground);margin:0 0 6px;max-width:60ch}
+  .intent{
+    font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
+    font-size:11px;color:var(--muted-foreground);
+    background:#f6f7f9;border:1px solid hsl(214.3 31.8% 91.4%);
+    border-radius:6px;padding:7px 10px;margin:12px 0 26px;
+  }
+  .intent b{color:var(--maroon)}
+
+  section{margin:0 0 30px}
+  .sechead{display:flex;align-items:baseline;gap:10px;margin:0 0 12px;flex-wrap:wrap}
+  .sechead h2{font-size:14px;font-weight:620;margin:0}
+  .sechead .tag{
+    font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
+    font-size:10.5px;color:var(--muted-foreground);
+  }
+
+  /* the surface the glass tiles sit over — artist pages have imagery/gradients behind.
+     A soft candy panel lets the translucent white + neon glow read. */
+  .stage{
+    border-radius:16px;
+    padding:26px 24px;
+    background:
+      radial-gradient(120% 130% at 18% 12%, rgba(42,212,252,.16), transparent 55%),
+      radial-gradient(120% 130% at 85% 90%, rgba(239,149,255,.20), transparent 55%),
+      radial-gradient(120% 130% at 60% 40%, rgba(25,255,184,.10), transparent 60%),
+      #eef1f5;
+    border:1px solid hsl(214.3 31.8% 91.4%);
+  }
+
+  /* ---- ArtistLinksGrid tile: literal resolution of the Tailwind classes ---- */
+  /* w-12 h-12 rounded-full backdrop-blur-sm bg-white/70 border border-white/40
+     shadow-sm  +  group-hover:scale-110 shadow-[0_0_15px_rgba(239,149,255,.45)] bg-white/90 */
+  .grid{display:grid;grid-template-columns:repeat(7,minmax(0,1fr));gap:12px}
+  @media(max-width:560px){.grid{grid-template-columns:repeat(4,minmax(0,1fr))}}
+
+  .chip{display:flex;flex-direction:column;align-items:center;gap:6px;text-decoration:none}
+  .tile{
+    width:48px;height:48px;border-radius:9999px;
+    background:rgba(255,255,255,.70);
+    border:1px solid rgba(255,255,255,.40);
+    -webkit-backdrop-filter:blur(4px);backdrop-filter:blur(4px);
+    box-shadow:0 1px 2px 0 rgba(0,0,0,.05);   /* shadow-sm */
+    display:flex;align-items:center;justify-content:center;overflow:hidden;
+    transition:all .3s ease;
+  }
+  .tile svg{width:28px;height:28px;display:block}          /* w-7 h-7 */
+  .label{font-size:12px;color:var(--muted-foreground);line-height:1.15;text-align:center}
+
+  /* live hover — the real "pink-glow lift" (default / social + web3 platforms) */
+  .chip:hover .tile,
+  .tile.is-hover{
+    transform:scale(1.1);
+    background:rgba(255,255,255,.90);
+    box-shadow:0 0 15px rgba(var(--pink-glow),.45);
+  }
+  /* the "listen" variant swaps the glow to blue */
+  .chip.listen:hover .tile,
+  .tile.is-hover.listen{
+    box-shadow:0 0 15px rgba(var(--blue-glow),.45);
+  }
+
+  .statecap{display:flex;gap:26px;flex-wrap:wrap;margin-top:16px}
+  .statecap div{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:10.5px;color:var(--muted-foreground);max-width:34ch}
+  .statecap b{color:var(--maroon);font-weight:600}
+  .hint{font-size:11.5px;color:var(--muted-foreground);margin:14px 0 0}
+
+  /* frozen specimens row: resting vs accented, side by side & visually distinct */
+  .compare{display:flex;gap:36px;flex-wrap:wrap;align-items:flex-end}
+  .compare .col{display:flex;flex-direction:column;align-items:center;gap:10px}
+  .compare .col .name{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:10.5px;color:var(--muted-foreground);text-align:center}
+
+  /* ---- legacy list-row renderer (ArtistLinks / StaticPlatformLink) ---- */
+  .rows{display:flex;flex-direction:column;gap:2px;max-width:340px}
+  .row{
+    display:grid;grid-template-columns:auto 1fr;align-items:center;   /* .link-item-grid */
+    column-gap:16px;                                                  /* gap-x-4 */
+    border-radius:12px;padding:8px 10px;text-decoration:none;color:#000;
+    transition:background .15s ease;
+  }
+  .row:hover{background:rgba(255,255,255,.6)}
+  .row .ico{width:34px;height:34px;border-radius:8px;overflow:hidden;display:flex;align-items:center;justify-content:center;background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.06)}
+  .row .ico svg{width:22px;height:22px}
+  .row .lab{font-size:14px;color:#000}
+</style>
+</head>
+<body>
+<!-- icon defs: same-document SVG symbols, referenced with <use> (no network, no JS) -->
+<svg width="0" height="0" style="position:absolute" aria-hidden="true" focusable="false">
+  <symbol id="g-sp" viewBox="0 0 24 24"><circle cx="12" cy="12" r="12" fill="#1DB954"/><g fill="none" stroke="#fff" stroke-linecap="round"><path d="M6.5 9.2c3.6-1 7.4-.7 10.6 1.1" stroke-width="1.9"/><path d="M7.1 12.4c2.9-.8 6-.5 8.6 1" stroke-width="1.6"/><path d="M7.7 15.3c2.3-.6 4.7-.4 6.7.8" stroke-width="1.3"/></g></symbol>
+  <symbol id="g-dz" viewBox="0 0 24 24"><g fill="#00c7f2"><rect x="3.5" y="14" width="3" height="5" rx=".6"/><rect x="8" y="11" width="3" height="8" rx=".6"/><rect x="12.5" y="8" width="3" height="11" rx=".6"/><rect x="17" y="5" width="3" height="14" rx=".6"/></g><rect x="17" y="5" width="3" height="2.2" rx=".6" fill="#ef95ff"/></symbol>
+  <symbol id="g-sc" viewBox="0 0 24 24"><g fill="#FF5500"><rect x="4" y="10" width="1.7" height="7" rx=".8"/><rect x="7" y="8" width="1.7" height="9" rx=".8"/><rect x="10" y="6.5" width="1.7" height="10.5" rx=".8"/><rect x="13" y="9" width="1.7" height="8" rx=".8"/></g><path d="M15 8.5a5 5 0 0 1 5 5 3.5 3.5 0 0 1-3.5 3.5H15z" fill="#FF7A33"/></symbol>
+  <symbol id="g-ig" viewBox="0 0 24 24"><defs><linearGradient id="igg" x1="0" y1="1" x2="1" y2="0"><stop offset="0" stop-color="#feda75"/><stop offset=".5" stop-color="#ef95ff"/><stop offset="1" stop-color="#7c3aed"/></linearGradient></defs><rect x="2.5" y="2.5" width="19" height="19" rx="5.5" fill="url(#igg)"/><circle cx="12" cy="12" r="4.4" fill="none" stroke="#fff" stroke-width="1.8"/><circle cx="17.2" cy="6.8" r="1.25" fill="#fff"/></symbol>
+  <symbol id="g-x" viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="20" rx="5" fill="#0f0f0f"/><path d="M7 6.5l4.1 5.2L7.2 17.5h1.7l3-3.9 3 3.9H19l-4.4-5.6L18.6 6.5h-1.7l-2.7 3.5-2.7-3.5z" fill="#fff"/></symbol>
+  <symbol id="g-yt" viewBox="0 0 24 24"><rect x="1.5" y="5" width="21" height="14" rx="4.5" fill="#FF0000"/><path d="M10 8.7l5.2 3.3L10 15.3z" fill="#fff"/></symbol>
+  <symbol id="g-bc" viewBox="0 0 24 24"><rect x="2.5" y="2.5" width="19" height="19" rx="4" fill="#1DA0C3"/><path d="M8 8.5h9l-3 7H5z" fill="#fff"/></symbol>
+</svg>
+<div class="wrap">
+  <h1>Artist links grid</h1>
+  <p class="lede">The signature MusicNerd platform-link renderer: circular frosted-glass tiles that lift and glow on hover — the "pink-glow lift" gesture. Two renderers coexist in the app; the glass grid is the newer, signature one.</p>
+  <p class="intent"><b>Reality note:</b> labels are declared <code>font-family:"KoHo"</code> in globals.css, but the webfont never loads — so text renders in the system sans stack, shown here. Glow uses <code>#ef95ff</code> <code>rgba(239,149,255,.45)</code>, not the <code>#ff9ce3</code> title glow (two pink hexes coexist).</p>
+
+  <!-- SPECIMEN 1 — the live grid -->
+  <section>
+    <div class="sechead">
+      <h2>ArtistLinksGrid — live tiles (hover me)</h2>
+      <span class="tag">grid-cols-7 · gap-3 · w-12 h-12 rounded-full</span>
+    </div>
+    <div class="stage">
+      <div class="grid">
+        <a class="chip" href="#" onclick="return false"><span class="tile"><svg><use href="#g-sp"/></svg></span><span class="label">Spotify</span></a>
+        <a class="chip listen" href="#" onclick="return false"><span class="tile"><svg><use href="#g-dz"/></svg></span><span class="label">Deezer</span></a>
+        <a class="chip" href="#" onclick="return false"><span class="tile"><svg><use href="#g-sc"/></svg></span><span class="label">SoundCloud</span></a>
+        <a class="chip" href="#" onclick="return false"><span class="tile"><svg><use href="#g-ig"/></svg></span><span class="label">Instagram</span></a>
+        <a class="chip" href="#" onclick="return false"><span class="tile"><svg><use href="#g-x"/></svg></span><span class="label">X</span></a>
+        <a class="chip" href="#" onclick="return false"><span class="tile"><svg><use href="#g-yt"/></svg></span><span class="label">YouTube</span></a>
+        <a class="chip" href="#" onclick="return false"><span class="tile"><svg><use href="#g-bc"/></svg></span><span class="label">Bandcamp</span></a>
+      </div>
+      <p class="hint">Hover any tile — <code style="font-family:ui-monospace,monospace">transition:all .3s</code> → <code style="font-family:ui-monospace,monospace">scale(1.1)</code> + colored glow. Social &amp; web3 = pink glow; the "listen" tile (Deezer) swaps to blue.</p>
+    </div>
+  </section>
+
+  <!-- SPECIMEN 2 — frozen states, guaranteed distinct -->
+  <section>
+    <div class="sechead">
+      <h2>Resting → accented (frozen)</h2>
+      <span class="tag">the two visual states side by side</span>
+    </div>
+    <div class="stage">
+      <div class="compare">
+        <div class="col">
+          <span class="tile"><svg><use href="#g-sc"/></svg></span>
+          <span class="name">resting<br>bg rgba(255,255,255,.70)<br>shadow-sm · scale 1.0</span>
+        </div>
+        <div class="col">
+          <span class="tile is-hover"><svg><use href="#g-ig"/></svg></span>
+          <span class="name">accented — social/web3<br>bg .90 · scale 1.10<br>glow rgba(239,149,255,.45)</span>
+        </div>
+        <div class="col">
+          <span class="tile is-hover listen"><svg><use href="#g-sp"/></svg></span>
+          <span class="name">accented — "listen"<br>bg .90 · scale 1.10<br>glow rgba(0,199,242,.45)</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- SPECIMEN 3 — the coexisting legacy renderer -->
+  <section>
+    <div class="sechead">
+      <h2>ArtistLinks — legacy list rows</h2>
+      <span class="tag">.link-item-grid · .corners-rounded · StaticPlatformLink</span>
+    </div>
+    <div class="stage" style="background:#f2f4f7">
+      <div class="rows">
+        <a class="row" href="#" onclick="return false"><span class="ico"><svg><use href="#g-sp"/></svg></span><span class="lab">Listen on Spotify</span></a>
+        <a class="row" href="#" onclick="return false"><span class="ico"><svg><use href="#g-ig"/></svg></span><span class="lab">Follow on Instagram</span></a>
+        <a class="row" href="#" onclick="return false"><span class="ico"><svg><use href="#g-yt"/></svg></span><span class="lab">Watch on YouTube</span></a>
+      </div>
+      <p class="hint">The older renderer draws links as full-width rows (icon + descriptor) rather than glass tiles — no glow, softer <code style="font-family:ui-monospace,monospace">:hover</code> background wash. Documented as a known duplication (DESIGN.md §Two artist-link renderers).</p>
+    </div>
+  </section>
+</div>
+</body>
+</html>

--- a/src/__tests__/ArtistPage.test.tsx
+++ b/src/__tests__/ArtistPage.test.tsx
@@ -39,7 +39,9 @@ jest.mock('@/app/_components/EditModeContext', () => ({
 jest.mock('@/app/_components/EditModeToggle', () => function EditModeToggle() { return <button data-testid="edit-mode-toggle">Edit</button>; });
 jest.mock('@/app/_components/AutoRefresh', () => function AutoRefresh() { return null; });
 jest.mock('@/app/artist/[id]/_components/BlurbSection', () => function BlurbSection() { return <div data-testid="blurb-section" />; });
-jest.mock('@/app/artist/[id]/_components/AddArtistData', () => function AddArtistData() { return <div data-testid="add-artist-data" />; });
+jest.mock('@/app/artist/[id]/_components/AddArtistData', () => function AddArtistData({ directEdit = false, autoApprove = false }: { directEdit?: boolean, autoApprove?: boolean }) {
+    return <div data-testid="add-artist-data" data-direct-edit={String(directEdit)} data-auto-approve={String(autoApprove)} />;
+});
 jest.mock('@/app/artist/[id]/_components/HeroSection', () => function HeroSection({ artistName }: { artistName: string }) { return <div data-testid="hero-section"><img alt={artistName} src="test.jpg" /></div>; });
 jest.mock('@/app/artist/[id]/_components/FunFacts', () => function FunFacts() { return <div data-testid="fun-facts" />; });
 jest.mock('@/app/artist/[id]/_components/GrapevineIframe', () => function GrapevineIframe() { return <div data-testid="grapevine-iframe" />; });
@@ -161,6 +163,59 @@ describe('ArtistProfile page', () => {
             (getUserById as jest.Mock).mockResolvedValue({ id: 'user-uuid', isAdmin: true, isWhiteListed: true });
             await renderArtistPage();
             expect(screen.getByTestId('edit-mode-toggle')).toBeInTheDocument();
+        });
+
+        it('routes admin link additions through the auto-approved UGC flow', async () => {
+            const { getUserById } = await import('@/server/utils/queries/userQueries');
+            const { getClaimByArtistId } = await import('@/server/utils/queries/dashboardQueries');
+            (getUserById as jest.Mock).mockResolvedValue({ id: 'user-uuid', isAdmin: true, isWhiteListed: true });
+            (getClaimByArtistId as jest.Mock).mockResolvedValue(null);
+
+            await renderArtistPage();
+
+            expect(screen.getAllByTestId('add-artist-data')).toHaveLength(2);
+            screen.getAllByTestId('add-artist-data').forEach((component) => {
+                expect(component).toHaveAttribute('data-direct-edit', 'false');
+                expect(component).toHaveAttribute('data-auto-approve', 'true');
+            });
+        });
+
+        it('preserves direct link editing for an approved claimed artist', async () => {
+            const { getUserById } = await import('@/server/utils/queries/userQueries');
+            const { getClaimByArtistId } = await import('@/server/utils/queries/dashboardQueries');
+            (getUserById as jest.Mock).mockResolvedValue({ id: 'user-uuid', isAdmin: false, isWhiteListed: false });
+            (getClaimByArtistId as jest.Mock).mockResolvedValue({
+                id: 'claim-uuid',
+                artistId: 'artist-uuid',
+                userId: 'user-uuid',
+                status: 'approved',
+            });
+
+            await renderArtistPage();
+
+            expect(screen.getAllByTestId('add-artist-data')).toHaveLength(2);
+            screen.getAllByTestId('add-artist-data').forEach((component) => {
+                expect(component).toHaveAttribute('data-direct-edit', 'true');
+            });
+        });
+
+        it('preserves direct link editing when the approved claimant is also an admin', async () => {
+            const { getUserById } = await import('@/server/utils/queries/userQueries');
+            const { getClaimByArtistId } = await import('@/server/utils/queries/dashboardQueries');
+            (getUserById as jest.Mock).mockResolvedValue({ id: 'user-uuid', isAdmin: true, isWhiteListed: true });
+            (getClaimByArtistId as jest.Mock).mockResolvedValue({
+                id: 'claim-uuid',
+                artistId: 'artist-uuid',
+                userId: 'user-uuid',
+                status: 'approved',
+            });
+
+            await renderArtistPage();
+
+            expect(screen.getAllByTestId('add-artist-data')).toHaveLength(2);
+            screen.getAllByTestId('add-artist-data').forEach((component) => {
+                expect(component).toHaveAttribute('data-direct-edit', 'true');
+            });
         });
 
         it('renders the VaultSection on the profile', async () => {

--- a/src/__tests__/components/AddArtistData.test.tsx
+++ b/src/__tests__/components/AddArtistData.test.tsx
@@ -74,7 +74,7 @@ describe('AddArtistData "+" trigger', () => {
     expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
   });
 
-  it('uses "Save Link" submit label for direct-edit (owner / admin)', () => {
+  it('uses "Save Link" submit label for a claim owner using direct edit', () => {
     (useSession as jest.Mock).mockReturnValue({ data: { user: { id: 'u1' } }, status: 'authenticated' });
 
     render(<AddArtistData {...baseProps} directEdit />);
@@ -82,6 +82,17 @@ describe('AddArtistData "+" trigger', () => {
 
     expect(screen.getByRole('heading', { name: /Add a link for Test Artist/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Save Link' })).toBeInTheDocument();
+  });
+
+  it('uses immediate-addition copy for an auto-approved contribution', () => {
+    (useSession as jest.Mock).mockReturnValue({ data: { user: { id: 'u1' } }, status: 'authenticated' });
+
+    render(<AddArtistData {...baseProps} autoApprove />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('heading', { name: /Add a link for Test Artist/i })).toBeInTheDocument();
+    expect(screen.getByText(/added immediately and recorded as your contribution/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add Link' })).toBeInTheDocument();
   });
 
   it('shows the friendly LINK_NOT_SUPPORTED error when a URL matches no platform', async () => {

--- a/src/app/artist/[id]/_components/AddArtistData.tsx
+++ b/src/app/artist/[id]/_components/AddArtistData.tsx
@@ -34,7 +34,7 @@ import { Plus } from "lucide-react";
 import Link from "next/link";
 import { LINK_NOT_SUPPORTED, LINK_TWITTER_INVALID, TIPS_BUTTON_LABEL } from "@/lib/linkSubmissionMessages";
 
-export default function AddArtistData({ artist, spotifyImg, availableLinks, isOpenOnLoad = false, label, directEdit = false }: { artist: Artist, spotifyImg: string, availableLinks: UrlMap[], isOpenOnLoad: boolean, label?: string, directEdit?: boolean }) {
+export default function AddArtistData({ artist, spotifyImg, availableLinks, isOpenOnLoad = false, label, directEdit = false, autoApprove = false }: { artist: Artist, spotifyImg: string, availableLinks: UrlMap[], isOpenOnLoad: boolean, label?: string, directEdit?: boolean, autoApprove?: boolean }) {
     const { data: session, status } = useSession();
     const [isModalOpen, setIsModalOpen] = useState(isOpenOnLoad);
     const [isLoading, setIsLoading] = useState(false);
@@ -237,13 +237,15 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
                     )}
                     <DialogHeader className="space-y-1">
                         <DialogTitle className="text-black dark:text-white text-lg font-bold">
-                            {directEdit
+                            {directEdit || autoApprove
                                 ? `Add a link for ${artist.name}`
                                 : `Suggest a link for ${artist.name}`}
                         </DialogTitle>
                         {!directEdit && (
                             <DialogDescription className="text-xs text-muted-foreground">
-                                An admin will review it before it&apos;s added.
+                                {autoApprove
+                                    ? "This link will be added immediately and recorded as your contribution."
+                                    : "An admin will review it before it’s added."}
                             </DialogDescription>
                         )}
                     </DialogHeader>
@@ -291,7 +293,7 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
                                     {isLoading ? (
                                         <img className="max-h-6" src="/spinner.svg" alt="submitting" />
                                     ) : (
-                                        <span>{directEdit ? "Save Link" : "Submit"}</span>
+                                        <span>{directEdit ? "Save Link" : autoApprove ? "Add Link" : "Submit"}</span>
                                     )}
                                 </Button>
                                 {addArtistResp && addArtistResp.status === "success" ? (

--- a/src/app/artist/[id]/page.tsx
+++ b/src/app/artist/[id]/page.tsx
@@ -95,6 +95,10 @@ export default async function ArtistProfile({ params }: ArtistProfileProps) {
     const isClaimedByUser = isClaimed && !!session && existingClaim.userId === session.user.id;
     const isPendingByUser = isPending && !!session && existingClaim.userId === session.user.id;
     const canEdit = isClaimedByUser || isAdmin;
+    // Claim owners keep direct editing, including owners who are also admins.
+    // Other admin/whitelisted additions use auto-approved UGC so they appear in the feed.
+    const directEditLinks = isClaimedByUser;
+    const autoApproveLinkSubmissions = isAdmin || !!dbUser?.isWhiteListed;
 
     const pendingSources = canEdit ? pendingSourcesRaw : [];
 
@@ -162,7 +166,8 @@ export default async function ArtistProfile({ params }: ArtistProfileProps) {
                             spotifyImg={platformImage ?? ""}
                             availableLinks={urlMapList}
                             isOpenOnLoad={false}
-                            directEdit={canEdit}
+                            directEdit={directEditLinks}
+                            autoApprove={autoApproveLinkSubmissions}
                         />
                     </div>
                     <ArtistLinksGrid isMonetized={false} artist={artist} availableLinks={urlMapList} canEdit={canEdit} />
@@ -177,7 +182,8 @@ export default async function ArtistProfile({ params }: ArtistProfileProps) {
                             spotifyImg={platformImage ?? ""}
                             availableLinks={urlMapList}
                             isOpenOnLoad={false}
-                            directEdit={canEdit}
+                            directEdit={directEditLinks}
+                            autoApprove={autoApproveLinkSubmissions}
                         />
                     </div>
                     <ArtistLinksGrid isMonetized={true} artist={artist} availableLinks={urlMapList} canEdit={canEdit} />


### PR DESCRIPTION
## Summary

Promotes the current `staging` release to `main`.

### Included changes

- Adds `DESIGN.md` and the standalone design-system preview gallery from #1132.
- Adds the Claude Design component-sync bundle from #1133; app runtime source is unaffected by this portion.
- Restores homepage activity-feed entries when an admin adds UGC from an artist page, while preserving direct editing for claimed artists, from #1135.

## Verification

- Full test suite: 109 suites passed; 1,086 tests passed; 6 skipped.
- Typecheck, lint, and production build passed on #1135.
- The admin UGC feed fix was manually verified on `staging`.

## Follow-up

- #1134 tracks whether claimed-artist edits should also create activity-feed contributions.
