### PR TITLE
fix: recover empty-MIME (.md) uploads + clear storage errors + front-to-back upload tests

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -1,0 +1,34 @@
+name: Post-deploy smoke
+
+# Runs AFTER a deployment succeeds (Vercel reports status via the GitHub
+# integration). Hits the LIVE deployed URL's /api/health and fails if storage or
+# the database aren't actually wired — catching deploy/config regressions (e.g. a
+# missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY) that the mocked unit suite
+# structurally cannot. Non-blocking until enabled as a required check.
+on:
+  deployment_status:
+
+jobs:
+  smoke:
+    # Only when the deployment actually succeeded, and only if we got a URL.
+    if: github.event.deployment_status.state == 'success' && github.event.deployment_status.environment_url != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Runs *.smoke.test.ts (jest.smoke.config.ts, no global mocks). The health
+      # smoke targets SMOKE_BASE_URL; the storage-integration smoke skips here
+      # because Supabase creds are not provided to this job.
+      - name: Smoke test the deployed environment
+        env:
+          SMOKE_BASE_URL: ${{ github.event.deployment_status.environment_url }}
+        run: npm run test:smoke

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -1,17 +1,30 @@
 name: Post-deploy smoke
 
-# Runs AFTER a deployment succeeds (Vercel reports status via the GitHub
-# integration). Hits the LIVE deployed URL's /api/health and fails if storage or
-# the database aren't actually wired — catching deploy/config regressions (e.g. a
-# missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY) that the mocked unit suite
-# structurally cannot. Non-blocking until enabled as a required check.
+# Hits a LIVE deployed URL's /api/health and fails if storage or the database
+# aren't actually wired — catching deploy/config regressions (e.g. a missing
+# SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY) that the mocked unit suite cannot.
+#
+# Runs automatically after a PRODUCTION deployment succeeds. (Preview deploys are
+# skipped: they can sit behind Vercel deployment protection, which would 401 the
+# health check. Point it at staging/prod public domains via manual dispatch.)
+# Non-blocking until enabled as a required check.
 on:
   deployment_status:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Base URL to smoke test (e.g. https://staging.musicnerd.xyz)'
+        required: true
+        type: string
 
 jobs:
   smoke:
-    # Only when the deployment actually succeeded, and only if we got a URL.
-    if: github.event.deployment_status.state == 'success' && github.event.deployment_status.environment_url != ''
+    # Manual dispatch, OR a successful *production* deployment with a URL.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.deployment_status.state == 'success' &&
+       github.event.deployment_status.environment == 'Production' &&
+       github.event.deployment_status.environment_url != '')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,6 +35,10 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      # package.json engines require npm >=11; the runner ships an older npm.
+      - name: Upgrade npm
+        run: npm install -g npm@11.12.1
+
       - name: Install dependencies
         run: npm ci
 
@@ -30,5 +47,5 @@ jobs:
       # because Supabase creds are not provided to this job.
       - name: Smoke test the deployed environment
         env:
-          SMOKE_BASE_URL: ${{ github.event.deployment_status.environment_url }}
+          SMOKE_BASE_URL: ${{ github.event.deployment_status.environment_url || github.event.inputs.base_url }}
         run: npm run test:smoke

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # testing
 /coverage
 /test-results
+/playwright-report
 
 # localhttps
 server.js

