### PR TITLE
Release: manifesto hero homepage

### DIFF
--- a/src/app/_components/ActivityFeed.tsx
+++ b/src/app/_components/ActivityFeed.tsx
@@ -13,8 +13,17 @@ type ActivityEvent = {
     createdAt: string;
 };
 
-const MAX_ITEMS = 15;
+// The manifesto hero owns the top of the homepage, so the feed is condensed to a short tail
+// beneath it (was 15).
+const MAX_ITEMS = 4;
 const POLL_INTERVAL = 30_000;
+
+// Rows fade down the list: with n rows, row i sits at 1 - (i / (n-1)) * 0.55.
+// 4 rows → 1, 0.82, 0.63, 0.45.
+function rowOpacity(i: number, n: number): number {
+    if (n <= 1) return 1;
+    return Math.round((1 - (i / (n - 1)) * 0.55) * 100) / 100;
+}
 
 // --- Helpers --------------------------------------------------------------
 
@@ -71,7 +80,6 @@ const feedThemeVars = `
         --feed-body-hover: #3d2f42;
         --feed-artist: #ff9ce3;
         --feed-timestamp: #9b8a9f;
-        --feed-timestamp-dim: rgba(155, 138, 159, 0.4);
         --feed-live-dot: #059669;
         --feed-live-label: rgba(90, 77, 94, 0.6);
         --feed-bar-agent: #0891b2;
@@ -101,7 +109,6 @@ const feedThemeVars = `
         --feed-body-hover: #e0d8e2;
         --feed-artist: #ff9ce3;
         --feed-timestamp: rgba(198, 191, 199, 0.35);
-        --feed-timestamp-dim: rgba(198, 191, 199, 0.25);
         --feed-live-dot: #19ffb8;
         --feed-live-label: rgba(198, 191, 199, 0.6);
         --feed-bar-agent: #2ad4fc;
@@ -144,14 +151,16 @@ export default function ActivityFeed() {
         }
     }, []);
 
-    // Initial load
+    // Initial load. The endpoint returns more than we show, so cap here as well as on the poll
+    // path — the row count drives the opacity ramp, so an uncapped list also flattens the fade.
     useEffect(() => {
         fetchEvents().then((data) => {
             if (!data?.length) return;
-            setEvents(data);
-            latestTimestamp.current = data[0].createdAt;
+            const rows = data.slice(0, MAX_ITEMS);
+            setEvents(rows);
+            latestTimestamp.current = rows[0].createdAt;
             // Clear initial load flag after stagger animation completes
-            setTimeout(() => setInitialLoad(false), data.length * 30 + 300);
+            setTimeout(() => setInitialLoad(false), rows.length * 30 + 300);
         });
     }, [fetchEvents]);
 
