### PR TITLE
fix(test): de-flake referenceCode 'generates unique codes'

### DIFF
--- a/src/lib/__tests__/referenceCode.test.ts
+++ b/src/lib/__tests__/referenceCode.test.ts
@@ -14,12 +14,21 @@ describe("generateReferenceCode", () => {
         }
     });
 
-    it("generates unique codes", () => {
+    it("produces effectively-unique codes across a large batch (high entropy)", () => {
+        // The generator is RANDOM over a 32^4 ≈ 1.05M code space; it does not
+        // guarantee strict uniqueness across independent calls. Asserting "all N
+        // unique" was therefore flaky — 50 codes collide with ~0.12% probability
+        // (birthday paradox), which reddened CI intermittently.
+        //
+        // Instead assert the property that actually holds: the uniqueness rate
+        // stays very high over a large batch. Expected collisions in 2000 draws
+        // ≈ 1.9, so the `>= N - 20` threshold has a flake probability far below
+        // 1e-9 while still catching a genuinely low-entropy regression.
+        const N = 2000;
         const codes = new Set<string>();
-        for (let i = 0; i < 50; i++) {
+        for (let i = 0; i < N; i++) {
             codes.add(generateReferenceCode());
         }
-        // With 28^4 = ~600K possibilities, 50 codes should all be unique
-        expect(codes.size).toBe(50);
+        expect(codes.size).toBeGreaterThanOrEqual(N - 20);
     });
 });

--- a/src/lib/referenceCode.ts
+++ b/src/lib/referenceCode.ts
@@ -8,7 +8,11 @@ export function generateReferenceCode(): string {
     // Rejection sampling to eliminate modulo bias
     const code = Array.from(bytes)
         .map(b => {
-            const limit = 256 - (256 % CHARS.length); // 256 - (256 % 28) = 252
+            // Rejection sampling to eliminate modulo bias. With the current
+            // 32-char alphabet this branch never fires (256 % 32 === 0, so
+            // limit === 256), but it keeps the generator unbiased if CHARS
+            // ever changes to a length that doesn't divide 256 evenly.
+            const limit = 256 - (256 % CHARS.length);
             if (b >= limit) return CHARS[randomBytes(1)[0] % CHARS.length]; // re-roll
             return CHARS[b % CHARS.length];
         })


### PR DESCRIPTION
Fixes #1155.

## Problem
`referenceCode.test.ts › generates unique codes` generated 50 codes and asserted all 50 unique. `generateReferenceCode()` is **random** over a 32^4 (~1.05M) space and does **not** guarantee uniqueness (the code is a human-facing claim label — no unique constraint, no retry). So 50 codes collided with ~0.12% probability → intermittent CI reds (seen on #1153).

## Fix
- Assert the property that actually holds: uniqueness rate stays very high over a large batch — `size >= N-20` for `N=2000` (expected ~1.9 collisions; flake probability < 1e-9), which still catches a genuine low-entropy regression.
- Corrected the generator's stale rejection-sampling comment (32-char alphabet, not 28; the branch is a no-op since 32 divides 256 evenly). No behavior change to the generator.

## Verified
Ran the test 25× in a row: 25/25 pass. type-check + lint clean.