--- a/e2e/vault-upload.spec.ts
+++ b/e2e/vault-upload.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+import { login } from './helpers/auth';
+
+/**
+ * FRONT-TO-BACK E2E for vault file upload.
+ *
+ * Drives the real UI in a real browser with a real (Privy test-account) session,
+ * through the real Next.js server → canEditArtist → Supabase Storage → DB. This
+ * is the layer that would catch a regression anywhere along that path — including
+ * the empty-MIME `.md` rejection and the storage-config break — that a mocked unit
+ * test can't. Runs against the local HTTPS dev server (see playwright.config.ts),
+ * which uses the Dev database + storage.
+ *
+ *   npm run test:e2e -- vault-upload
+ *
+ * Admin test account → canEdit is true for any artist, so no claim setup needed.
+ */
+// Admin test account (is_admin = true in Dev) ⇒ canEdit is true for any artist,
+// so no per-artist claim setup is needed. Same account the agent-work/mcp-keys specs use.
+const ADMIN = { email: 'test-6184@privy.io', otp: '413532' };
+
+// A real, magic-byte-valid PDF payload.
+const PDF = Buffer.from('%PDF-1.4\n1 0 obj<<>>endobj\ntrailer<<>>\n%%EOF\n');
+
+test.describe('Vault file upload', () => {
+  test.setTimeout(120_000);
+
+  test('admin uploads a PDF via the edit UI and it appears in the vault', async ({ page }) => {
+    await login(page, ADMIN.email, ADMIN.otp);
+
+    // Land on any artist page (homepage surfaces artist links).
+    await page.goto('/');
+    const firstArtist = page.locator('a[href^="/artist/"]').first();
+    await firstArtist.waitFor({ state: 'visible', timeout: 20_000 });
+    const href = await firstArtist.getAttribute('href');
+    expect(href, 'expected an artist link on the homepage').toBeTruthy();
+    await page.goto(href!);
+
+    // Enter edit mode (admin ⇒ canEdit ⇒ toggle is rendered).
+    const toggle = page.getByTestId('edit-mode-toggle');
+    await toggle.waitFor({ state: 'visible', timeout: 20_000 });
+    await toggle.click();
+
+    // The vault file input is present once editing. Drive it directly — no native
+    // file dialog — by setting files on the hidden <input type="file">. Target the
+    // VAULT input specifically (accept includes ".pdf") — the HeroSection
+    // profile-image input (accept="image/*") also exists in edit mode.
+    const fileInput = page.locator('input[type="file"][accept*=".pdf"]');
+    await fileInput.waitFor({ state: 'attached', timeout: 20_000 });
+
+    const fileName = `e2e-upload-${Date.now()}.pdf`;
+    await fileInput.setInputFiles({ name: fileName, mimeType: 'application/pdf', buffer: PDF });
+
+    // Front-to-back success: the uploaded file surfaces in the vault UI as its
+    // own source card (the filename is the card heading). Target the heading
+    // specifically — the "Uploaded file: <name>" caption also contains the name.
+    const uploadedHeading = page.getByRole('heading', { name: fileName });
+    await expect(uploadedHeading).toBeVisible({ timeout: 30_000 });
+
+    // Cleanup so the run is idempotent — delete the card we just added via its
+    // Delete button. Best-effort: a cleanup miss shouldn't fail the upload test.
+    const deleteBtn = uploadedHeading
+      .locator('xpath=ancestor::*[.//button[@aria-label="Delete"]][1]')
+      .locator('button[aria-label="Delete"]')
+      .first();
+    if (await deleteBtn.count().catch(() => 0)) {
+      await deleteBtn.click().catch(() => {});
+      await expect(uploadedHeading).toBeHidden({ timeout: 10_000 }).catch(() => {});
+    }
+  });
+});

--- a/jest.smoke.config.ts
+++ b/jest.smoke.config.ts
@@ -1,0 +1,34 @@
+/**
+ * Jest config for SMOKE / INTEGRATION tests (`*.smoke.test.ts`).
+ *
+ * Deliberately does NOT load `jest.setup.ts`, so the global mocks (fetch, db,
+ * openai, server actions) are absent — smoke tests must hit REAL services
+ * (Supabase Storage, a deployed URL) to catch integration/deploy regressions
+ * that the mocked unit suite structurally cannot. Runs in the `node` environment.
+ *
+ * Run:  npm run test:smoke
+ *   Storage integration reads creds from `.env.local` (skips if absent).
+ *   Post-deploy health smoke needs SMOKE_BASE_URL=https://staging.musicnerd.xyz
+ */
+import type { Config } from "jest";
+import nextJest from "next/jest.js";
+
+const createJestConfig = nextJest({ dir: "./" });
+
+const config: Config = {
+    // No setupFilesAfterEnv → no global mocks. This is the whole point.
+    setupFilesAfterEnv: [],
+    testEnvironment: "node",
+    extensionsToTreatAsEsm: [".ts", ".tsx"],
+    moduleNameMapper: {
+        "^@/(.*)$": "<rootDir>/src/$1",
+    },
+    transformIgnorePatterns: [
+        "node_modules/(?!(jose|@radix-ui|@panva|@tanstack|@tanstack/react-query|@tanstack/query-core|p-limit|yocto-queue)/)",
+    ],
+    testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/.next/"],
+    testMatch: ["**/*.smoke.test.ts"],
+    testTimeout: 30000,
+};
+
+export default createJestConfig(config);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:ci": "jest --ci --coverage",
+    "test:smoke": "jest --config jest.smoke.config.ts",
+    "test:e2e": "playwright test",
     "type-check": "tsc --noEmit",
     "ci": "npm run type-check && npm run lint && npm run test:ci && npm run build",
     "db:generate": "drizzle-kit generate",

--- a/src/app/api/artist/profile-image/__tests__/route.admin.test.ts
+++ b/src/app/api/artist/profile-image/__tests__/route.admin.test.ts
@@ -14,6 +14,7 @@ jest.mock('@/server/lib/supabase', () => {
   return {
     supabaseAdmin: { storage: { from } },
     VAULT_BUCKET: 'vault',
+    isSupabaseStorageConfigured: jest.fn(() => true),
     __storageMocks: { upload, list, remove, getPublicUrl, from },
   };
 });