@@ -194,8 +203,8 @@ export default function ActivityFeed() {
     return (
         <>
             <style dangerouslySetInnerHTML={{ __html: feedThemeVars }} />
-            <div className="feed-root flex flex-col items-center w-full px-2 sm:px-4">
-                <div className="w-full max-w-xl">
+            <div className="feed-root flex flex-col items-center w-full px-2 pt-[26px]">
+                <div className="w-full">
                     {/* Live indicator */}
                     <div className="flex items-center justify-center gap-2 mb-3">
                         <span className="relative flex h-2 w-2">
@@ -222,7 +231,7 @@ export default function ActivityFeed() {
                                 const key = eventKey(e);
                                 const isFresh = freshIds.has(key);
                                 const shouldAnimate = initialLoad || isFresh;
-                                const opacity = Math.max(0.45, 1 - i * 0.035);
+                                const opacity = rowOpacity(i, events.length);
 
                                 return (
                                     <li
@@ -237,7 +246,7 @@ export default function ActivityFeed() {
                                     >
                                         <Link
                                             href={`/artist/${e.artistId}`}
-                                            className="group flex items-center gap-2.5 py-[5px] px-2 sm:px-3 rounded-md
+                                            className="group flex items-center gap-3 py-[7px] px-2 rounded-md
                                                        transition-all duration-300 hover:bg-[var(--feed-hover-bg)]"
                                             style={{
                                                 backgroundColor: isFresh
@@ -246,21 +255,22 @@ export default function ActivityFeed() {
                                             }}
                                         >
                                             <span
-                                                className="flex-shrink-0 w-[3px] h-4 rounded-full transition-all duration-300
+                                                className="flex-shrink-0 w-[3px] h-[18px] rounded-[2px] transition-all duration-300
                                                            group-hover:h-5"
                                                 style={{ backgroundColor: typeBarVar[e.type] }}
                                             />
-                                            <span className="feed-text text-[13px] truncate flex-1
+                                            <span className="feed-text text-sm truncate flex-1
                                                              transition-colors duration-300"
                                                 style={{ color: 'var(--feed-body)' }}
                                             >
                                                 {eventText(e)}
                                             </span>
-                                            <span className="feed-ts text-[11px] flex-shrink-0 tabular-nums transition-colors duration-300"
+                                            <span className="feed-ts text-xs flex-shrink-0 tabular-nums transition-colors duration-300"
                                                 style={{
                                                     color: isFresh
                                                         ? 'var(--feed-fresh-time)'
-                                                        : 'var(--feed-timestamp-dim)',
+                                                        : 'var(--feed-timestamp)',
+                                                    opacity: isFresh ? 1 : 0.7,
                                                 }}
                                             >
                                                 {relativeTime(e.createdAt)}

--- a/src/app/_components/HomePageSplash.tsx
+++ b/src/app/_components/HomePageSplash.tsx
@@ -2,16 +2,40 @@
 
 import ActivityFeed from "./ActivityFeed";
 
+// The manifesto is the hero. Each line is a maroon statement with one keyword lifted into the
+// identity pink (#ff9ce3) — the same pink as the wordmark, applied inline exactly as the app
+// already does for it. globals.css defends `[style*="#ff9ce3"]` in dark mode, so the keywords and
+// the wordmark stay pink in both themes while `text-maroon` flips to white around them.
+// The highlighted keyword can fall anywhere in the line, not just at the end.
+const MANIFESTO: ReadonlyArray<{ before: string; keyword: string; after?: string }> = [
+    { before: "we listen with ", keyword: "intent" },
+    { before: "we follow with ", keyword: "curiosity" },
+    { before: "we ", keyword: "care", after: " when artists let us into the work" },
+    { before: "we act with ", keyword: "purpose" },
+];
+
+const LINE_STYLE = {
+    fontSize: 'clamp(24px, 4.2vw, 33px)',
+    lineHeight: '1.38',
+} as const;
+
+const KEYWORD_STYLE = {
+    color: '#ff9ce3',
+    textShadow: '0 0 24px rgba(255, 156, 227, 0.35)',
+} as const;
+
 export default function HomePage() {
     return (
         <div className="px-6 sm:px-8 pt-0 pb-4 flex flex-col items-center w-full !flex-grow-0">
-            <div className="w-full max-w-2xl">
-                {/* Title */}
-                <div className="flex justify-center w-full px-4 -mt-2 mb-5">
+            <div className="w-full max-w-[800px]">
+                {/* Wordmark — trimmed from the production hero scale (was 32→84px) so the
+                    manifesto leads, but kept large enough to still read as the wordmark.
+                    Sits tight under the nav; the manifesto owns the vertical space below. */}
+                <div className="flex justify-center w-full px-4 -mt-2">
                     <h1 className="lowercase font-bold"
                         style={{
-                            fontSize: 'clamp(32px, calc(32px + (84 - 32) * ((100vw - 360px) / (1440 - 360))), 84px)',
-                            letterSpacing: 'clamp(-1px, calc(-1px + (-4 - -1) * ((100vw - 360px) / (1440 - 360))), -4px)',
+                            fontSize: 'clamp(32px, calc(32px + (68 - 32) * ((100vw - 360px) / (1440 - 360))), 68px)',
+                            letterSpacing: 'clamp(-1px, calc(-1px + (-3 - -1) * ((100vw - 360px) / (1440 - 360))), -3px)',
                             lineHeight: '1',
                             color: '#ff9ce3',
                             textShadow: '0 0 40px rgba(255, 156, 227, 0.25)',
@@ -19,6 +43,21 @@ export default function HomePage() {
                     >
                         music nerd
                     </h1>
+                </div>
+
+                {/* Manifesto */}
+                <div className="text-center lowercase pt-[26px] px-4 pb-1">
+                    {MANIFESTO.map(({ before, keyword, after }) => (
+                        <p key={keyword} className="font-bold text-maroon" style={LINE_STYLE}>
+                            {before}
+                            <span style={KEYWORD_STYLE}>{keyword}</span>
+                            {after}
+                        </p>
+                    ))}
+
+                    <p className="font-semibold text-maroon text-[17px] mt-[18px]">
+                        buy the music. follow the process. help make what comes next possible.
+                    </p>
                 </div>
 
                 <ActivityFeed />

--- a/src/app/_components/__tests__/ActivityFeed.test.tsx
+++ b/src/app/_components/__tests__/ActivityFeed.test.tsx
@@ -113,4 +113,77 @@ describe("ActivityFeed", () => {
 
         expect(screen.getByText("Waiting for activity...")).toBeTruthy();
     });
+
+    // The endpoint returns more rows than the homepage shows. The cap used to be applied only on
+    // the poll path, so the first paint rendered everything the API returned — and because the row
+    // count drives the opacity ramp, an uncapped list also flattened the fade.
+    it("caps the initial load to 4 rows even when the endpoint returns more", async () => {
+        const many = Array.from({ length: 9 }, (_, i) => ({
+            type: "artist_added",
+            artistId: `id${i}`,
+            artistName: `Artist ${i}`,
+            platform: null,
+            createdAt: `2026-03-27T12:0${i}:00Z`,
+        }));
+
+        (global.fetch as jest.Mock).mockResolvedValueOnce({
+            ok: true,
+            json: async () => many,
+        });
+
+        await act(async () => { render(<ActivityFeed />); });
+
+        await waitFor(() => {
+            expect(screen.getByText("Artist 0")).toBeTruthy();
+        });
+
+        const rows = screen.getByRole("list").querySelectorAll("li");
+        expect(rows.length).toBe(4);
+
+        // The newest four are kept, in order; the rest are dropped.
+        expect(screen.getByText("Artist 3")).toBeTruthy();
+        expect(screen.queryByText("Artist 4")).toBeNull();
+        expect(screen.queryByText("Artist 8")).toBeNull();
+    });
+
+    it("fades rows down the list: 1, 0.82, 0.63, 0.45", async () => {
+        const four = Array.from({ length: 4 }, (_, i) => ({
+            type: "artist_added",
+            artistId: `id${i}`,
+            artistName: `Artist ${i}`,
+            platform: null,
+            createdAt: `2026-03-27T12:0${i}:00Z`,
+        }));
+
+        (global.fetch as jest.Mock).mockResolvedValueOnce({
+            ok: true,
+            json: async () => four,
+        });
+
+        await act(async () => { render(<ActivityFeed />); });
+
+        await waitFor(() => {
+            expect(screen.getByText("Artist 0")).toBeTruthy();
+        });
+
+        const rows = [...screen.getByRole("list").querySelectorAll("li")];
+        expect(rows.map((r) => r.style.opacity)).toEqual(["1", "0.82", "0.63", "0.45"]);
+    });
+
+    it("does not divide by zero when only one row is returned", async () => {
+        (global.fetch as jest.Mock).mockResolvedValueOnce({
+            ok: true,
+            json: async () => [mockEvents[0]],
+        });
+
+        await act(async () => { render(<ActivityFeed />); });
+
+        await waitFor(() => {
+            expect(screen.getByText("Mogwai")).toBeTruthy();
+        });
+
+        const rows = [...screen.getByRole("list").querySelectorAll("li")];
+        expect(rows).toHaveLength(1);
+        expect(rows[0].style.opacity).toBe("1");
+    });
 });

--- a/src/app/_components/nav/components/SearchBar.tsx
+++ b/src/app/_components/nav/components/SearchBar.tsx
@@ -198,6 +198,12 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
     return (
         <div className="relative w-full max-w-[400px]">
             <div className="relative">
+                {/* The Input primitive ships with no border, height or focus ring (a documented
+                    deviation from stock shadcn), so the search pill's chrome is added here at the
+                    call site rather than by forking the primitive.
+                    Focus tints the hairline to the brand pink (the handoff's spec) AND draws a
+                    ring: the tint alone is a 1px 50%-opacity change, which is too weak to serve as
+                    the sole focus indicator once the browser's default outline is suppressed. */}
                 <Input
                     type="text"
                     placeholder="Search for an artist..."
@@ -205,7 +211,10 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
                     onChange={handleInputChange}
                     onBlur={handleBlur}
                     onFocus={handleFocus}
-                    className="pl-10"
+                    className="pl-10 h-[46px] rounded-full border border-input
+                               transition-colors duration-300
+                               focus:outline-none focus:border-pastypink/50
+                               focus:ring-2 focus:ring-pastypink/40"
                 />
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
             </div>


### PR DESCRIPTION
Promotes `staging` → `main`. One change since the last release (#1136).

## feat: manifesto hero homepage (#1138)

Implements the Manifesto Hero Homepage design handoff. The manifesto becomes the hero statement, the wordmark yields scale to it, and the activity feed condenses to a short tail underneath.

**4 files, all presentational + one bug fix:**

| file | what |
|---|---|
| `HomePageSplash.tsx` | wordmark rescaled `clamp(32→84px)` → `clamp(32→68px)`; new four-line manifesto with pink keyword highlights + CTA |
| `ActivityFeed.tsx` | condensed 15 → 4 rows, opacity ramp `1 / 0.82 / 0.63 / 0.45`, `3×18px` bars |
| `ActivityFeed.test.tsx` | 3 new regression tests |
| `SearchBar.tsx` | search pill hairline + focus ring — **global nav, affects every page** |

### Bug fixed along the way
`ActivityFeed`'s `MAX_ITEMS` cap was only applied on the **poll** path — the initial page load rendered every event the endpoint returned (15, not the intended cap). Pre-existing. Now capped on both paths, with a regression test that fails without the fix.

### Accessibility
The search pill's focus affordance was a 1px 50%-opacity border tint with the browser outline suppressed — too weak to be the sole indicator (WCAG 2.4.7). It now keeps the design's pink border tint **and** draws a 2px `pastypink/40` ring.

### Notable
- The feed keeps **all three event types** (agent ID-mappings, approved UGC links, artist additions). The design mock only showed "added to the directory" rows; implementing it literally would have deleted the other copy, which is the majority of rows in practice.
- **Dark mode is supported** despite the spec giving light values only — reusing the app's existing `text-maroon` and `[style*="#ff9ce3"]` rules, so no new entries were added to the `!important` override wall.

### Verification
Driven in a real browser: light, dark, and 375px mobile (no horizontal overflow). Row count, opacity ramp, bar geometry, and focus styles asserted against computed styles. CI green on #1138 — build, test, claude-review, Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)