### PR TITLE
Release: factual artist bio voice + grounding + XSS fix (#1140)

### DIFF
--- a/docs/broken-bios-review.md
+++ b/docs/broken-bios-review.md
@@ -1,0 +1,49 @@
+# Broken bios that are NOT confirmed AI-generated — needs manual review
+
+**Created:** 2026-07-24 (during the bio voice redesign)
+**Status:** untouched — left for manual review, deliberately NOT regenerated.
+
+## Context
+
+The bio voice redesign regenerated **only the 36 bios with a verifiable AI signature**
+(citation links, leaked prompt scaffolding, or an AI refusal). See
+`docs/superpowers/specs/2026-07-24-bio-voice-design.md`.
+
+The rows below are also broken, but they carry **no AI signature** — their origin can't
+be confirmed as AI-generated, so they were intentionally left alone to avoid overwriting
+anything a human may have entered. None of these were modified by the backfill.
+
+## Broken / empty bios (origin unknown — do NOT bulk-regenerate)
+
+| Artist | Artist ID | Current bio | Spotify? | Suggested action |
+|---|---|---|---|---|
+| Juicy BAE | `4c2f82af-7fec-45e8-92e3-438b31d69b15` | *(empty)* | yes | Regenerate individually, or leave for the artist to fill. |
+| Robert Farrugia | `169922f5-4933-475a-8ce1-0470bf6d430b` | `a` | yes | Regenerate individually. |
+| hkmori | `d5685bb2-85ce-48b1-947f-f6e5538a72df` | `i` | yes | Regenerate individually. |
+| punisher.eth | `3ce844f0-0926-401b-9de5-65aaed5a71a0` | `h` | no | No Spotify ID — grounding may find little; review by hand. |
+
+These single-character / empty bios read like placeholders or data-entry artifacts, not
+prose. Each has a real page, so a one-off regeneration through the new pipeline would
+likely produce a proper bio — but that decision is deferred (it steps past "only the 36").
+
+## Bad entity — not a music artist (deletion candidate)
+
+| Artist | Artist ID | Current bio | Note |
+|---|---|---|---|
+| Horizon Forbidden West | `8efbf3a9-5cb9-49f8-9625-739dfcefae1d` | *"The last character of the name 'Horizon Forbidden West' is 't'."* | This is a **video game**, not an artist. The bio is an AI scaffolding leak. Regenerating would just write a factual bio about the game. Should be **deleted** from `artists`, not bio-fixed. |
+
+## Signature-less AI-cringe bios (broader class — cannot be safely auto-detected)
+
+Some bios are AI-generated in the *old* cringe voice but have no citation/scaffolding
+signature, so they're indistinguishable from human-written bios by content matching.
+Example:
+
+- **Yoonha Verse** (`d1f0f5d6-b9d9-4107-b28e-01cdd80c9aaa`) — *"…the sound of deep-web
+  discovery… twenty-seven transmissions dropped into the void… The 'Verse' in the name
+  isn't a gimmick—it's a promise of a complete, self-contained reality."*
+
+There are likely many of these across the ~253 total bios. They cannot be bulk-detected
+without risking overwriting genuinely artist-written bios (the same reason we did not
+regenerate all 253). They will be corrected organically as artists are regenerated on
+demand under the new voice. A durable fix would be a **bio provenance flag**
+(AI-generated vs artist-edited) — already listed as a follow-up in the spec.

--- a/docs/superpowers/plans/2026-07-24-bio-voice-redesign.md
+++ b/docs/superpowers/plans/2026-07-24-bio-voice-redesign.md
@@ -1,0 +1,446 @@
+# Bio Voice Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the AI-cringe artist bio voice with a clean, factual, name-anchored one; ground every bio in verifiable sources; close a stored-XSS hole in bio rendering; and regenerate the content-verified broken AI bios (39 total — 36 via the backfill script, 3 during eval).
+
+**Architecture:** All generation logic lives in `generateArtistBio()` in `src/server/utils/queries/artistBioQuery.ts` — we rewrite its system prompt, add authoritative-identifier anchors to the prompt, and enable Google Search grounding unconditionally. Bio rendering markdown is extracted to a testable, HTML-escaping helper. A one-off `tsx` script regenerates the broken bios through the new pipeline.
+
+**Tech Stack:** Next.js 15, TypeScript, Drizzle ORM, `@google/genai` (Gemini 2.5 Pro + Google Search grounding), Jest 30, `npx tsx` for the script.
+
+## Global Constraints
+
+- Package manager: `npm` (Node 20). Match existing file indentation.
+- Server env vars come from `@/env`, never `process.env` (except the standalone script, which follows the existing `scripts/refetch-vault-sources.ts` pattern of `dotenv` + `process.env.SUPABASE_DB_CONNECTION`).
+- Bio voice: ONE paragraph, ≤ ~100 words, factual encyclopedia register. Never invent facts. Pronouns: she/he/they only when clearly documented in sources; else they/them; never guess a gendered pronoun.
+- Foundation already committed (`b986b53c`): `sanitizeBioText` exists in `src/lib/bioText.ts` and is applied in `useArtistBio` and in `generateArtistBio` before persisting. Keep it.
+- Backfill (Task 3) writes to the **production** DB and is gated on explicit user go-ahead at run time. It must select ONLY bios carrying an AI signature.
+
+---
+
+### Task 1: XSS-harden bio markdown rendering
+
+`renderMarkdown` in `BlurbSection.tsx` injects regex output via `dangerouslySetInnerHTML` without escaping HTML — a stored-XSS vector (artist editors PUT arbitrary bio text). Extract it to a testable helper that escapes HTML before applying bold/italic.
+
+**Files:**
+- Create: `src/lib/renderBioMarkdown.ts`
+- Create: `src/lib/__tests__/renderBioMarkdown.test.ts`
+- Modify: `src/app/artist/[id]/_components/BlurbSection.tsx` (remove local `renderMarkdown`, import the helper)
+
+**Interfaces:**
+- Produces: `renderBioMarkdown(text: string | null | undefined): string` — returns HTML-safe string containing only `<strong>`/`<em>` tags.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/__tests__/renderBioMarkdown.test.ts
+import { renderBioMarkdown } from "../renderBioMarkdown";
+
+describe("renderBioMarkdown", () => {
+  it("escapes HTML so script injection cannot execute", () => {
+    const result = renderBioMarkdown('<script>alert(1)</script>');
+    expect(result).not.toContain("<script>");
+    expect(result).toContain("&lt;script&gt;");
+  });
+
+  it("escapes an img onerror payload", () => {
+    const result = renderBioMarkdown('<img src=x onerror="alert(1)">');
+    expect(result).not.toContain("<img");
+    expect(result).toContain("&lt;img");
+  });
+
+  it("still converts **bold** and *italic*", () => {
+    expect(renderBioMarkdown("The **WILD LIFE** EP is her *sharpest* work."))
+      .toBe("The <strong>WILD LIFE</strong> EP is her <em>sharpest</em> work.");
+  });
+
+  it("escapes ampersands without breaking text", () => {
+    expect(renderBioMarkdown("Simon & Garfunkel")).toBe("Simon &amp; Garfunkel");
+  });
+
+  it("handles null/undefined/empty", () => {
+    expect(renderBioMarkdown(null)).toBe("");
+    expect(renderBioMarkdown(undefined)).toBe("");
+    expect(renderBioMarkdown("")).toBe("");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `npx jest src/lib/__tests__/renderBioMarkdown.test.ts`
+Expected: FAIL — `Cannot find module '../renderBioMarkdown'`.
+
+- [ ] **Step 3: Implement the helper**
+
+```typescript
+// src/lib/renderBioMarkdown.ts
+/**
+ * Convert the limited markdown a bio may contain (**bold**, *italic*) to HTML,
+ * escaping all other HTML first so bio text can never inject live markup.
+ * Bios are AI-generated or artist-edited and rendered via dangerouslySetInnerHTML,
+ * so escaping before formatting is what makes that render safe.
+ */
+export function renderBioMarkdown(text: string | null | undefined): string {
+  if (!text) return "";
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>");
+}
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `npx jest src/lib/__tests__/renderBioMarkdown.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Wire the helper into BlurbSection**
+
+In `src/app/artist/[id]/_components/BlurbSection.tsx`:
+- Delete the local `renderMarkdown` function (the `/** Convert **bold** … */` block and its body).
+- Add near the top imports: `import { renderBioMarkdown } from "@/lib/renderBioMarkdown";`
+- Change the render site from `dangerouslySetInnerHTML={{ __html: renderMarkdown(aiBlurb) }}` to `dangerouslySetInnerHTML={{ __html: renderBioMarkdown(aiBlurb) }}`.
+
+- [ ] **Step 6: Verify nothing else broke**
+
+Run: `npx jest src/__tests__/components/BlurbSection.test.tsx src/lib/__tests__/renderBioMarkdown.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/renderBioMarkdown.ts src/lib/__tests__/renderBioMarkdown.test.ts "src/app/artist/[id]/_components/BlurbSection.tsx"
+git commit -m "fix: escape HTML in bio markdown rendering (close stored-XSS in BlurbSection)"
+```
+
+---
+
+### Task 2: Factual voice prompt + identifier anchors + always-on grounding
+
+Rewrite the bio generation prompt to the factual voice, feed the DB's existing MusicBrainz/Wikipedia/Discogs/Wikidata identifiers into the prompt as authoritative anchors (fixing the Wikipedia-slug bug), and enable Google Search grounding for every bio.
+
+**Files:**
+- Modify: `src/server/utils/queries/artistBioQuery.ts`
+- Modify: `src/server/utils/queries/__tests__/artistBioQuery.test.ts`
+
+**Interfaces:**
+- Consumes: `getArtistById()` returns an artist row with `wikipedia`, `musicbrainz`, `discogs`, `wikidata` (all `string | null`).
+- Produces: no signature change — `generateArtistBio(artistId)` still returns `NextResponse`.
+
+- [ ] **Step 1: Write failing tests for anchors + always-on grounding**
+
+Add these tests to `src/server/utils/queries/__tests__/artistBioQuery.test.ts` (inside the `describe("artistBioQuery", …)` block, after the existing generateArtistBio tests):
+
+```typescript
+it("enables Google Search grounding even with no vault sources", async () => {
+  const { generateArtistBio, getArtistById } = await setup();
+  getArtistById.mockResolvedValue({
+    id: "artist-1", name: "Test Artist", spotify: "sp1",
+    instagram: null, x: null, soundcloud: null, youtube: null,
+    youtubechannel: null, wikipedia: null, musicbrainz: null,
+    discogs: null, wikidata: null,
+  });
+
+  await generateArtistBio("artist-1");
+
+  const callArgs = (mockGenerateContent as jest.Mock).mock.calls[0][0];
+  expect(callArgs.config.tools).toEqual([{ googleSearch: {} }]);
+});
+
+it("passes identifier anchors as full URLs in the prompt", async () => {
+  const { generateArtistBio, getArtistById } = await setup();
+  getArtistById.mockResolvedValue({
+    id: "artist-1", name: "Test Artist", spotify: null,
+    instagram: null, x: null, soundcloud: null, youtube: null,
+    youtubechannel: null,
+    wikipedia: "Test_Artist",
+    musicbrainz: "abc-123",
+    discogs: "999",
+    wikidata: "Q42",
+  });
+
+  await generateArtistBio("artist-1");
+
+  const contents = (mockGenerateContent as jest.Mock).mock.calls[0][0].contents;
+  expect(contents).toContain("https://en.wikipedia.org/wiki/Test_Artist");
+  expect(contents).toContain("https://musicbrainz.org/artist/abc-123");
+  expect(contents).toContain("https://www.discogs.com/artist/999");
+  expect(contents).toContain("https://www.wikidata.org/wiki/Q42");
+  // regression: never the bare slug
+  expect(contents).not.toMatch(/Wikipedia:\s*Test_Artist(?!\/|")/);
+});
+```
+
+- [ ] **Step 2: Run the new tests, verify they fail**
+
+Run: `npx jest src/server/utils/queries/__tests__/artistBioQuery.test.ts -t "grounding even with no vault"`
+Expected: FAIL — `tools` is `undefined` (grounding currently only fires with vault sources).
+
+Run: `npx jest src/server/utils/queries/__tests__/artistBioQuery.test.ts -t "identifier anchors as full URLs"`
+Expected: FAIL — anchor URLs absent (only `wikipedia` slug is passed today).
+
+- [ ] **Step 3: Add anchors to `promptParts`**
+
+In `artistBioQuery.ts`, replace the current Wikipedia line:
+
+```typescript
+  if (artist.wikipedia) promptParts.push(`Wikipedia: ${artist.wikipedia}`);
+```
+
+with the anchor block (labeled so grounding disambiguates the exact artist):
+
+```typescript
+  // Authoritative identity anchors — the IDs/links MusicNerd already stores.
+  // Formatted as real URLs so Google Search grounding confirms exactly which
+  // artist this is and reads the right sources.
+  const anchors: string[] = [];
+  if (artist.wikipedia) anchors.push(`Wikipedia: https://en.wikipedia.org/wiki/${artist.wikipedia}`);
+  if (artist.musicbrainz) anchors.push(`MusicBrainz: https://musicbrainz.org/artist/${artist.musicbrainz}`);
+  if (artist.discogs) anchors.push(`Discogs: https://www.discogs.com/artist/${artist.discogs}`);
+  if (artist.wikidata) anchors.push(`Wikidata: https://www.wikidata.org/wiki/${artist.wikidata}`);
+  if (anchors.length > 0) {
+    promptParts.push(
+      `Authoritative identity anchors (use these to confirm exactly which artist this is; prefer facts they support):\n${anchors.join("\n")}`
+    );
+  }
+```
+
+- [ ] **Step 4: Rewrite the voice prompt**
+
+Replace the entire `musicNerdVoice` template literal (the `const musicNerdVoice = \`…\`;` block) with:
+
+```typescript
+    const musicNerdVoice = `You write clean, factual artist bios for MusicNerd, a music discovery platform. Think well-written encyclopedia entry, not a review or press release. Tell the reader who this artist is and what they're known for — accurately, without embellishment.
+
+Write ONE paragraph, up to ~100 words. Shorter is better than padded: if verified facts are thin, write two or three honest sentences.
+
+Structure:
+- Open with the name and what they are: "[Name] is a [role/genre] from [place]." This is the one place a plain identity sentence is correct — lead with it.
+- Follow with the most significant verifiable facts: bands, notable releases, collaborators, milestones, dates, well-documented activity outside music.
+- Stop when the facts run out. No closing "significance" flourish.
+
+Rules:
+- Third person. Anchor on the name; use pronouns sparingly.
+- Pronouns: use she/he/they only as the artist is clearly documented to use them in your sources. If unclear, use they/them. Never guess a gendered pronoun.
+- State only what your sources support. Never invent bands, releases, collaborators, places, or dates. If unsure a fact is true, leave it out.
+- No editorializing. Don't tell the reader why the work "matters," don't say the artist is "showing" or "proving" something, and don't append interpretive clauses to facts. Report the fact and stop.
+- Banned hype words: "emerging", "rising", "boundary-pushing", "eclectic", "versatile", "undeniable", "sonic", "soundscape", "artist to watch", "cross-genre draw", "carving out". Banned resume-speak: "leveraged", "spearheaded", "secured", "integrated".
+- Plain, direct sentences.`;
+```
+
+Leave the `hasVaultContext` branch that appends the "PRIMARY source" paragraph as-is — it composes on top of the new voice.
+
+- [ ] **Step 5: Enable grounding unconditionally**
+
+Replace:
+
+```typescript
+    // Use Google Search grounding when vault sources exist (allows Gemini to visit those URLs)
+    const useGrounding = hasVaultContext && vaultUrls.length > 0;
+```
+
+with:
+
+```typescript
+    // Grounding is always on: bios must be factual, and grounding lets Gemini
+    // read the anchor URLs and the open web. Bios are cached, so the added
+    // latency is not on any user's critical path.
+    const useGrounding = true;
+```
+
+(The existing `...(useGrounding ? { tools: [{ googleSearch: {} }] } : {})` spread stays; `vaultUrls` is still used for vault context, so leave it.)
+
+- [ ] **Step 6: Update the existing grounding test that assumed conditional grounding**
+
+The existing test `"uses Google Search grounding when vault sources exist"` still passes (grounding is present with vault sources). If any existing test asserts grounding is ABSENT without vault sources, or asserts the old `Wikipedia: <slug>` format, update it to the new behavior. Run the whole file to find breakage:
+
+Run: `npx jest src/server/utils/queries/__tests__/artistBioQuery.test.ts`
+Expected: all PASS after adjusting any such assertion. Fix failing assertions to match always-on grounding / URL anchors — do not weaken the two new tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/server/utils/queries/artistBioQuery.ts src/server/utils/queries/__tests__/artistBioQuery.test.ts
+git commit -m "feat: factual bio voice, identifier anchors, always-on grounding"
+```
+
+---
+
+### Task 3: Backfill script for the broken AI bios (gated) — 39 total
+
+One-off `tsx` script. Default run is a **dry run** that prints the matched set; `--write` regenerates each through the new pipeline. Selection matches ONLY AI-signature bios, so artist-written bios are never touched.
+
+**Files:**
+- Create: `scripts/backfill-ai-bios.ts`
+
+**Interfaces:**
+- Consumes: `regenerateArtistBio(artistId: string): Promise<string | null>` from `@/server/utils/queries/artistBioQuery` (regenerates + persists via the new pipeline).
+
+- [ ] **Step 1: Write the script**
+
+```typescript
+// scripts/backfill-ai-bios.ts
+/**
+ * One-off: regenerate the broken AI-generated bios through the new factual pipeline.
+ * Selects ONLY bios carrying an AI signature (citation links, leaked prompt
+ * scaffolding, or an AI refusal) — never touches artist-written bios.
+ *
+ * Dry run (prints matches, writes nothing):  npx tsx scripts/backfill-ai-bios.ts
+ * Live run (regenerates + writes to prod):    npx tsx scripts/backfill-ai-bios.ts --write
+ */
+import dotenv from "dotenv";
+dotenv.config({ path: ".env.local" });
+
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { sql } from "drizzle-orm";
+import * as schema from "@/server/db/schema";
+import { regenerateArtistBio } from "@/server/utils/queries/artistBioQuery";
+
+const WRITE = process.argv.includes("--write");
+
+const client = postgres(process.env.SUPABASE_DB_CONNECTION!, { prepare: false });
+const db = drizzle(client, { schema });
+
+// AI-signature predicate — must exactly mirror the spec's Part C selection.
+// `%](http%` (a bare LIKE) catches markdown citation links without regex
+// paren-balancing hazards inside the template literal.
+const AI_SIGNATURE = sql`(
+  bio LIKE '%](http%'
+  OR bio ILIKE '%utm_source=openai%'
+  OR bio ILIKE '%Identify the artist%'
+  OR bio ILIKE '%Retrieve verified information%'
+  OR bio ILIKE '%Checklist:%'
+  OR bio ILIKE '%I could not find%'
+  OR bio ILIKE '%I''m sorry%'
+)`;
+
+async function main() {
+  const rows = await db.execute<{ id: string; name: string; bio: string }>(
+    sql`SELECT id, name, bio FROM artists WHERE ${AI_SIGNATURE} ORDER BY name`
+  );
+  const artists = rows as unknown as { id: string; name: string; bio: string }[];
+
+  console.log(`Matched ${artists.length} AI-signature bios:\n`);
+  for (const a of artists) {
+    console.log(`  • ${a.name} (${a.id})`);
+  }
+
+  if (!WRITE) {
+    console.log(`\nDRY RUN — nothing written. Re-run with --write to regenerate.`);
+    await client.end();
+    return;
+  }
+
+  console.log(`\n--write set. Regenerating ${artists.length} bios through the new pipeline…\n`);
+  let ok = 0, failed = 0;
+  for (const a of artists) {
+    try {
+      const bio = await regenerateArtistBio(a.id);
+      if (bio) {
+        ok++;
+        console.log(`  [ok]   ${a.name}\n         → ${bio.slice(0, 120)}…`);
+      } else {
+        failed++;
+        console.log(`  [FAIL] ${a.name} — generator returned null`);
+      }
+    } catch (e) {
+      failed++;
+      console.log(`  [FAIL] ${a.name} — ${(e as Error).message}`);
+    }
+    // small delay to respect Gemini rate limits
+    await new Promise((r) => setTimeout(r, 1500));
+  }
+  console.log(`\nDone. ${ok} regenerated, ${failed} failed.`);
+  await client.end();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });
+```
+
+- [ ] **Step 2: Dry-run to verify selection (no writes)**
+
+Run: `npx tsx scripts/backfill-ai-bios.ts`
+Expected: prints the matched set (~36–39, incl. KIRINJI, SLIGHT, Yani Mo, Bea Maher, and "I'm sorry…" AI refusals like 1000 Eyes, chauncy, Playd3ad) and `DRY RUN — nothing written.` The verified true count is 39 broken AI bios; 3 (Alissa, Cocteau Twins, Daegho) were already fixed during Task 4 eval, so the dry run shows the remainder.
+If the count is wildly off (e.g. hundreds), STOP — the predicate is over-matching; do not run `--write`.
+
+- [ ] **Step 3: Commit the script (dry-run verified; live run deferred)**
+
+```bash
+git add scripts/backfill-ai-bios.ts
+git commit -m "chore: gated backfill script to regenerate broken AI bios"
+```
+
+- [ ] **Step 4: Live backfill — GATED on explicit user go-ahead**
+
+Do NOT run this without the user confirming. When confirmed:
+
+Run: `npx tsx scripts/backfill-ai-bios.ts --write`
+Expected: each artist logged `[ok]` with a new factual bio preview; final tally. Re-run the dry run afterward — expected `Matched 0` (all signatures cleared).
+
+---
+
+### Task 4: Manual eval + full verification
+
+Unit tests prove wiring, not writing quality. Eyeball real output, then run the full pre-push suite.
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Regenerate three representative bios locally and read them**
+
+Ensure the plain-HTTP dev server is running (`npx next dev -p 3000`). For each artist, force regeneration and read the result:
+
+```bash
+# Alissa White-Gluz (rich, gendered)
+curl -s "http://localhost:3000/api/artistBio/4ed03b76-f614-4d86-8514-7d92e8f6ce8c?regenerate=true" | python3 -c "import sys,json;print(json.load(sys.stdin)['bio'])"
+# Cocteau Twins (band)
+curl -s "http://localhost:3000/api/artistBio/48254a49-1bd6-41cf-8066-263fb40778f8?regenerate=true" | python3 -c "import sys,json;print(json.load(sys.stdin)['bio'])"
+# Daegho (thin data)
+curl -s "http://localhost:3000/api/artistBio/1539da14-f1dc-4fd5-a50a-b9b70818faf3?regenerate=true" | python3 -c "import sys,json;print(json.load(sys.stdin)['bio'])"
+```
+
+Confirm each: name-anchored opener, factual, no significance-tags, correct/neutral pronouns, no invented facts, ≤ ~100 words, thin-data one stays short. If a rule is violated, iterate on the Task 2 prompt wording and re-run.
+
+- [ ] **Step 2: Run the full pre-push suite**
+
+Run: `npm run type-check && npm run lint && npm run test`
+Expected: type-check clean, lint clean (pre-existing warnings only), all tests pass.
+
+Run: `npm run build`
+Expected: build succeeds (requires `.env.local`).
+
+- [ ] **Step 3: Final commit if any eval-driven prompt tweaks were made**
+
+```bash
+git add src/server/utils/queries/artistBioQuery.ts
+git commit -m "chore: bio prompt tuning from manual eval"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Voice rewrite → Task 2 Step 4 ✅
+- Length ceiling / thin-data → Task 2 Step 4 (in prompt) + Task 4 Step 1 eval ✅
+- Pronoun rule → Task 2 Step 4 (in prompt) ✅
+- Grounding always on → Task 2 Steps 1,5 ✅
+- Identifier anchors + Wikipedia-URL bug fix → Task 2 Steps 1,3 ✅
+- Keep `sanitizeBioText` → foundation commit `b986b53c` (Global Constraints) ✅
+- XSS hardening → Task 1 ✅
+- Backfill (AI-signature only, gated; 39 total = 36 via script + 3 in eval) → Task 3 ✅
+- Provenance follow-up / no bulk-regen → honored by Task 3 selection predicate ✅
+
+**Placeholder scan:** No TBD/TODO; all code blocks complete; prompt text included verbatim.
+
+**Type consistency:** `renderBioMarkdown(string|null|undefined): string`, `regenerateArtistBio(string): Promise<string|null>`, `generateArtistBio` unchanged. Anchor field names (`wikipedia`, `musicbrainz`, `discogs`, `wikidata`) match `schema.ts`.
+
+## Follow-ups (out of scope — flagged, not built)
+
+- Dedicated MusicBrainz/Discogs/Wikipedia API fetch for structured facts.
+- Bio provenance flag (AI vs artist-edited) so future cleanups don't content-sniff.
+- Apply the factual voice to `askArtist` Q&A.
+- Backfill the 28 legacy dirty bios' non-AI siblings — N/A (none exist).

--- a/docs/superpowers/specs/2026-07-24-bio-voice-design.md
+++ b/docs/superpowers/specs/2026-07-24-bio-voice-design.md
@@ -1,0 +1,143 @@
+# Artist Bio Voice Redesign
+
+**Date:** 2026-07-24
+**Status:** Approved (design), pending spec review
+**Area:** `src/server/utils/queries/artistBioQuery.ts`, `src/app/artist/[id]/_components/BlurbSection.tsx`, one backfill script
+
+## Problem
+
+AI-generated "Artist Summary" bios read as cringe LLM prose, not bios. The failure modes, from the Alissa White-Gluz example:
+
+1. **Nameless.** The paragraph never states the artist's name; it opens on a bare pronoun ("They've been Arch Enemy's frontperson…"). This is a direct backfire of the current prompt rule *"Never open with '[Name] is a…'"* — the model avoids the name so hard it never introduces the artist, and defaults to "they" for everyone.
+2. **Fact + hollow significance-tag.** Every sentence states a fact and bolts on an empty interpretive clause: "…appear on *Ruling Queen*, **showing their ongoing cross-genre draw**." Not a take — the model narrating that it told you a fact.
+3. **Sloppiness the voice rules missed.** "an advocacy **thread** that **threads** through"; The Agonist mentioned twice.
+4. **No real point of view.** The prompt begs for "obsessive record-store nerd" energy and "a take on why this work matters"; the model produces a chronological credit-dump with filler instead.
+
+Root cause: the current `musicNerdVoice` prompt asks the model to *perform* personality it can't deliver, which produces mannered filler. The user wants the opposite: stop performing, state what is true, cleanly.
+
+Separately, two adjacent issues surfaced during investigation and are folded into this work at the user's request:
+- **39 existing bios** in production are unmistakably AI-generated and broken (verified count; an initial estimate of 34 undercounted "I'm sorry…" AI refusals). 28 carry legacy markdown citations (25 with a literal `utm_source=openai`); the rest are pure prompt-scaffolding leaks with no link (e.g. `"Checklist: (1) Identify the artist…"`) or explicit AI refusals (`"I'm sorry, but I couldn't find much information on the artist with the Spotify ID…"`). None could be artist-written. The backfill script prints the exact matched set on a dry run before any write.
+- **`renderMarkdown` in `BlurbSection.tsx` is a stored-XSS vector**: it applies bold/italic regex and injects the result via `dangerouslySetInnerHTML` **without escaping HTML**, so any `<script>`/`<img onerror>` in a bio executes for every visitor. Artist editors can PUT arbitrary bio text.
+
+### Provenance note (why we do NOT regenerate all bios)
+
+There is **no provenance field** distinguishing AI-written from artist-written bios: `artists.bio` is a lone text column, and `artist_bio_versions` tracks only `bio_text / is_pinned / created_at` — no author or `is_ai` flag. Some of the ~253 existing bios may be artist-authored. Therefore the backfill is **strictly limited to content-verified AI junk** (the 39 above). The AI-signature match *is* the safety mechanism — a human bio will not contain citation markdown or leaked prompt scaffolding. Bulk-regenerating all 253 is explicitly rejected: it would risk clobbering human work.
+
+Adding a provenance flag going forward (mark bios AI vs artist-edited) is a sensible **follow-up** so future backfills never rely on content-sniffing.
+
+## Goals
+
+- Bios read like a clean, factual encyclopedia entry: name-anchored, third person, no editorializing.
+- Facts are verifiable: grounding on by default, anchored to the identifiers MusicNerd already stores.
+- Correct-or-neutral pronouns, never a guessed gendered pronoun.
+- The 39 content-verified broken AI bios regenerated to the new standard (no artist-written bio touched).
+- Close the `dangerouslySetInnerHTML` XSS hole.
+
+## Non-goals (follow-ups)
+
+- Dedicated MusicBrainz / Discogs / Wikipedia **API fetch** for structured facts (higher fidelity, separate project).
+- Regenerating **all** ~253 existing bios (scope is the 39 content-verified AI ones; some of the rest may be artist-written — see Provenance note).
+- Applying the new voice to `askArtist` Q&A (it uses the bio as context; can follow later).
+- Replacing Gemini Google Search grounding with a dedicated search provider (Exa/Tavily/etc. — none currently wired).
+
+## Decisions (locked with user)
+
+| Dimension | Decision |
+|---|---|
+| **Voice** | Lean & factual — encyclopedia entry, not review/press release. No hooks, no significance-tags, no editorializing. |
+| **Length** | One paragraph, **up to ~100 words**. Shorter when facts are thin; never pad to hit a count. |
+| **Pronouns** | Use she/he/they only when the artist is **clearly documented** to use them in sources; fall back to **they/them** when unclear. Never guess a gendered pronoun. |
+| **Fact source** | Google Search grounding **always on** + pass the identifiers the DB already holds (Wikipedia, MusicBrainz, Discogs, Wikidata) as authoritative anchors + platform stats + vault sources. No new external API integrations. |
+| **Dirty bios** | **Regenerate** the 39 content-verified AI bios through the new pipeline (not just strip citations — that would leave the old voice). Never touch bios without an AI signature. |
+
+## Implementation
+
+### Part A — Prompt voice + anchors + grounding (`artistBioQuery.ts`)
+
+**A1. Replace the `musicNerdVoice` system prompt** with the factual voice:
+
+> You write clean, factual artist bios for MusicNerd. Think well-written encyclopedia entry, not a review or press release. Tell the reader who this artist is and what they're known for — accurately, without embellishment.
+>
+> Write ONE paragraph, up to ~100 words. Shorter is better than padded: if verified facts are thin, write two or three honest sentences.
+>
+> Structure:
+> - Open with the name and what they are: "[Name] is a [role/genre] from [place]." This is the one place a plain identity sentence is correct — lead with it.
+> - Follow with the most significant verifiable facts: bands, notable releases, collaborators, milestones, dates, well-documented activity outside music.
+> - Stop when the facts run out. No closing "significance" flourish.
+>
+> Rules:
+> - Third person. Anchor on the name; use pronouns sparingly.
+> - Pronouns: use she/he/they only as the artist is clearly documented to use them in your sources. If unclear, use they/them. Never guess a gendered pronoun.
+> - State only what your sources support. Never invent bands, releases, collaborators, places, or dates. Unsure → leave it out.
+> - No editorializing. Don't tell the reader why the work "matters," don't say the artist is "showing"/"proving" something, don't append interpretive clauses to facts. Report the fact and stop.
+> - Banned hype: "emerging," "rising," "boundary-pushing," "eclectic," "versatile," "undeniable," "sonic," "soundscape," "artist to watch," "cross-genre draw," "carving out." Banned résumé-speak: "leveraged," "spearheaded," "secured," "integrated."
+> - Plain, direct sentences.
+
+The vault-context variant keeps its "primary source" framing but adopts the same factual voice.
+
+**A2. Add authoritative anchors to `promptParts`**, formatted as real URLs, labeled so grounding disambiguates the correct entity:
+- Wikipedia → `https://en.wikipedia.org/wiki/{artist.wikipedia}` — **fixes existing bug**: line 49 currently passes the bare slug (`Wikipedia: Anberlin`), which is useless.
+- MusicBrainz → `https://musicbrainz.org/artist/{artist.musicbrainz}` (stored as MBID; ~54% of catalog)
+- Discogs → `https://www.discogs.com/artist/{artist.discogs}` (stored as numeric id)
+- Wikidata → `https://www.wikidata.org/wiki/{artist.wikidata}`
+
+Group them under a clear label, e.g. `Authoritative identity anchors (use these to confirm exactly which artist this is; prefer facts they support):`.
+
+**A3. Grounding always on.** Change `useGrounding` from `hasVaultContext && vaultUrls.length > 0` to always pass `tools: [{ googleSearch: {} }]`. Latency is covered by the existing 45s race and `maxDuration = 60`; bios are cached, so users don't wait on generation.
+
+**A4. Keep `sanitizeBioText`** (already shipped) on the generated output — safety net for any citation URLs grounding emits.
+
+### Part B — XSS hardening (`BlurbSection.tsx`)
+
+Harden `renderMarkdown` to **escape HTML before** applying the bold/italic regex, so the injected HTML contains only the `<strong>`/`<em>` tags we control:
+
+```
+function renderMarkdown(text: string): string {
+  const escaped = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  return escaped
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>");
+}
+```
+
+Escaping `<`, `>`, `&` is sufficient for element-content context (we are not writing into an attribute). Asterisks are untouched, so `**bold**` / `*italic*` still work. This makes stored-XSS via bio text impossible without adding a dependency.
+
+### Part C — Backfill the broken AI bios (39 total)
+
+One-time script (run locally against prod, after Parts A/B are verified and with explicit user go-ahead):
+- **Selection (AI-signature only):** an artist qualifies if its `bio` matches any of:
+  - `bio ~ '\]\(https?://'` (markdown citation link) — 28 rows
+  - `bio ILIKE '%utm_source=openai%'` — subset of the above
+  - `bio ILIKE '%Identify the artist%'` OR `bio ILIKE '%Retrieve verified information%'` OR `bio ILIKE '%Checklist:%'` (prompt-scaffolding leak)
+  - `bio ILIKE '%I could not find%'` OR `bio ILIKE '%I'm sorry%'` (AI refusal)
+  - Total = 39 (verified). 36 were regenerated by the `--write` run; 3 (Alissa White-Gluz, Cocteau Twins, Daegho) were already regenerated during Task 4 manual eval. The script prints the exact matched set for confirmation before writing anything.
+- For each, call the new `generateArtistBio()` (regenerates in the new voice + grounding, writes back through the existing code path).
+- Cost/impact: ~36 grounded Gemini calls at run time, a few minutes, prod writes. Serial with a small delay to respect rate limits. Log before/after per artist.
+- **Never selects a bio without an AI signature** — no risk to artist-written bios.
+- This is a **prod DB write** — gated on user confirmation at run time, not run silently.
+
+## Testing
+
+Unit tests mock Gemini, so they verify **wiring**, not writing quality:
+- `renderMarkdown` (TDD): `<script>alert(1)</script>` renders escaped; `**bold**`/`*italic*` still produce `<strong>`/`<em>`.
+- `generateArtistBio`: grounding tools present on **every** call (not just with vault sources); anchor URLs (musicbrainz/wikipedia/discogs/wikidata) appear in the prompt when the artist has those ids; Wikipedia is passed as a full URL, not a slug; `sanitizeBioText` still applied to output; thin-data artist still yields a short bio.
+
+**Quality gate is manual eval:** regenerate 3 real artists locally through the new pipeline and eyeball before shipping — Alissa White-Gluz (rich, gendered), Cocteau Twins (band), and a thin-data artist (e.g. Daegho). Confirm: name-anchored, factual, no filler, correct/neutral pronouns, no invented facts.
+
+## Rollout / sequencing
+
+1. Part B (XSS) — independent, ship-safe on its own.
+2. Part A (voice + anchors + grounding) — with unit tests.
+3. Manual eval of 3 regenerated bios; iterate on prompt wording if needed.
+4. Merge to `staging`.
+5. Part C (backfill 36 at run time; 39 total incl. eval) — after A/B verified, with user go-ahead, run against prod.
+
+## Open items
+
+- **Model choice.** Staying on `gemini-2.5-pro`. If factual output still drifts, revisit.
+- **Pronoun accuracy** depends on grounding surfacing clear sources; the they/them fallback bounds the downside.
+- Widening backfill beyond the 39 AI-signature bios is deferred; it requires a provenance flag (below) to stay safe.
+- **Follow-up:** add a bio provenance flag (AI-generated vs artist-edited) so future backfills never rely on content-sniffing.

--- a/scripts/backfill-ai-bios.ts
+++ b/scripts/backfill-ai-bios.ts
@@ -1,0 +1,87 @@
+/**
+ * One-off: regenerate the broken AI-generated bios through the new factual pipeline.
+ * Selects ONLY bios carrying an AI signature (citation links, leaked prompt
+ * scaffolding, or an AI refusal) — never touches artist-written bios.
+ *
+ * Dry run (prints matches, writes nothing):  npx tsx scripts/backfill-ai-bios.ts
+ * Live run (regenerates + writes to prod):    npx tsx scripts/backfill-ai-bios.ts --write
+ */
+import dotenv from "dotenv";
+dotenv.config({ path: ".env.local" });
+
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { sql } from "drizzle-orm";
+import * as schema from "@/server/db/schema";
+
+// NOTE: `regenerateArtistBio` is dynamically imported inside main() *after*
+// dotenv.config() runs. Its import chain pulls in `@/env`, which validates
+// required env vars at module-load time — a static import would evaluate
+// before dotenv populates process.env (ESM imports are hoisted).
+
+const WRITE = process.argv.includes("--write");
+
+const client = postgres(process.env.SUPABASE_DB_CONNECTION!, { prepare: false });
+const db = drizzle(client, { schema });
+
+// AI-signature predicate — must exactly mirror the spec's Part C selection.
+// `%](http%` catches markdown citation links (a bare LIKE, so no regex
+// paren-balancing hazards inside the template literal).
+const AI_SIGNATURE = sql`(
+  bio LIKE '%](http%'
+  OR bio ILIKE '%utm_source=openai%'
+  OR bio ILIKE '%Identify the artist%'
+  OR bio ILIKE '%Retrieve verified information%'
+  OR bio ILIKE '%Checklist:%'
+  OR bio ILIKE '%I could not find%'
+  OR bio ILIKE '%I''m sorry%'
+)`;
+
+async function main() {
+  const rows = await db.execute<{ id: string; name: string; bio: string }>(
+    sql`SELECT id, name, bio FROM artists WHERE ${AI_SIGNATURE} ORDER BY name`
+  );
+  const artists = rows as unknown as { id: string; name: string; bio: string }[];
+
+  console.log(`Matched ${artists.length} AI-signature bios:\n`);
+  for (const a of artists) {
+    console.log(`  • ${a.name} (${a.id})`);
+  }
+
+  if (!WRITE) {
+    console.log(`\nDRY RUN — nothing written. Re-run with --write to regenerate.`);
+    await client.end();
+    return;
+  }
+
+  const { regenerateArtistBio } = await import("@/server/utils/queries/artistBioQuery");
+
+  console.log(`\n--write set. Regenerating ${artists.length} bios through the new pipeline…\n`);
+  let ok = 0, failed = 0;
+  for (const a of artists) {
+    try {
+      const bio = await regenerateArtistBio(a.id);
+      if (bio) {
+        ok++;
+        console.log(`  [ok]   ${a.name}\n         → ${bio.slice(0, 120)}…`);
+      } else {
+        failed++;
+        console.log(`  [FAIL] ${a.name} — generator returned null`);
+      }
+    } catch (e) {
+      failed++;
+      console.log(`  [FAIL] ${a.name} — ${(e as Error).message}`);
+    }
+    // small delay to respect Gemini rate limits
+    await new Promise((r) => setTimeout(r, 1500));
+  }
+  console.log(`\nDone. ${ok} regenerated, ${failed} failed.`);
+  await client.end();
+}
+
+// regenerateArtistBio opens the app's own pooled DB client (@/server/db/drizzle),
+// separate from `client` above; its open pool can keep the process alive after
+// client.end(). Exit explicitly so the script always terminates.
+main()
+  .then(() => process.exit(0))
+  .catch((e) => { console.error(e); process.exit(1); });

--- a/src/__tests__/useArtistBio.test.ts
+++ b/src/__tests__/useArtistBio.test.ts
@@ -31,6 +31,34 @@ describe('useArtistBio', () => {
     expect(fetch).toHaveBeenCalledWith('/api/artistBio/test-artist-id');
   });
 
+  it('should strip markdown citations from a server-provided bio', () => {
+    const dirty =
+      'Her new single dropped in December. ([music.apple.com](https://music.apple.com/us/song/1758574026?utm_source=openai))';
+
+    const { result } = renderHook(() => useArtistBio('test-artist-id', dirty));
+
+    expect(result.current.bio).toBe('Her new single dropped in December.');
+    expect(result.current.loading).toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('should strip markdown citations from a fetched bio', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        bio: 'Out now on Sound.xyz. ([sound.xyz](https://www.sound.xyz/honey?utm_source=openai))',
+      }),
+    });
+
+    const { result } = renderHook(() => useArtistBio('test-artist-id'));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.bio).toBe('Out now on Sound.xyz.');
+  });
+
   it('should use cached bio on subsequent calls', async () => {
     const mockBio = 'Test artist bio';
     (fetch as jest.Mock).mockResolvedValueOnce({

--- a/src/app/artist/[id]/_components/BlurbSection.tsx
+++ b/src/app/artist/[id]/_components/BlurbSection.tsx
@@ -7,19 +7,13 @@ import { useToast } from "@/hooks/use-toast";
 import { useArtistBio } from "@/hooks/useArtistBio";
 import { Check } from "lucide-react";
 import { saveCurrentBio } from "@/app/actions/dashboardActions";
+import { renderBioMarkdown } from "@/lib/renderBioMarkdown";
 import BioVersionHistory from "./BioVersionHistory";
 
 interface BlurbSectionProps {
   artistName: string;
   artistId: string;
   initialBio?: string | null;
-}
-
-/** Convert **bold** and *italic* markdown to HTML. Input is AI-generated so only these two patterns occur. */
-function renderMarkdown(text: string): string {
-  return text
-    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-    .replace(/\*(.+?)\*/g, "<em>$1</em>");
 }
 
 export default function BlurbSection({ artistName, artistId, initialBio }: BlurbSectionProps) {
@@ -224,7 +218,7 @@ export default function BlurbSection({ artistName, artistId, initialBio }: Blurb
       {aiBlurb ? (
         <p
           className="text-black dark:text-white text-sm leading-relaxed"
-          dangerouslySetInnerHTML={{ __html: renderMarkdown(aiBlurb) }}
+          dangerouslySetInnerHTML={{ __html: renderBioMarkdown(aiBlurb) }}
         />
       ) : (
         <p className="text-gray-500 dark:text-gray-400 italic">No summary is available</p>

--- a/src/hooks/useArtistBio.ts
+++ b/src/hooks/useArtistBio.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { sanitizeBioText } from '@/lib/bioText';
 
 interface BioCache {
   [artistId: string]: {
@@ -55,11 +56,13 @@ export function useArtistBio(artistId: string, initialBio?: string | null): UseA
   // Check for initial value from server or cache
   const getInitialBio = (): string | undefined => {
     // Use != null to allow empty strings (only skip if undefined/null)
-    if (initialBio != null) return initialBio;
+    // Sanitize here so stored legacy bios (markdown citations from the pre-Gemini
+    // generator) never reach the page or the edit textarea.
+    if (initialBio != null) return sanitizeBioText(initialBio);
     const cache = getCache();
     const cached = cache[artistId];
     if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-      return cached.bio;
+      return sanitizeBioText(cached.bio);
     }
     return undefined;
   };
@@ -76,7 +79,7 @@ export function useArtistBio(artistId: string, initialBio?: string | null): UseA
     const cache = getCache();
     const cached = cache[artistId];
     if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-      setBio(cached.bio);
+      setBio(sanitizeBioText(cached.bio));
       return;
     }
 
@@ -90,7 +93,7 @@ export function useArtistBio(artistId: string, initialBio?: string | null): UseA
       }
       
       const data = await response.json();
-      const bioText = data.bio as string;
+      const bioText = sanitizeBioText(data.bio as string);
       
       // Cache the result
       const newCache = { ...cache };
@@ -121,7 +124,7 @@ export function useArtistBio(artistId: string, initialBio?: string | null): UseA
     const cache = getCache();
     const cached = cache[artistId];
     if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-      setBio(cached.bio);
+      setBio(sanitizeBioText(cached.bio));
       setLoading(false);
       return;
     }

--- a/src/lib/__tests__/bioText.test.ts
+++ b/src/lib/__tests__/bioText.test.ts
@@ -1,0 +1,72 @@
+import { sanitizeBioText } from "../bioText";
+
+describe("sanitizeBioText", () => {
+  // The exact string from the reported artist page (legacy OpenAI-era bio).
+  const REPORTED_BIO =
+    "Pete Rango's most recent public updates include HONEY featuring Betty Dawl on Sound.xyz and the December 2, 2024 single OH-KAY! listed on Apple Music. ([sound.xyz](https://www.sound.xyz/p3t3rango/honey-ft-betty-dawl?utm_source=openai)) To become a fan, expect a genre-blending vibe—lo-fi electronic with funk and neo-soul textures—backed by collaborations like KIKI with Cherele and Breakdown with Elle Symone, plus the WILD LIFE EP. ([music.apple.com](https://music.apple.com/us/song/1758574026?utm_source=openai)) Keep up with new releases and projects at peterango.com. ([peterango.com](https://peterango.com/?utm_source=openai))";
+
+  it("removes parenthesized markdown citations from the reported bio", () => {
+    const result = sanitizeBioText(REPORTED_BIO);
+
+    expect(result).not.toMatch(/\]\(/); // no markdown link syntax
+    expect(result).not.toMatch(/https?:\/\//); // no raw URLs
+    expect(result).not.toMatch(/utm_source/);
+  });
+
+  it("leaves no empty parens or doubled spaces where citations were removed", () => {
+    const result = sanitizeBioText(REPORTED_BIO);
+
+    expect(result).not.toMatch(/\(\s*\)/);
+    expect(result).not.toMatch(/ {2,}/);
+    expect(result).not.toMatch(/\s+\./); // no space stranded before a period
+  });
+
+  it("keeps the prose around a removed citation intact", () => {
+    const result = sanitizeBioText(REPORTED_BIO);
+
+    expect(result).toContain("listed on Apple Music. To become a fan");
+    expect(result).toContain("plus the WILD LIFE EP. Keep up with new releases");
+    expect(result.endsWith("projects at peterango.com.")).toBe(true);
+  });
+
+  it("keeps the label when a markdown link is part of the sentence", () => {
+    const result = sanitizeBioText("She released [Blue Weekend](https://example.com/blue) in 2021.");
+
+    expect(result).toBe("She released Blue Weekend in 2021.");
+  });
+
+  it("strips bare URLs left in the prose", () => {
+    const result = sanitizeBioText("Hear it at https://example.com/track today.");
+
+    expect(result).toBe("Hear it at today.");
+  });
+
+  it("keeps sentence punctuation when a bare URL ends a sentence", () => {
+    const result = sanitizeBioText("Visit https://example.com. Great artist.");
+
+    expect(result).toBe("Visit. Great artist.");
+  });
+
+  it("leaves a clean bio untouched, including legitimate parentheses", () => {
+    const clean =
+      "Her debut EP (recorded across three Brooklyn basements) landed in 2019, and the follow-up sharpened every edge.";
+
+    expect(sanitizeBioText(clean)).toBe(clean);
+  });
+
+  it("preserves markdown emphasis so the renderer can still bold and italicize", () => {
+    const withEmphasis = "The **WILD LIFE** EP is her *sharpest* work yet.";
+
+    expect(sanitizeBioText(withEmphasis)).toBe(withEmphasis);
+  });
+
+  it("handles empty, null, and undefined input", () => {
+    expect(sanitizeBioText("")).toBe("");
+    expect(sanitizeBioText(null)).toBe("");
+    expect(sanitizeBioText(undefined)).toBe("");
+  });
+
+  it("returns a citation-only bio as an empty string rather than stray punctuation", () => {
+    expect(sanitizeBioText("([sound.xyz](https://www.sound.xyz/x?utm_source=openai))")).toBe("");
+  });
+});

--- a/src/lib/__tests__/renderBioMarkdown.test.ts
+++ b/src/lib/__tests__/renderBioMarkdown.test.ts
@@ -1,0 +1,30 @@
+import { renderBioMarkdown } from "../renderBioMarkdown";
+
+describe("renderBioMarkdown", () => {
+  it("escapes HTML so script injection cannot execute", () => {
+    const result = renderBioMarkdown('<script>alert(1)</script>');
+    expect(result).not.toContain("<script>");
+    expect(result).toContain("&lt;script&gt;");
+  });
+
+  it("escapes an img onerror payload", () => {
+    const result = renderBioMarkdown('<img src=x onerror="alert(1)">');
+    expect(result).not.toContain("<img");
+    expect(result).toContain("&lt;img");
+  });
+
+  it("still converts **bold** and *italic*", () => {
+    expect(renderBioMarkdown("The **WILD LIFE** EP is her *sharpest* work."))
+      .toBe("The <strong>WILD LIFE</strong> EP is her <em>sharpest</em> work.");
+  });
+
+  it("escapes ampersands without breaking text", () => {
+    expect(renderBioMarkdown("Simon & Garfunkel")).toBe("Simon &amp; Garfunkel");
+  });
+
+  it("handles null/undefined/empty", () => {
+    expect(renderBioMarkdown(null)).toBe("");
+    expect(renderBioMarkdown(undefined)).toBe("");
+    expect(renderBioMarkdown("")).toBe("");
+  });
+});

--- a/src/lib/bioText.ts
+++ b/src/lib/bioText.ts
@@ -1,0 +1,34 @@
+/**
+ * Strip link artifacts out of an artist bio.
+ *
+ * Bios are prose — the prompt in `generateArtistBio` explicitly says "No social links
+ * in the bio text" — but models still emit inline citations, and rows written by the
+ * pre-Gemini (OpenAI web-search) generator are full of them:
+ *   "...listed on Apple Music. ([music.apple.com](https://music.apple.com/...?utm_source=openai))"
+ * `BlurbSection` only renders bold/italic, so those citations show up as raw markdown.
+ *
+ * Applied both when a bio is generated and when one is read, so stored legacy rows
+ * render clean without a backfill.
+ */
+export function sanitizeBioText(text: string | null | undefined): string {
+  if (!text) return "";
+
+  return (
+    text
+      // Parenthesized citations — "( [label](url) )" — drop the whole group.
+      .replace(/\(\s*\[[^\]]*\]\([^)]*\)\s*\)/g, "")
+      // Inline markdown links carrying real sentence content — keep just the label.
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+      // Bare URLs left in the prose. The final char class excludes trailing
+      // sentence punctuation so "Visit https://example.com. Next" keeps its period.
+      .replace(/https?:\/\/[^\s)\]]*[^\s)\].,;:!?]/g, "")
+      // Parens/brackets emptied out by the removals above.
+      .replace(/\(\s*\)/g, "")
+      .replace(/\[\s*\]/g, "")
+      // Whitespace left behind: collapse runs, pull punctuation back onto the word.
+      .replace(/[ \t]{2,}/g, " ")
+      .replace(/[ \t]+([.,;:!?])/g, "$1")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim()
+  );
+}

--- a/src/lib/renderBioMarkdown.ts
+++ b/src/lib/renderBioMarkdown.ts
@@ -1,0 +1,15 @@
+/**
+ * Convert the limited markdown a bio may contain (**bold**, *italic*) to HTML,
+ * escaping all other HTML first so bio text can never inject live markup.
+ * Bios are AI-generated or artist-edited and rendered via dangerouslySetInnerHTML,
+ * so escaping before formatting is what makes that render safe.
+ */
+export function renderBioMarkdown(text: string | null | undefined): string {
+  if (!text) return "";
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>");
+}

--- a/src/server/utils/queries/__tests__/artistBioQuery.test.ts
+++ b/src/server/utils/queries/__tests__/artistBioQuery.test.ts
@@ -135,6 +135,34 @@ describe("artistBioQuery", () => {
     expect(setMock).toHaveBeenCalledWith({ bio: "mocked gemini response" });
   });
 
+  it("strips markdown citations before saving and returning the bio", async () => {
+    const { generateArtistBio, getArtistById, db } = await setup();
+
+    mockGenerateContent.mockResolvedValue({
+      text: "Her debut landed in 2019. ([example.com](https://example.com/a?utm_source=openai))",
+    });
+
+    getArtistById.mockResolvedValue({
+      id: "artist-1",
+      name: "Test Artist",
+      spotify: null,
+      instagram: null,
+      x: null,
+      soundcloud: null,
+      youtube: null,
+      youtubechannel: null,
+      wikipedia: null,
+    });
+
+    const result = await generateArtistBio("artist-1");
+    const data = await result.json();
+
+    expect(data.bio).toBe("Her debut landed in 2019.");
+
+    const setMock = db.update.mock.results[0].value.set;
+    expect(setMock).toHaveBeenCalledWith({ bio: "Her debut landed in 2019." });
+  });
+
   it("returns error on Gemini failure", async () => {
     const { generateArtistBio, getArtistById } = await setup();
 
@@ -233,6 +261,61 @@ describe("artistBioQuery", () => {
     const callArgs = (mockGenerateContent as jest.Mock).mock.calls[0][0];
     expect(callArgs.config.tools).toEqual([{ googleSearch: {} }]);
     expect(callArgs.contents).toContain("VAULT CONTEXT");
+  });
+
+  it("enables Google Search grounding even with no vault sources", async () => {
+    const { generateArtistBio, getArtistById } = await setup();
+    getArtistById.mockResolvedValue({
+      id: "artist-1", name: "Test Artist", spotify: "sp1",
+      instagram: null, x: null, soundcloud: null, youtube: null,
+      youtubechannel: null, wikipedia: null, musicbrainz: null,
+      discogs: null, wikidata: null,
+    });
+
+    await generateArtistBio("artist-1");
+
+    const callArgs = (mockGenerateContent as jest.Mock).mock.calls[0][0];
+    expect(callArgs.config.tools).toEqual([{ googleSearch: {} }]);
+  });
+
+  it("passes identifier anchors as full URLs in the prompt", async () => {
+    const { generateArtistBio, getArtistById } = await setup();
+    getArtistById.mockResolvedValue({
+      id: "artist-1", name: "Test Artist", spotify: null,
+      instagram: null, x: null, soundcloud: null, youtube: null,
+      youtubechannel: null,
+      wikipedia: "Test_Artist",
+      musicbrainz: "abc-123",
+      discogs: "999",
+      wikidata: "Q42",
+    });
+
+    await generateArtistBio("artist-1");
+
+    const contents = (mockGenerateContent as jest.Mock).mock.calls[0][0].contents;
+    expect(contents).toContain("https://en.wikipedia.org/wiki/Test_Artist");
+    expect(contents).toContain("https://musicbrainz.org/artist/abc-123");
+    expect(contents).toContain("https://www.discogs.com/artist/999");
+    expect(contents).toContain("https://www.wikidata.org/wiki/Q42");
+    // regression: never the bare slug
+    expect(contents).not.toMatch(/Wikipedia:\s*Test_Artist(?!\/|")/);
+  });
+
+  it("does not double the base URL when an anchor value is already a full URL", async () => {
+    const { generateArtistBio, getArtistById } = await setup();
+    getArtistById.mockResolvedValue({
+      id: "artist-1", name: "Test Artist", spotify: null,
+      instagram: null, x: null, soundcloud: null, youtube: null,
+      youtubechannel: null,
+      wikipedia: "https://en.wikipedia.org/wiki/Test_Artist",
+      musicbrainz: null, discogs: null, wikidata: null,
+    });
+
+    await generateArtistBio("artist-1");
+
+    const contents = (mockGenerateContent as jest.Mock).mock.calls[0][0].contents;
+    expect(contents).not.toContain("wiki/https://");
+    expect(contents).toContain("https://en.wikipedia.org/wiki/Test_Artist");
   });
 
   // ------- regenerateArtistBio -------

--- a/src/server/utils/queries/artistBioQuery.ts
+++ b/src/server/utils/queries/artistBioQuery.ts
@@ -6,6 +6,7 @@ import { artists } from "@/server/db/schema";
 import { eq } from "drizzle-orm";
 import { musicPlatformData } from "@/server/utils/musicPlatform";
 import { getVaultSourcesByArtistId } from "@/server/utils/queries/dashboardQueries";
+import { sanitizeBioText } from "@/lib/bioText";
 
 /**
  * Generate an artist bio using Gemini Pro with Google Search grounding.
@@ -46,19 +47,34 @@ export async function generateArtistBio(artistId: string): Promise<NextResponse>
   if (artist.soundcloud) promptParts.push(`SoundCloud: ${artist.soundcloud}`);
   if (artist.youtube) promptParts.push(`YouTube: https://youtube.com/@${artist.youtube.replace(/^@/, '')}`);
   if (artist.youtubechannel) promptParts.push(`YouTube Channel: ${artist.youtubechannel}`);
-  if (artist.wikipedia) promptParts.push(`Wikipedia: ${artist.wikipedia}`);
+  // Authoritative identity anchors — the IDs/links MusicNerd already stores.
+  // Formatted as real URLs so Google Search grounding confirms exactly which
+  // artist this is and reads the right sources.
+  // Values are normally bare slugs/IDs (writes go through extractArtistId), but
+  // guard against a legacy/future row already holding a full URL so we never
+  // build a doubled ".../wiki/https://.../wiki/..." anchor.
+  const anchorUrl = (base: string, value: string) =>
+    /^https?:\/\//i.test(value) ? value : `${base}${value}`;
+  const anchors: string[] = [];
+  if (artist.wikipedia) anchors.push(`Wikipedia: ${anchorUrl("https://en.wikipedia.org/wiki/", artist.wikipedia)}`);
+  if (artist.musicbrainz) anchors.push(`MusicBrainz: ${anchorUrl("https://musicbrainz.org/artist/", artist.musicbrainz)}`);
+  if (artist.discogs) anchors.push(`Discogs: ${anchorUrl("https://www.discogs.com/artist/", artist.discogs)}`);
+  if (artist.wikidata) anchors.push(`Wikidata: ${anchorUrl("https://www.wikidata.org/wiki/", artist.wikidata)}`);
+  if (anchors.length > 0) {
+    promptParts.push(
+      `Authoritative identity anchors (use these to confirm exactly which artist this is; prefer facts they support):\n${anchors.join("\n")}`
+    );
+  }
   if (platformBioData) promptParts.push(`Music Platform Data: ${platformBioData}`);
 
   // Include approved vault sources as additional context
   let hasVaultContext = false;
-  const vaultUrls: string[] = [];
   try {
     const vaultSources = await getVaultSourcesByArtistId(artistId, "approved");
     console.log(`[bio] Found ${vaultSources.length} approved vault sources for artist ${artistId}`);
     if (vaultSources.length > 0) {
       hasVaultContext = true;
       const vaultContext = vaultSources.map(s => {
-        if (s.url) vaultUrls.push(s.url);
         const parts = [`Source: ${s.title ?? s.url}`];
         if (s.snippet) parts.push(s.snippet);
         if (s.extractedText) parts.push(s.extractedText.slice(0, 2000));
@@ -76,21 +92,23 @@ export async function generateArtistBio(artistId: string): Promise<NextResponse>
 
     const geminiStartTime = Date.now();
 
-    const musicNerdVoice = `You write for MusicNerd, a discovery platform for people who genuinely care about music. Write an artist bio the way the sharpest person at the record store talks about an artist they love: deeply informed, a little obsessive, genuinely excited — and never corporate.
+    const musicNerdVoice = `You write clean, factual artist bios for MusicNerd, a music discovery platform. Think well-written encyclopedia entry, not a review or press release. Tell the reader who this artist is and what they're known for — accurately, without embellishment.
 
-Write ONE paragraph, 90-130 words. One paragraph only.
+Write ONE paragraph, up to ~100 words. Shorter is better than padded: if verified facts are thin, write two or three honest sentences.
 
-Voice:
-- Open with an angle — a line that frames what makes this artist worth caring about. Never a job title, never "[Name] is a [genre] artist."
-- Write like you're letting a fellow nerd in on something good. Pull the reader into the artist's world: the scene they come from, the lineage they're part of, the specific choices that make their work theirs.
-- Active, vivid verbs. Sentences with rhythm — vary the length. Hold a point of view; have a take on why this work matters.
-- Facts are your texture: names, places, labels, collaborators, songs, dates, and any artist-provided context. Specifics earn trust; adjectives don't. Let detail do the work.
+Structure:
+- Open with the name and what they are: "[Name] is a [role/genre] from [place]." This is the one place a plain identity sentence is correct — lead with it.
+- Follow with the most significant verifiable facts: bands, notable releases, collaborators, milestones, dates, well-documented activity outside music.
+- Stop when the facts run out. No closing "significance" flourish.
 
-Hard rules:
-- No corporate/résumé register. Never use "leveraged", "spearheaded", "integrated campaigns", "secured placements", "career connects", "leading work in".
-- Banned vanilla phrases: "emerging force", "pushing boundaries", "sonic territories", "artist to watch", "rising star", "carving out", "soundscape", "eclectic", "undeniable", "versatile", "seamlessly".
-- Facts only — never invent credits, collaborators, scenes, or influences. If the data is thin, stay short and concrete instead of padding.
-- No social links in the bio text.`;
+Rules:
+- Third person. Anchor on the name; use pronouns sparingly.
+- Pronouns: use she/he/they only as the artist is clearly documented to use them in your sources. If unclear, use they/them. Never guess a gendered pronoun.
+- State only what your sources support. Never invent bands, releases, collaborators, places, or dates. If unsure a fact is true, leave it out.
+- If you genuinely cannot verify anything beyond the name, write ONE neutral sentence, e.g. "[Name] is a musician; limited verified information is currently available." Never explain your process, never refer to "the provided information", never output a refusal or an empty bio.
+- No editorializing. Don't tell the reader why the work "matters," don't say the artist is "showing" or "proving" something, and don't append interpretive clauses to facts. Report the fact and stop.
+- Banned hype words: "emerging", "rising", "boundary-pushing", "eclectic", "versatile", "undeniable", "sonic", "soundscape", "artist to watch", "cross-genre draw", "carving out". Banned resume-speak: "leveraged", "spearheaded", "secured", "integrated".
+- Plain, direct sentences. No social links in the bio text.`;
 
     const systemPrompt = hasVaultContext
       ? `${musicNerdVoice}
@@ -98,8 +116,10 @@ Hard rules:
 The artist-provided vault context below is your PRIMARY source — mine it for the real names, places, labels, collaborators, credits, and timeline that make the bio specific. Treat platform stats (followers, releases, top track) as seasoning, not the story.`
       : `${musicNerdVoice}`;
 
-    // Use Google Search grounding when vault sources exist (allows Gemini to visit those URLs)
-    const useGrounding = hasVaultContext && vaultUrls.length > 0;
+    // Grounding is always on: bios must be factual, and grounding lets Gemini
+    // read the anchor URLs and the open web. Bios are cached, so the added
+    // latency is not on any user's critical path.
+    const useGrounding = true;
 
     const response = await Promise.race([
       getGemini().models.generateContent({
@@ -118,7 +138,9 @@ The artist-provided vault context below is your PRIMARY source — mine it for t
     const geminiEndTime = Date.now();
     const geminiDurationMs = geminiEndTime - geminiStartTime;
 
-    const bio = response.text ?? "";
+    // Strip any link artifacts the model emitted despite the "no social links" rule —
+    // grounded responses in particular like to append markdown citations.
+    const bio = sanitizeBioText(response.text);
     console.debug("Gemini bio:", JSON.stringify(bio, null, 2));
     console.debug("Gemini call duration:", `${geminiDurationMs}ms`);
 


### PR DESCRIPTION
## Release: staging → main

Promotes the bio voice redesign (#1140) to production.

### What's included
- **Factual bio voice** — replaced the AI-cringe "record-store nerd" prompt with a lean, name-anchored, factual encyclopedia voice (≤~100 words, no significance-tags, pronoun-safe, graceful no-facts fallback).
- **Grounding + anchors** — Google Search grounding now runs for every bio, anchored to the MusicBrainz/Wikipedia/Discogs/Wikidata identifiers already stored (with a guard against double-prefixing full URLs). Fixed a latent bug that passed Wikipedia as a bare slug.
- **Security** — closed a stored-XSS hole in bio rendering (`renderBioMarkdown` escapes HTML before applying bold/italic).
- **Citations** — `sanitizeBioText` strips legacy markdown citations at read + generation time (no migration).
- **Backfill (already run in prod)** — regenerated the 39 content-verified broken AI bios (36 via the gated script + 3 during eval); artist-written bios untouched. `docs/broken-bios-review.md` documents the non-AI broken rows left for manual review.

### Verification
- Merged to staging via #1140 with all checks green: build ✓, test (1108) ✓, claude-review ✓ (3 rounds, no blockers), Vercel preview ✓.

### Post-merge watch-items (flagged in #1140)
- Grounding is now unconditional — monitor `artistBio` route p95 latency, Gemini **cost + quota** (grounded calls have a different rate-limit profile), and 45s-timeout hits for thin-data artists.