@@ -191,5 +192,32 @@ describe('POST /api/artist/profile-image admin path', () => {
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body.error).toBe('Not authorized for this artist');
+  });
+
+  it('returns a clear 503 (not a generic 500) when storage is not configured', async () => {
+    const auth = await import('@/server/auth');
+    const users = await import('@/server/utils/queries/userQueries');
+    const claims = await import('@/server/utils/queries/dashboardQueries');
+    const supabase = await import('@/server/lib/supabase');
+    (auth.getServerAuthSession as jest.Mock).mockResolvedValue({ user: { id: 'admin-1' } });
+    (users.getUserById as jest.Mock).mockResolvedValue({ isAdmin: true });
+    (claims.getApprovedClaimForArtistByUserId as jest.Mock).mockResolvedValue(undefined);
+    (supabase.isSupabaseStorageConfigured as jest.Mock).mockReturnValue(false);
+
+    const { POST } = await import('../route');
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // valid PNG header — reaches the storage guard
+    const mockFile = {
+      name: 'a.png',
+      type: 'image/png',
+      size: pngBytes.byteLength,
+      arrayBuffer: async () => pngBytes.buffer,
+    };
+    const fd = new Map([['file', mockFile], ['artistId', 'artist-x']]);
+    const req = { formData: async () => ({ get: (k) => fd.get(k) }) } as unknown as Request;
+    const res = await POST(req);
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toMatch(/not configured/i);
   });
 });

--- a/src/app/api/artist/profile-image/route.ts
+++ b/src/app/api/artist/profile-image/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { getServerAuthSession } from "@/server/auth";
 import { getDevSession } from "@/server/utils/dev-auth";
 import { canEditArtist } from "@/server/utils/artistEditAuth";
-import { supabaseAdmin, VAULT_BUCKET } from "@/server/lib/supabase";
+import { supabaseAdmin, VAULT_BUCKET, isSupabaseStorageConfigured } from "@/server/lib/supabase";
 import { validateMagicBytes } from "@/server/utils/validateMagicBytes";
 import { db } from "@/server/db/drizzle";
 import { artists } from "@/server/db/schema";
@@ -68,6 +68,17 @@ export async function POST(req: Request) {
             return NextResponse.json(
                 { error: "Image content does not match declared type" },
                 { status: 400 }
+            );
+        }
+
+        // Fail fast with a clear message when storage credentials are absent (a common
+        // deploy misconfig: DB connection set but SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY
+        // missing). Without this, the getSupabaseAdmin() throw below surfaces as a generic 500.
+        if (!isSupabaseStorageConfigured()) {
+            console.error("[artist/profile-image] storage not configured: SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY missing");
+            return NextResponse.json(
+                { error: "Image storage is not configured on this server (missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY)." },
+                { status: 503 }
             );
         }
 

--- a/src/app/api/health/__tests__/health.smoke.test.ts
+++ b/src/app/api/health/__tests__/health.smoke.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * POST-DEPLOY SMOKE TEST — hits the LIVE /api/health of a deployed environment
+ * and fails if storage/database aren't actually wired. This is the layer that
+ * catches deploy/config regressions (e.g. missing SUPABASE_URL /
+ * SUPABASE_SERVICE_ROLE_KEY on Vercel) that mocked unit tests structurally cannot.
+ *
+ * Excluded from the unit suite via the `*.smoke.test.ts` name. Run it against a
+ * deployed URL:
+ *
+ *   SMOKE_BASE_URL=https://staging.musicnerd.xyz npm run test:smoke
+ *
+ * Intended to run automatically after each deploy (see CI). With no SMOKE_BASE_URL
+ * set, it skips so a local `npm run test:smoke` doesn't fail for lack of a target.
+ */
+const BASE = process.env.SMOKE_BASE_URL?.replace(/\/$/, "");
+
+(BASE ? describe : describe.skip)("post-deploy smoke: /api/health", () => {
+  jest.setTimeout(30_000);
+
+  it(`reports storage + database healthy at ${BASE}`, async () => {
+    const res = await fetch(`${BASE}/api/health`);
+    const body = await res.json().catch(() => ({}));
+    // Include the actual payload in the assertion so a failure shows exactly
+    // which check is red (e.g. { storage: false }) for fast diagnosis.
+    expect({ httpStatus: res.status, ...body }).toMatchObject({
+      httpStatus: 200,
+      ok: true,
+      checks: { storage: true, database: true },
+    });
+  });
+});

