### PR TITLE
test(e2e): verify uploaded vault files feed the Ask-About chat

### DIFF
--- a/e2e/askartist-vault-context.spec.ts
+++ b/e2e/askartist-vault-context.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import { login } from './helpers/auth';
+
+/**
+ * FRONT-TO-BACK: uploaded vault files actually feed the "Ask About" chat.
+ *
+ * Uploads a file containing a UNIQUE, un-Googleable fact to an artist's vault,
+ * then asks /api/askArtist a question whose answer exists ONLY in that file. If
+ * the answer echoes the marker, the uploaded file was used as LLM context —
+ * proving the vault → askArtist pipeline (upload → extractedText → approved
+ * source → Gemini "VERIFIED SOURCES") works end-to-end.
+ *
+ * Runs against the local dev server by default, or a deployed host via
+ * E2E_BASE_URL, e.g.:
+ *   E2E_BASE_URL=https://staging.musicnerd.xyz npx playwright test askartist-vault-context
+ */
+const ADMIN = { email: 'test-6184@privy.io', otp: '413532' };
+
+// A nonsense proper noun that appears in no public source. If it shows up in the
+// answer, it can only have come from the uploaded vault file.
+const MARKER = 'Blorptangle Marmalade Protocol';
+
+test.describe('Ask About uses uploaded vault files as context', () => {
+  test.setTimeout(180_000);
+
+  test('uploaded file answers an otherwise-unknowable question', async ({ page }) => {
+    await login(page, ADMIN.email, ADMIN.otp);
+
+    // Pick any artist from the homepage.
+    await page.goto('/');
+    const firstArtist = page.locator('a[href^="/artist/"]').first();
+    await firstArtist.waitFor({ state: 'visible', timeout: 20_000 });
+    const href = await firstArtist.getAttribute('href');
+    expect(href, 'expected an artist link on the homepage').toBeTruthy();
+    const artistId = href!.replace(/^\/artist\//, '').split(/[?#]/)[0];
+    await page.goto(href!);
+
+    // Enter edit mode and upload a .txt file carrying the unique fact.
+    const toggle = page.getByTestId('edit-mode-toggle');
+    await toggle.waitFor({ state: 'visible', timeout: 20_000 });
+    await toggle.click();
+
+    const fileInput = page.locator('input[type="file"][accept*=".pdf"]'); // the vault input
+    await fileInput.waitFor({ state: 'attached', timeout: 20_000 });
+
+    const fileName = `askabout-context-${Date.now()}.txt`;
+    const fileText = `Verification note for testing. This artist's debut mixtape is titled "${MARKER}", released in 2094. This fact appears in no public source.`;
+    await fileInput.setInputFiles({ name: fileName, mimeType: 'text/plain', buffer: Buffer.from(fileText) });
+
+    // Part 1: the upload actually lands in the vault (on whatever host we target).
+    await expect(page.getByRole('heading', { name: fileName })).toBeVisible({ timeout: 30_000 });
+
+    // Part 2: ask the public Ask-About endpoint a question only the file can answer.
+    const res = await page.request.post('/api/askArtist', {
+      data: { artistId, question: "What is the title of this artist's debut mixtape?" },
+      timeout: 60_000,
+    });
+    expect(res.ok(), `askArtist HTTP ${res.status()}`).toBeTruthy();
+    const body = await res.json();
+    const answer: string = body.answer ?? '';
+    console.log(`\n[askArtist answer]\n${answer}\n`);
+
+    // The marker can only be in the answer if the uploaded file fed the context.
+    expect(answer.toLowerCase()).toContain('blorptangle');
+
+    // Cleanup — remove the test source so the artist's vault/answers aren't polluted.
+    const deleteBtn = page
+      .getByRole('heading', { name: fileName })
+      .locator('xpath=ancestor::*[.//button[@aria-label="Delete"]][1]')
+      .locator('button[aria-label="Delete"]')
+      .first();
+    if (await deleteBtn.count().catch(() => 0)) {
+      await deleteBtn.click().catch(() => {});
+      await expect(page.getByRole('heading', { name: fileName })).toBeHidden({ timeout: 10_000 }).catch(() => {});
+    }
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig } from '@playwright/test';
 
+// Set E2E_BASE_URL to run the E2E suite against a deployed environment (e.g.
+// https://staging.musicnerd.xyz) instead of a local dev server. When set, the
+// local dev webServer is not started.
+const remoteBaseUrl = process.env.E2E_BASE_URL;
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -8,15 +13,18 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'https://localhost:3001',
+    baseURL: remoteBaseUrl ?? 'https://localhost:3001',
     ignoreHTTPSErrors: true,
     trace: 'on-first-retry',
   },
-  webServer: {
-    command: 'npx next dev --experimental-https --port 3001',
-    url: 'https://localhost:3001',
-    reuseExistingServer: true,
-    ignoreHTTPSErrors: true,
-    timeout: 60_000,
-  },
+  // Only spin up the local dev server when targeting localhost.
+  webServer: remoteBaseUrl
+    ? undefined
+    : {
+        command: 'npx next dev --experimental-https --port 3001',
+        url: 'https://localhost:3001',
+        reuseExistingServer: true,
+        ignoreHTTPSErrors: true,
+        timeout: 60_000,
+      },
 });


### PR DESCRIPTION
Adds regression coverage for the vault → "Ask About" chat pipeline (the vault's core purpose) and enables running the E2E suite against a deployed host.

## What
- `e2e/askartist-vault-context.spec.ts` — uploads a file containing a unique, un-Googleable marker to an artist's vault, then asks `/api/askArtist` a question only that file can answer, and asserts the answer echoes the marker. Proves **upload → `extractedText` → approved vault source → Gemini "VERIFIED SOURCES" → answer** works end-to-end. Self-cleans the test source.
- `playwright.config.ts` — `E2E_BASE_URL` env runs the suite against a deployed host (staging/prod), skipping the local dev webServer.

## Verified
Ran green against **https://staging.musicnerd.xyz** — the chat answered with the exact planted fact ("Blorptangle Marmalade Protocol"), and cleanup left 0 residual rows. type-check + lint clean.

## Notes
E2E specs are not part of the CI unit run (jest ignores `e2e/`); this is on-demand / manual (`npx playwright test`, optionally with `E2E_BASE_URL`).