--- a/src/app/api/health/__tests__/route.test.ts
+++ b/src/app/api/health/__tests__/route.test.ts
@@ -1,0 +1,60 @@
+// @ts-nocheck
+import { jest } from '@jest/globals';
+
+// Mock the two things the health check inspects.
+jest.mock('@/server/lib/supabase', () => ({ isSupabaseStorageConfigured: jest.fn(() => true) }));
+jest.mock('@/server/db/drizzle', () => ({ db: { execute: jest.fn().mockResolvedValue([{ result: 1 }]) } }));
+
+if (!('json' in Response)) {
+  Response.json = (data, init) =>
+    new Response(JSON.stringify(data), {
+      headers: { 'Content-Type': 'application/json', ...(init?.headers || {}) },
+      status: init?.status || 200,
+    });
+}
+
+describe('GET /api/health', () => {
+  beforeEach(() => { jest.resetModules(); jest.clearAllMocks(); });
+
+  it('returns 200 and ok:true when storage + database are healthy', async () => {
+    const { GET } = await import('../route');
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.checks.storage).toBe(true);
+    expect(body.checks.database).toBe(true);
+  });
+
+  it('returns 503 and ok:false when storage is not configured (the outage we just had)', async () => {
+    const supabase = await import('@/server/lib/supabase');
+    (supabase.isSupabaseStorageConfigured as jest.Mock).mockReturnValue(false);
+    const { GET } = await import('../route');
+    const res = await GET();
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.checks.storage).toBe(false);
+  });
+
+  it('returns 503 when the database ping throws', async () => {
+    const drizzle = await import('@/server/db/drizzle');
+    (drizzle.db.execute as jest.Mock).mockRejectedValue(new Error('connection refused'));
+    const { GET } = await import('../route');
+    const res = await GET();
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.checks.database).toBe(false);
+  });
+
+  it('never leaks secrets (connection strings, service keys, JWTs) in the response', async () => {
+    const { GET } = await import('../route');
+    const res = await GET();
+    const body = await res.json();
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toMatch(/postgres(ql)?:\/\//i);
+    expect(serialized).not.toMatch(/service_role|SUPABASE_SERVICE_ROLE_KEY/i);
+    expect(serialized).not.toMatch(/eyJ[A-Za-z0-9_-]{10,}/); // JWT-looking blobs
+  });
+});

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { sql } from "drizzle-orm";
+import { isSupabaseStorageConfigured } from "@/server/lib/supabase";
+import { db } from "@/server/db/drizzle";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Deployment health check. Reports whether the RUNTIME environment is actually
+ * wired — not whether the code is correct. Mocked unit tests can't catch a
+ * missing env var on the deployed host; a post-deploy smoke test hitting this
+ * endpoint against the live URL can (see health.smoke.test.ts).
+ *
+ * Returns only booleans + a timestamp — never secrets, values, or connection
+ * strings. 200 when all critical checks pass, 503 otherwise (so a post-deploy
+ * check / uptime monitor fails loudly).
+ */
+export async function GET() {
+    // Storage: are the Supabase service-role credentials present? (The exact gap
+    // that broke profile-photo + vault uploads in the deployed environments.)
+    const storage = isSupabaseStorageConfigured();
+
+    // Database: can we actually round-trip a trivial query as the app's role?
+    let database = false;
+    try {
+        await db.execute(sql`select 1`);
+        database = true;
+    } catch (err) {
+        console.error("[health] database ping failed:", err);
+    }
+
+    const ok = storage && database;
+    return NextResponse.json(
+        {
+            ok,
+            checks: { storage, database },
+            timestamp: new Date().toISOString(),
+        },
+        { status: ok ? 200 : 503 }
+    );
+}

--- a/src/app/api/vault/upload/__tests__/route.admin.test.ts
+++ b/src/app/api/vault/upload/__tests__/route.admin.test.ts
@@ -19,6 +19,7 @@ jest.mock('@/server/lib/supabase', () => ({
     },
   },
   VAULT_BUCKET: 'vault',
+  isSupabaseStorageConfigured: jest.fn(() => true),
 }));
 jest.mock('@/server/utils/validateMagicBytes', () => ({ validateMagicBytes: jest.fn().mockReturnValue(true) }));
 jest.mock('@/server/utils/extractPdfText', () => ({ extractPdfText: jest.fn().mockResolvedValue(null) }));
@@ -175,5 +176,68 @@ describe('POST /api/vault/upload admin path', () => {
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body.error).toBe('Not authorized for this artist');
+  });
+
+  it('accepts a .md file the browser reports with an EMPTY MIME type', async () => {
+    // Browsers frequently send file.type === "" for .md. The old strict allowlist
+    // check on file.type alone rejected these; resolveUploadType recovers via the extension.
+    const auth = await import('@/server/auth');
+    const users = await import('@/server/utils/queries/userQueries');
+    const claims = await import('@/server/utils/queries/dashboardQueries');
+    (auth.getServerAuthSession as jest.Mock).mockResolvedValue({ user: { id: 'admin-1' } });
+    (users.getUserById as jest.Mock).mockResolvedValue({ isAdmin: true });
+    (claims.getApprovedClaimForArtistByUserId as jest.Mock).mockResolvedValue(undefined);
+    (claims.insertVaultSource as jest.Mock).mockResolvedValue({ id: 'src-md' });
+
+    const { POST } = await import('../route');
+    const mdBytes = new TextEncoder().encode('# Notes\nsome content here');
+    const mockFile = {
+      name: 'notes.md',
+      type: '', // the empty-MIME case
+      size: mdBytes.byteLength,
+      arrayBuffer: async () => mdBytes.buffer,
+    };
+    const fd = new Map([['file', mockFile], ['artistId', 'artist-x']]);
+    const req = { formData: async () => ({ get: (k) => fd.get(k) }) } as unknown as Request;
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    const callArg = (claims.insertVaultSource as jest.Mock).mock.calls[0][0];
+    // resolved to text/markdown despite the empty declared type...
+    expect(callArg.contentType).toBe('text/markdown');
+    // ...and text was extracted for LLM context (proves resolvedType drives extraction)
+    expect(callArg.extractedText).toContain('some content here');
+  });
+
+  it('returns a clear 503 (not a generic 500) when storage is not configured', async () => {
+    // Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY on the deployment — the guard
+    // must surface a diagnosable error and never attempt a DB insert.
+    const auth = await import('@/server/auth');
+    const users = await import('@/server/utils/queries/userQueries');
+    const claims = await import('@/server/utils/queries/dashboardQueries');
+    const supabase = await import('@/server/lib/supabase');
+    (auth.getServerAuthSession as jest.Mock).mockResolvedValue({ user: { id: 'admin-1' } });
+    (users.getUserById as jest.Mock).mockResolvedValue({ isAdmin: true });
+    (claims.getApprovedClaimForArtistByUserId as jest.Mock).mockResolvedValue(undefined);
+    (supabase.isSupabaseStorageConfigured as jest.Mock).mockReturnValue(false);
+
+    const { POST } = await import('../route');
+    const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // %PDF
+    const mockFile = {
+      name: 'doc.pdf',
+      type: 'application/pdf',
+      size: pdfBytes.byteLength,
+      arrayBuffer: async () => pdfBytes.buffer,
+    };
+    const fd = new Map([['file', mockFile], ['artistId', 'artist-x']]);
+    const req = { formData: async () => ({ get: (k) => fd.get(k) }) } as unknown as Request;
+    const res = await POST(req);
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toMatch(/not configured/i);
+    expect(claims.insertVaultSource).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/vault/upload/__tests__/vaultStorage.smoke.test.ts
+++ b/src/app/api/vault/upload/__tests__/vaultStorage.smoke.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * REAL-STORAGE INTEGRATION SMOKE TEST — exercises the ACTUAL Supabase Storage
+ * round-trip (upload → public URL → list → delete) against the real project in
+ * `.env.local` (Dev). This is the layer that catches storage-integration
+ * regressions the mocked unit tests structurally cannot: a revoked service-role
+ * key, a missing/renamed `vault-files` bucket, a changed bucket policy.
+ *
+ * Excluded from the unit suite via the `*.smoke.test.ts` name. Run on demand:
+ *   npm run test:smoke
+ *
+ * Reads real creds from `.env.local` (jest forces NODE_ENV=test, which makes
+ * `@/env` return stubs — so we go straight to process.env here). Skips cleanly
+ * when SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY are absent.
+ */
+import { config as loadEnv } from "dotenv";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+loadEnv({ path: ".env.local" });
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const BUCKET = "vault-files";
+const ready = Boolean(SUPABASE_URL && SERVICE_KEY);
+
+(ready ? describe : describe.skip)("real-storage integration: vault-files bucket", () => {
+  jest.setTimeout(30_000);
+
+  const sb: SupabaseClient = ready
+    ? createClient(SUPABASE_URL as string, SERVICE_KEY as string, { auth: { persistSession: false } })
+    : (null as unknown as SupabaseClient);
+
+  const baseName = `${Date.now()}_probe.pdf`;
+  const path = `__smoke__/${baseName}`;
+
+  afterAll(async () => {
+    // Belt-and-suspenders cleanup in case an assertion aborted before the remove.
+    if (ready) await sb.storage.from(BUCKET).remove([path]).catch(() => {});
+  });
+
+  it("uploads a PDF, exposes a public URL, reads it back, and deletes it", async () => {
+    // Real %PDF payload so it would pass the route's magic-byte validation too.
+    const pdf = Buffer.from("%PDF-1.4\n1 0 obj<<>>endobj\ntrailer<<>>\n%%EOF\n", "utf8");
+
+    const { error: uploadErr } = await sb.storage
+      .from(BUCKET)
+      .upload(path, pdf, { contentType: "application/pdf" });
+    expect(uploadErr).toBeNull();
+
+    const { data: urlData } = sb.storage.from(BUCKET).getPublicUrl(path);
+    expect(urlData.publicUrl).toMatch(/\/vault-files\/__smoke__\/.+\.pdf$/);
+
+    // Read-back: download the exact object and verify its bytes round-tripped.
+    const { data: blob, error: downloadErr } = await sb.storage.from(BUCKET).download(path);
+    expect(downloadErr).toBeNull();
+    const readBack = Buffer.from(await (blob as Blob).arrayBuffer());
+    expect(readBack.subarray(0, 4).toString("latin1")).toBe("%PDF");
+    expect(readBack.length).toBe(pdf.length);
+
+    const { error: removeErr } = await sb.storage.from(BUCKET).remove([path]);
+    expect(removeErr).toBeNull();
+  });
+});

--- a/src/app/api/vault/upload/route.ts
+++ b/src/app/api/vault/upload/route.ts
@@ -3,8 +3,9 @@ import { getServerAuthSession } from "@/server/auth";
 import { getDevSession } from "@/server/utils/dev-auth";
 import { insertVaultSource } from "@/server/utils/queries/dashboardQueries";
 import { canEditArtist } from "@/server/utils/artistEditAuth";
-import { supabaseAdmin, VAULT_BUCKET } from "@/server/lib/supabase";
+import { supabaseAdmin, VAULT_BUCKET, isSupabaseStorageConfigured } from "@/server/lib/supabase";
 import { validateMagicBytes } from "@/server/utils/validateMagicBytes";
+import { resolveUploadType } from "@/server/utils/resolveUploadType";
 import { extractPdfText } from "@/server/utils/extractPdfText";
 
 export const dynamic = "force-dynamic";
@@ -67,7 +68,13 @@ export async function POST(req: Request) {
             );
         }
 
-        if (!ALLOWED_TYPES.includes(file.type)) {
+        // Resolve the effective MIME type. Browsers report an empty or nonstandard
+        // `file.type` for some formats (notably .md, sometimes .csv), which a strict
+        // allowlist check on file.type alone would wrongly reject — fall back to the
+        // extension. resolvedType is used for the rest of the flow (magic bytes,
+        // storage content-type, text extraction, DB record).
+        const resolvedType = resolveUploadType(file.name, file.type, ALLOWED_TYPES);
+        if (!resolvedType) {
             console.error("[vault/upload] rejected:", { name: file.name, type: file.type, size: file.size, reason: "unsupported_type" });
             return NextResponse.json(
                 { error: `File type not supported: "${file.type || "unknown"}". Supported: PDF, TXT, MD, CSV, JSON, DOCX, images, audio.` },
@@ -80,7 +87,7 @@ export async function POST(req: Request) {
         const buffer = Buffer.from(bytes);
 
         // Validate magic bytes for binary formats to prevent MIME type spoofing
-        if (!validateMagicBytes(buffer, file.type)) {
+        if (!validateMagicBytes(buffer, resolvedType)) {
             console.error("[vault/upload] rejected:", {
                 name: file.name,
                 type: file.type,
@@ -94,15 +101,27 @@ export async function POST(req: Request) {
             );
         }
 
+        // Fail fast with a clear message when the storage service-role credentials
+        // are absent (a common deploy misconfig: SUPABASE_DB_CONNECTION set so DB
+        // features work, but SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY missing). Without
+        // this, the getSupabaseAdmin() throw below surfaces as a generic 500.
+        if (!isSupabaseStorageConfigured()) {
+            console.error("[vault/upload] storage not configured: SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY missing");
+            return NextResponse.json(
+                { error: "File storage is not configured on this server (missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY)." },
+                { status: 503 }
+            );
+        }
+
         // All ALLOWED_TYPES have entries in MIME_EXT_MAP; fallback is safety-net only
-        const ext = MIME_EXT_MAP[file.type] ?? "";
+        const ext = MIME_EXT_MAP[resolvedType] ?? "";
         const baseName = file.name.replace(/\.[^.]+$/, "").replace(/[^a-zA-Z0-9_-]/g, "_");
         const storagePath = `${artistId}/${Date.now()}_${baseName}${ext}`;
 
         // Upload to Supabase Storage
         const { error: uploadError } = await supabaseAdmin.storage
             .from(VAULT_BUCKET)
-            .upload(storagePath, buffer, { contentType: file.type });
+            .upload(storagePath, buffer, { contentType: resolvedType });
 
         if (uploadError) {
             console.error("[vault/upload] Supabase upload error:", uploadError);
@@ -118,13 +137,13 @@ export async function POST(req: Request) {
         // Extract text content for LLM access (bio + funFacts + askArtist context)
         let extractedText: string | undefined;
         if (
-            file.type === "text/plain" ||
-            file.type === "text/markdown" ||
-            file.type === "text/csv" ||
-            file.type === "application/json"
+            resolvedType === "text/plain" ||
+            resolvedType === "text/markdown" ||
+            resolvedType === "text/csv" ||
+            resolvedType === "application/json"
         ) {
             extractedText = new TextDecoder().decode(bytes);
-        } else if (file.type === "application/pdf") {
+        } else if (resolvedType === "application/pdf") {
             extractedText = (await extractPdfText(buffer)) ?? undefined;
             if (!extractedText) {
                 console.warn(`[vault/upload] No text extracted from PDF "${file.name}" (image-only or empty?)`);
@@ -142,12 +161,12 @@ export async function POST(req: Request) {
             url: publicUrl,
             title: file.name,
             snippet: extractedText ? extractedText.slice(0, 300) : `Uploaded file: ${file.name} (${formatFileSize(file.size)})`,
-            type: getSourceType(file.type),
+            type: getSourceType(resolvedType),
             status: "approved",
             fileName: file.name,
             fileSize: file.size,
             filePath: storagePath,
-            contentType: file.type,
+            contentType: resolvedType,
             extractedText: extractedText ?? null,
         });
 

--- a/src/server/lib/supabase.ts
+++ b/src/server/lib/supabase.ts
@@ -16,6 +16,17 @@ export function getSupabaseAdmin(): SupabaseClient {
     return _supabaseAdmin;
 }
 
+/**
+ * Whether Supabase Storage is usable in this environment. Returns false when the
+ * service-role credentials are absent — the common deploy misconfiguration where
+ * `SUPABASE_DB_CONNECTION` is set (so DB-only features work) but the storage vars
+ * are not, so every upload throws a generic 500. Routes call this to fail fast
+ * with a clear "storage not configured" message instead.
+ */
+export function isSupabaseStorageConfigured(): boolean {
+    return Boolean(SUPABASE_URL && SUPABASE_SERVICE_ROLE_KEY);
+}
+
 /** @deprecated Use getSupabaseAdmin() instead — kept for existing imports */
 export const supabaseAdmin = new Proxy({} as SupabaseClient, {
     get(_, prop) {

--- a/src/server/utils/__tests__/resolveUploadType.test.ts
+++ b/src/server/utils/__tests__/resolveUploadType.test.ts
@@ -1,0 +1,57 @@
+import { resolveUploadType } from "../resolveUploadType";
+
+// Mirrors the vault upload route's ALLOWED_TYPES so tests exercise the real allowlist.
+const ALLOWED = [
+    "application/pdf",
+    "text/plain",
+    "text/markdown",
+    "text/csv",
+    "application/json",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+    "audio/mpeg",
+    "audio/wav",
+];
+
+describe("resolveUploadType", () => {
+    it("uses the declared type when it is allowed", () => {
+        expect(resolveUploadType("notes.txt", "text/plain", ALLOWED)).toBe("text/plain");
+        expect(resolveUploadType("doc.pdf", "application/pdf", ALLOWED)).toBe("application/pdf");
+    });
+
+    it("falls back to the extension when the browser reports an EMPTY type (the .md case)", () => {
+        // Browsers frequently report "" for .md — a strict MIME allowlist would wrongly reject it.
+        expect(resolveUploadType("readme.md", "", ALLOWED)).toBe("text/markdown");
+        expect(resolveUploadType("data.csv", "", ALLOWED)).toBe("text/csv");
+        expect(resolveUploadType("paper.pdf", "", ALLOWED)).toBe("application/pdf");
+    });
+
+    it("falls back to the extension when the declared type is a generic non-allowed value", () => {
+        // Some browsers send application/octet-stream for known types.
+        expect(resolveUploadType("paper.pdf", "application/octet-stream", ALLOWED)).toBe("application/pdf");
+    });
+
+    it("is case-insensitive on both extension and declared type", () => {
+        expect(resolveUploadType("READExME.MD", "", ALLOWED)).toBe("text/markdown");
+        expect(resolveUploadType("PHOTO.JPEG", "IMAGE/JPEG", ALLOWED)).toBe("image/jpeg");
+    });
+
+    it("maps .markdown and .jpg aliases", () => {
+        expect(resolveUploadType("readme.markdown", "", ALLOWED)).toBe("text/markdown");
+        expect(resolveUploadType("pic.jpg", "", ALLOWED)).toBe("image/jpeg");
+    });
+
+    it("returns null for a genuinely unsupported type (empty MIME, unknown ext)", () => {
+        expect(resolveUploadType("malware.exe", "", ALLOWED)).toBeNull();
+        expect(resolveUploadType("archive.zip", "application/zip", ALLOWED)).toBeNull();
+        expect(resolveUploadType("noextension", "", ALLOWED)).toBeNull();
+    });
+
+    it("prefers an allowed declared type even when the extension differs", () => {
+        // Declared type wins when allowed — preserves existing behavior, adds no new spoof path.
+        expect(resolveUploadType("weird.name.pdf", "text/plain", ALLOWED)).toBe("text/plain");
+    });
+});

--- a/src/server/utils/resolveUploadType.ts
+++ b/src/server/utils/resolveUploadType.ts
@@ -1,0 +1,51 @@
+// Extension → canonical MIME type, for files whose browser-reported `file.type`
+// is empty or nonstandard. Browsers commonly report "" for .md (and occasionally
+// generic values like application/octet-stream for known types), which a strict
+// MIME allowlist would wrongly reject. Keep these in sync with the upload routes'
+// ALLOWED_TYPES.
+const EXT_TO_MIME: Record<string, string> = {
+    pdf: "application/pdf",
+    txt: "text/plain",
+    md: "text/markdown",
+    markdown: "text/markdown",
+    csv: "text/csv",
+    json: "application/json",
+    doc: "application/msword",
+    docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    webp: "image/webp",
+    mp3: "audio/mpeg",
+    wav: "audio/wav",
+};
+
+/**
+ * Resolve a file's effective MIME type against an allowlist.
+ *
+ * Prefers the browser-declared type when it is itself allowed (preserves existing
+ * behavior — adds no new acceptance path for spoofed binaries, which are still
+ * caught downstream by validateMagicBytes). Otherwise falls back to the file
+ * extension. Returns null when neither the declared type nor the extension maps
+ * to an allowed type, so the caller can reject with a clear "unsupported" error.
+ *
+ * @param fileName     the original upload filename (used for the extension fallback)
+ * @param declaredType the browser-reported MIME type (may be "" / nonstandard)
+ * @param allowed      the caller's allowlist of acceptable MIME types
+ */
+export function resolveUploadType(
+    fileName: string,
+    declaredType: string,
+    allowed: readonly string[]
+): string | null {
+    const declared = (declaredType || "").trim().toLowerCase();
+    if (declared && allowed.includes(declared)) return declared;
+
+    const ext = fileName.includes(".")
+        ? fileName.split(".").pop()!.toLowerCase()
+        : "";
+    const fromExt = ext ? EXT_TO_MIME[ext] : undefined;
+    if (fromExt && allowed.includes(fromExt)) return fromExt;
+
+    return null;
+}


### PR DESCRIPTION
## What & why

Artist asset uploads (profile photos + vault files: PDF/txt/**.md**/etc.) were failing. Two distinct problems:

1. **Deploy config (fixed outside this PR):** the deployed environments were missing `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`, so the storage admin client couldn't initialize and every upload threw a generic error. Vars are now set on staging (Preview) + prod, and staging has been redeployed. Tracked in #1152.
2. **Code (this PR):** even with storage configured, the vault route rejected files whose browser-reported MIME is empty/nonstandard — notably `.md`. And a missing-storage-config failure surfaced as an undiagnosable 500.

## Changes

**Fix**
- `resolveUploadType()` — resolves the effective MIME type, falling back to the file **extension** when the browser sends `""`/nonstandard (binary spoofs still caught by `validateMagicBytes`). Threaded through the vault route for magic-bytes, storage content-type, text extraction, and the DB record.
- `isSupabaseStorageConfigured()` guard on **both** upload routes → clear **503** ("storage not configured — missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY") instead of a generic 500.

**Front-to-back tests (real services, not mocks)** — the layer that would have caught the outage:
- `/api/health` endpoint + `health.smoke.test.ts` + `.github/workflows/post-deploy-smoke.yml` (hits the **live** URL after each deploy; fails if storage/db aren't wired).
- `vaultStorage.smoke.test.ts` — round-trips a file against the real Supabase `vault-files` bucket.
- `e2e/vault-upload.spec.ts` — real Privy login → upload via the UI → verify it lands → self-clean.
- `jest.smoke.config.ts` runs `*.smoke.test.ts` with **no global mocks**; adds `test:smoke` / `test:e2e`.

## Verification
- ✅ type-check, lint, build (`/api/health` compiles)
- ✅ unit suite: **1129 passing**
- ✅ E2E passed (13.3s) and storage-integration smoke passed against Dev — the same DB + storage staging uses
- ✅ new unit tests cover `.md` empty-MIME acceptance and the 503 on both routes

## Follow-ups (filed, not in this PR)
#1150 (CI required-check + deploy-config coverage), #1151 (Vercel 4.5MB body cap), #1152 (storage env provisioning)

https://claude.ai/code/session_01SxgsJLvpQ8mPqhSftgx9wz