### PR TITLE
feat: add artist research foundation

### DIFF
--- a/agents/id-mapping/programmatic-resolver.ts
+++ b/agents/id-mapping/programmatic-resolver.ts
@@ -19,14 +19,25 @@ import {
   mkdirSync,
 } from "fs";
 import { dirname } from "path";
+import {
+  WIKIDATA_PLATFORM_DEFINITIONS,
+} from "../../src/lib/artistResearch/platformRegistry";
+import {
+  filterSafeWikidataLookupIds,
+  lookupWikidataArtists,
+} from "../../src/lib/artistResearch/wikidata";
+import { verifyDeezerArtistId } from "../../src/lib/artistResearch/deezer";
+import {
+  queryMusicBrainzByMbid,
+  queryMusicBrainzByName,
+  type MusicBrainzResult,
+} from "../../src/lib/artistResearch/musicbrainz";
 
 // --- Config ---
 
 const DB_URL = process.env.SUPABASE_DB_CONNECTION;
 const WIKIDATA_BATCH = parseInt(process.env.WIKIDATA_BATCH || "80", 10);
 const DRY_RUN = process.env.DRY_RUN === "1";
-const USER_AGENT =
-  "MusicNerdWeb/1.0 (https://musicnerd.xyz; contact@musicnerd.xyz)";
 
 // --- Types ---
 
@@ -67,30 +78,56 @@ interface CollectStats {
   errors: number;
 }
 
-// Wikidata property → target info
+// Preserve the legacy JSONL shape while deriving Wikidata property metadata
+// from the shared registry. New research flows store every allowlisted finding;
+// the catalog importer intentionally retains its historical targets.
+const LEGACY_MAPPING_PLATFORMS = new Set([
+  "deezer",
+  "apple_music",
+  "musicbrainz",
+  "tidal",
+  "amazon_music",
+  "youtube_music",
+  "genius",
+  "allmusic",
+  "billboard",
+  "rolling_stone",
+]);
+
+const LEGACY_ARTIST_COLUMN_PLATFORMS = new Set([
+  "musicbrainz",
+  "discogs",
+  "lastfm",
+  "soundcloud",
+  "imdb",
+  "youtube_channel",
+  "x",
+  "instagram",
+  "facebook",
+]);
+
+const LEGACY_WIKIDATA_DEFINITIONS = WIKIDATA_PLATFORM_DEFINITIONS.filter(
+  (definition) =>
+    definition.key !== "spotify" && definition.key !== "official_website",
+);
+
 const WIKIDATA_PROPS: Record<
   string,
   { sparqlVar: string; platform?: string; artistColumn?: string }
-> = {
-  P2722: { sparqlVar: "deezer", platform: "deezer" },
-  P2850: { sparqlVar: "apple", platform: "apple_music" },
-  P434: { sparqlVar: "mbid", platform: "musicbrainz", artistColumn: "musicbrainz" },
-  P7650: { sparqlVar: "tidal", platform: "tidal" },
-  P7400: { sparqlVar: "amazonMusic", platform: "amazon_music" },
-  P10625: { sparqlVar: "youtubeMusic", platform: "youtube_music" },
-  P1953: { sparqlVar: "discogs", artistColumn: "discogs" },
-  P2373: { sparqlVar: "genius", platform: "genius" },
-  P1728: { sparqlVar: "allmusic", platform: "allmusic" },
-  P3192: { sparqlVar: "lastfm", artistColumn: "lastfm" },
-  P3040: { sparqlVar: "soundcloud", artistColumn: "soundcloud" },
-  P4208: { sparqlVar: "billboard", platform: "billboard" },
-  P345: { sparqlVar: "imdb", artistColumn: "imdb" },
-  P3017: { sparqlVar: "rollingStone", platform: "rolling_stone" },
-  P2397: { sparqlVar: "youtube", artistColumn: "youtubechannel" },
-  P2002: { sparqlVar: "twitter", artistColumn: "x" },
-  P2003: { sparqlVar: "instagram", artistColumn: "instagram" },
-  P2013: { sparqlVar: "facebook", artistColumn: "facebookID" },
-};
+> = Object.fromEntries(
+  LEGACY_WIKIDATA_DEFINITIONS.map((definition) => [
+    definition.key,
+    {
+      sparqlVar: definition.wikidataVariable,
+      platform: LEGACY_MAPPING_PLATFORMS.has(definition.key)
+        ? definition.key
+        : undefined,
+      artistColumn: LEGACY_ARTIST_COLUMN_PLATFORMS.has(definition.key)
+        ? definition.artistColumn
+        : undefined,
+    },
+  ]),
+);
 
 // --- Helpers ---
 
@@ -108,20 +145,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function normalizeName(name: string): string {
-  return name
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase()
-    .replace(/^the\s+/, "")
-    .replace(/\s+(feat\.?|ft\.?|featuring)\s+.*/i, "")
-    .trim();
-}
-
-function namesMatch(a: string, b: string): boolean {
-  return normalizeName(a) === normalizeName(b);
-}
-
 function ensureDir(filePath: string): void {
   const dir = dirname(filePath);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
@@ -132,173 +155,42 @@ function ensureDir(filePath: string): void {
 async function queryWikidata(
   spotifyIds: string[],
 ): Promise<{ results: Map<string, Record<string, string[]>>; skippedMultiEntity: number }> {
-  // Validate Spotify IDs before embedding in SPARQL (defense against malformed DB data)
-  const safeIds = spotifyIds.filter((id) => /^[A-Za-z0-9]+$/.test(id));
-  const values = safeIds.map((id) => `"${id}"`).join(" ");
-  const optionals = Object.entries(WIKIDATA_PROPS)
-    .map(([code, { sparqlVar }]) => `  OPTIONAL { ?item wdt:${code} ?${sparqlVar} }`)
-    .join("\n");
+  const safeIds = filterSafeWikidataLookupIds(spotifyIds, "spotify");
+  if (safeIds.length === 0) {
+    return { results: new Map(), skippedMultiEntity: 0 };
+  }
 
-  const sparql = `
-SELECT ?item ?spotifyId
-       ${Object.values(WIKIDATA_PROPS).map((p) => `?${p.sparqlVar}`).join(" ")}
-WHERE {
-  VALUES ?spotifyId { ${values} }
-  ?item wdt:P1902 ?spotifyId .
-${optionals}
-}`;
-
-  const res = await fetch("https://query.wikidata.org/sparql", {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      "User-Agent": USER_AGENT,
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: `query=${encodeURIComponent(sparql)}`,
-    signal: AbortSignal.timeout(30_000),
+  const lookup = await lookupWikidataArtists({
+    sourcePlatform: "spotify",
+    sourceIds: safeIds,
+    targetPlatforms: LEGACY_WIKIDATA_DEFINITIONS.map(
+      (definition) => definition.key,
+    ),
   });
-
-  if (!res.ok) {
-    throw new Error(`Wikidata SPARQL error: ${res.status} ${res.statusText}`);
-  }
-
-  const data = await res.json();
-  const bindings = data.results?.bindings ?? [];
-
-  // Group by spotifyId, track entities per spotifyId for multi-entity dedup
-  const grouped = new Map<
-    string,
-    { entities: Set<string>; values: Record<string, Set<string>> }
-  >();
-
-  for (const row of bindings) {
-    const spotifyId = row.spotifyId?.value;
-    const entity = row.item?.value?.replace("http://www.wikidata.org/entity/", "");
-    if (!spotifyId || !entity) continue;
-
-    if (!grouped.has(spotifyId)) {
-      grouped.set(spotifyId, { entities: new Set(), values: {} });
-    }
-    const entry = grouped.get(spotifyId)!;
-    entry.entities.add(entity);
-
-    // Collect wikidata entity ID
-    if (!entry.values.wikidata) entry.values.wikidata = new Set();
-    entry.values.wikidata.add(entity);
-
-    // Collect all property values
-    for (const { sparqlVar } of Object.values(WIKIDATA_PROPS)) {
-      const val = row[sparqlVar]?.value;
-      if (val) {
-        if (!entry.values[sparqlVar]) entry.values[sparqlVar] = new Set();
-        entry.values[sparqlVar].add(val);
-      }
-    }
-  }
-
-  // Filter: skip multi-entity matches (Case 1), pick first value for multi-value (Case 2)
   const results = new Map<string, Record<string, string[]>>();
-  let skippedMultiEntity = 0;
-  for (const [spotifyId, entry] of grouped) {
-    if (entry.entities.size > 1) {
-      warn(
-        `Spotify ID ${spotifyId} matched ${entry.entities.size} Wikidata entities (${[...entry.entities].join(", ")}) — skipping`,
-      );
-      skippedMultiEntity++;
-      continue;
-    }
-    const values: Record<string, string[]> = {};
-    for (const [key, valSet] of Object.entries(entry.values)) {
-      values[key] = [...valSet];
+  for (const [spotifyId, match] of lookup.matches) {
+    const values: Record<string, string[]> = {
+      wikidata: [match.entityId],
+    };
+    for (const definition of LEGACY_WIKIDATA_DEFINITIONS) {
+      const platformValues = match.values[definition.key];
+      if (platformValues) {
+        values[definition.wikidataVariable] = platformValues;
+      }
     }
     results.set(spotifyId, values);
   }
 
-  return { results, skippedMultiEntity };
-}
-
-async function verifyDeezer(
-  deezerId: string,
-  expectedName: string,
-): Promise<boolean> {
-  try {
-    const res = await fetch(`https://api.deezer.com/artist/${deezerId}`, {
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!res.ok) return false;
-    const data = await res.json();
-    if (data.error) return false;
-    return namesMatch(data.name ?? "", expectedName);
-  } catch {
-    return false;
-  }
-}
-
-interface MusicBrainzResult {
-  deezerId?: string;
-  otherUrls: { platform: string; id: string }[];
-}
-
-async function queryMusicBrainzByMbid(
-  mbid: string,
-): Promise<MusicBrainzResult> {
-  const res = await fetch(
-    `https://musicbrainz.org/ws/2/artist/${mbid}?inc=url-rels&fmt=json`,
-    { headers: { "User-Agent": USER_AGENT }, signal: AbortSignal.timeout(10_000) },
-  );
-  if (!res.ok) throw new Error(`MusicBrainz ${res.status}`);
-  const data = await res.json();
-  return parseMusicBrainzRelations(data.relations ?? []);
-}
-
-async function queryMusicBrainzByName(
-  name: string,
-): Promise<{ mbid: string } | null> {
-  // Escape Lucene special characters in artist name before embedding in query
-  const escapedName = name.replace(/([+\-!(){}[\]^"~*?:\\\/])/g, "\\$1");
-  const res = await fetch(
-    `https://musicbrainz.org/ws/2/artist/?query=artist:"${encodeURIComponent(escapedName)}"&fmt=json&limit=10`,
-    { headers: { "User-Agent": USER_AGENT }, signal: AbortSignal.timeout(10_000) },
-  );
-  if (!res.ok) throw new Error(`MusicBrainz search ${res.status}`);
-  const data = await res.json();
-  const artists = data.artists ?? [];
-
-  // Require exact name match, reject ambiguous
-  const matches = artists.filter(
-    (a: { name: string }) => namesMatch(a.name, name),
-  );
-  if (matches.length === 1) return { mbid: matches[0].id };
-  return null;
-}
-
-function parseMusicBrainzRelations(
-  relations: { url?: { resource: string }; type: string }[],
-): MusicBrainzResult {
-  const result: MusicBrainzResult = { otherUrls: [] };
-
-  for (const rel of relations) {
-    const url = rel.url?.resource;
-    if (!url) continue;
-
-    // Deezer artist URL
-    const deezerMatch = url.match(
-      /deezer\.com\/(?:[a-z]{2}\/)?artist\/(\d+)/,
+  for (const [spotifyId, entityIds] of lookup.ambiguous) {
+    warn(
+      `Spotify ID ${spotifyId} matched ${entityIds.length} Wikidata entities (${entityIds.join(", ")}) — skipping`,
     );
-    if (deezerMatch) {
-      result.deezerId = deezerMatch[1];
-      continue;
-    }
-
-    // Tidal
-    const tidalMatch = url.match(/tidal\.com\/(?:browse\/)?artist\/(\d+)/);
-    if (tidalMatch) {
-      result.otherUrls.push({ platform: "tidal", id: tidalMatch[1] });
-    }
   }
 
-  return result;
+  return {
+    results,
+    skippedMultiEntity: lookup.ambiguous.size,
+  };
 }
 
 // --- Collect command ---
@@ -432,7 +324,7 @@ async function collect(outFile: string): Promise<void> {
           if (prop.platform) {
             if (prop.platform === "deezer") {
               // Deezer requires name verification
-              const verified = await verifyDeezer(val, artist.name);
+              const verified = await verifyDeezerArtistId(val, artist.name);
               if (verified) {
                 collected.mappings.deezer = { id: val, verified: true };
                 needsDeezer.delete(artist.spotifyId);
@@ -548,7 +440,10 @@ async function collect(outFile: string): Promise<void> {
       }
 
       if (mbResult?.deezerId) {
-        const verified = await verifyDeezer(mbResult.deezerId, artist.name);
+        const verified = await verifyDeezerArtistId(
+          mbResult.deezerId,
+          artist.name,
+        );
         if (verified) {
           const mbLine: CollectedArtist = {
             artistId: artist.id,
@@ -562,7 +457,11 @@ async function collect(outFile: string): Promise<void> {
           };
           // Add any other URLs found
           for (const url of mbResult.otherUrls) {
-            mbLine.mappings[url.platform] = { id: url.id };
+            // Preserve the legacy importer behavior; the reusable resolver
+            // exposes all allowlisted URLs through mbResult.findings.
+            if (url.platform === "tidal") {
+              mbLine.mappings[url.platform] = { id: url.id };
+            }
           }
           appendFileSync(outFile, JSON.stringify(mbLine) + "\n");
           stats.musicbrainzDeezerResolved++;
@@ -751,7 +650,7 @@ async function importData(inFile: string): Promise<void> {
     const idChunk = artistIds.slice(i, i + 1000);
     const rows = await sql`
       SELECT id, wikidata, musicbrainz, discogs, lastfm, soundcloud, imdb,
-             youtubechannel, x, instagram, "facebookID"
+             youtubechannel, x, instagram, facebook, "facebookID"
       FROM artists
       WHERE id = ANY(${idChunk}::uuid[])
     `;
@@ -783,6 +682,7 @@ async function importData(inFile: string): Promise<void> {
     youtubechannel: "youtubechannel",
     x: "x",
     instagram: "instagram",
+    facebook: "facebook",
     facebookID: "facebookID",
   };
 

--- a/src/lib/artistResearch/__tests__/deezer.test.ts
+++ b/src/lib/artistResearch/__tests__/deezer.test.ts
@@ -1,0 +1,51 @@
+import {
+  deezerArtistMatchesName,
+  fetchDeezerArtistIdentity,
+  verifyDeezerArtistId,
+} from "../deezer";
+
+describe("Deezer artist verification", () => {
+  it("uses the legacy normalized-name comparison", () => {
+    expect(
+      deezerArtistMatchesName(
+        { id: "145", name: "Beyoncé" },
+        "Beyonce",
+      ),
+    ).toBe(true);
+  });
+
+  it("fetches a Deezer artist identity", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ id: 145, name: "Beyoncé" }),
+    });
+
+    await expect(fetchDeezerArtistIdentity("145", fetchImpl)).resolves.toEqual(
+      { id: "145", name: "Beyoncé" },
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.deezer.com/artist/145",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it.each([
+    { ok: false, json: jest.fn() },
+    {
+      ok: true,
+      json: jest.fn().mockResolvedValue({ error: { code: 800 } }),
+    },
+  ])("treats HTTP/API failures as an unverified match", async (response) => {
+    const fetchImpl = jest.fn().mockResolvedValue(response);
+    await expect(
+      verifyDeezerArtistId("145", "Beyoncé", fetchImpl),
+    ).resolves.toBe(false);
+  });
+
+  it("preserves the legacy false-on-fetch-error behavior", async () => {
+    const fetchImpl = jest.fn().mockRejectedValue(new Error("timeout"));
+    await expect(
+      verifyDeezerArtistId("145", "Beyoncé", fetchImpl),
+    ).resolves.toBe(false);
+  });
+});

--- a/src/lib/artistResearch/__tests__/musicbrainz.test.ts
+++ b/src/lib/artistResearch/__tests__/musicbrainz.test.ts
@@ -1,0 +1,124 @@
+import {
+  escapeMusicBrainzLuceneValue,
+  parseMusicBrainzRelations,
+  selectUniqueMusicBrainzNameMatch,
+} from "../musicbrainz";
+
+describe("MusicBrainz artist research", () => {
+  it("parses allowlisted URL relationships and preserves legacy fields", () => {
+    const result = parseMusicBrainzRelations([
+      {
+        type: "free streaming",
+        url: { resource: "https://www.deezer.com/us/artist/145" },
+      },
+      {
+        type: "free streaming",
+        url: { resource: "https://www.deezer.com/artist/999" },
+      },
+      {
+        type: "streaming",
+        url: { resource: "https://tidal.com/browse/artist/1566" },
+      },
+      {
+        type: "streaming",
+        url: { resource: "https://tidal.com/artist/1566" },
+      },
+      {
+        type: "social network",
+        url: { resource: "https://www.instagram.com/beyonce/" },
+      },
+      {
+        type: "social network",
+        url: {
+          resource:
+            "https://www.facebook.com/profile.php?id=12345&ref=musicbrainz",
+        },
+      },
+      {
+        type: "official homepage",
+        url: { resource: "https://www.beyonce.com" },
+      },
+    ]);
+
+    expect(result.deezerId).toBe("999");
+    expect(result.otherUrls).toEqual([
+      { platform: "tidal", id: "1566" },
+      { platform: "tidal", id: "1566" },
+      { platform: "instagram", id: "beyonce" },
+      {
+        platform: "facebook_id",
+        id: "https://www.facebook.com/profile.php?id=12345",
+      },
+    ]);
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ platform: "tidal", value: "1566" }),
+        expect.objectContaining({ platform: "instagram", value: "beyonce" }),
+        expect.objectContaining({
+          platform: "facebook_id",
+          value: "https://www.facebook.com/profile.php?id=12345",
+        }),
+        expect.objectContaining({
+          platform: "official_website",
+          value: "https://www.beyonce.com/",
+        }),
+      ]),
+    );
+    expect(result.ambiguities).toContainEqual({
+      platform: "deezer",
+      values: ["145", "999"],
+    });
+    expect(
+      result.findings.filter((finding) => finding.platform === "tidal"),
+    ).toHaveLength(1);
+  });
+
+  it("ignores missing and malformed relationship URLs", () => {
+    expect(
+      parseMusicBrainzRelations([
+        {},
+        { type: "official homepage", url: { resource: "not a url" } },
+      ]),
+    ).toEqual({ otherUrls: [], findings: [], ambiguities: [] });
+  });
+
+  it("ignores malformed percent-encoded relationship paths", () => {
+    expect(() =>
+      parseMusicBrainzRelations([
+        {
+          type: "streaming",
+          url: { resource: "https://www.deezer.com/artist/%E0%A4%A" },
+        },
+      ]),
+    ).not.toThrow();
+  });
+
+  it("selects exactly one normalized name match", () => {
+    expect(
+      selectUniqueMusicBrainzNameMatch(
+        [
+          { id: "mb1", name: "Beyoncé" },
+          { id: "mb2", name: "Different Artist" },
+        ],
+        "Beyonce",
+      ),
+    ).toEqual({ mbid: "mb1", name: "Beyoncé" });
+
+    expect(
+      selectUniqueMusicBrainzNameMatch(
+        [
+          { id: "mb1", name: "The Beatles" },
+          { id: "mb2", name: "Beatles" },
+        ],
+        "Beatles",
+      ),
+    ).toBeNull();
+  });
+
+  it("escapes Lucene syntax without changing ordinary names", () => {
+    expect(escapeMusicBrainzLuceneValue("AC/DC + Friends")).toBe(
+      "AC\\/DC \\+ Friends",
+    );
+    expect(escapeMusicBrainzLuceneValue("Beyoncé")).toBe("Beyoncé");
+  });
+});

--- a/src/lib/artistResearch/__tests__/normalization.test.ts
+++ b/src/lib/artistResearch/__tests__/normalization.test.ts
@@ -1,0 +1,25 @@
+import {
+  artistNamesMatch,
+  normalizeArtistName,
+} from "../normalization";
+
+describe("artist research name normalization", () => {
+  it.each([
+    ["Beyoncé", "beyonce"],
+    ["The Beatles", "beatles"],
+    ["Artist feat. Guest", "artist"],
+    ["Artist ft Guest", "artist"],
+    ["Artist featuring Guest", "artist"],
+  ])("normalizes %s using the legacy rules", (input, expected) => {
+    expect(normalizeArtistName(input)).toBe(expected);
+  });
+
+  it("preserves punctuation and internal whitespace", () => {
+    expect(artistNamesMatch("AC/DC", "ACDC")).toBe(false);
+    expect(artistNamesMatch("Artist  Name", "Artist Name")).toBe(false);
+  });
+
+  it("preserves the legacy trim-order edge case", () => {
+    expect(normalizeArtistName("  The Beatles  ")).toBe("the beatles");
+  });
+});

--- a/src/lib/artistResearch/__tests__/platformRegistry.test.ts
+++ b/src/lib/artistResearch/__tests__/platformRegistry.test.ts
@@ -1,0 +1,123 @@
+import {
+  RESEARCH_PLATFORM_REGISTRY,
+  WIKIDATA_PLATFORM_DEFINITIONS,
+  buildResearchPlatformUrl,
+  extractResearchPlatformFromUrl,
+  normalizeResearchPlatformValue,
+} from "../platformRegistry";
+import { RESEARCH_PLATFORM_VALUES } from "../types";
+
+describe("artist research platform registry", () => {
+  it("defines every allowlisted platform exactly once", () => {
+    expect(Object.keys(RESEARCH_PLATFORM_REGISTRY).sort()).toEqual(
+      [...RESEARCH_PLATFORM_VALUES].sort(),
+    );
+  });
+
+  it("contains the deterministic Wikidata property allowlist", () => {
+    const properties = new Map(
+      WIKIDATA_PLATFORM_DEFINITIONS.map((definition) => [
+        definition.key,
+        definition.wikidataProperty,
+      ]),
+    );
+
+    expect(properties.get("spotify")).toBe("P1902");
+    expect(properties.get("deezer")).toBe("P2722");
+    expect(properties.get("musicbrainz")).toBe("P434");
+    expect(properties.get("tidal")).toBe("P4576");
+    expect(properties.get("amazon_music")).toBe("P6276");
+    expect(properties.get("youtube_music")).toBe("P2397");
+    expect(properties.get("official_website")).toBe("P856");
+  });
+
+  it("builds public URLs from native IDs and handles", () => {
+    expect(buildResearchPlatformUrl("spotify", "abc123")).toBe(
+      "https://open.spotify.com/artist/abc123",
+    );
+    expect(buildResearchPlatformUrl("x", "@musicnerd")).toBe(
+      "https://x.com/musicnerd",
+    );
+    expect(buildResearchPlatformUrl("youtube_channel", "UC123")).toBe(
+      "https://www.youtube.com/channel/UC123",
+    );
+  });
+
+  it("extracts supported platform values from relationship URLs", () => {
+    expect(
+      extractResearchPlatformFromUrl(
+        "https://www.deezer.com/us/artist/145?utm_source=test",
+      ),
+    ).toEqual({ platform: "deezer", value: "145" });
+    expect(
+      extractResearchPlatformFromUrl(
+        "https://tidal.com/browse/artist/1566",
+      ),
+    ).toEqual({ platform: "tidal", value: "1566" });
+    expect(
+      extractResearchPlatformFromUrl("https://twitter.com/Beyonce"),
+    ).toEqual({ platform: "x", value: "beyonce" });
+    expect(
+      extractResearchPlatformFromUrl(
+        "https://facebook.com/profile.php?id=12345",
+      ),
+    ).toEqual({
+      platform: "facebook_id",
+      value: "https://www.facebook.com/profile.php?id=12345",
+    });
+    expect(
+      extractResearchPlatformFromUrl(
+        "https://facebook.com/people/Artist-Name/12345/?ref=about",
+      ),
+    ).toEqual({
+      platform: "facebook_id",
+      value: "https://www.facebook.com/people/Artist-Name/12345/",
+    });
+  });
+
+  it("stores Wikidata Facebook usernames in the username column", () => {
+    expect(RESEARCH_PLATFORM_REGISTRY.facebook.artistColumn).toBe("facebook");
+    expect(RESEARCH_PLATFORM_REGISTRY.facebook_id.artistColumn).toBe(
+      "facebookID",
+    );
+  });
+
+  it("rejects malformed or reserved Facebook profile paths", () => {
+    expect(
+      extractResearchPlatformFromUrl(
+        "https://facebook.com/profile.php?id=notanumber",
+      ),
+    ).toBeNull();
+    expect(
+      extractResearchPlatformFromUrl("https://facebook.com/pages/Artist/123"),
+    ).toBeNull();
+  });
+
+  it("does not shift path segments after malformed encoding", () => {
+    expect(
+      extractResearchPlatformFromUrl(
+        "https://open.spotify.com/artist/%E0%A4%A/abc123",
+      ),
+    ).toBeNull();
+    expect(
+      extractResearchPlatformFromUrl(
+        "https://open.spotify.com/artist//abc123",
+      ),
+    ).toBeNull();
+  });
+
+  it("accepts only HTTP(S) official website values", () => {
+    expect(
+      normalizeResearchPlatformValue(
+        "official_website",
+        "https://artist.example",
+      ),
+    ).toBe("https://artist.example/");
+    expect(
+      normalizeResearchPlatformValue(
+        "official_website",
+        "javascript:alert(1)",
+      ),
+    ).toBe("");
+  });
+});

--- a/src/lib/artistResearch/__tests__/platformRegistry.test.ts
+++ b/src/lib/artistResearch/__tests__/platformRegistry.test.ts
@@ -31,6 +31,23 @@ describe("artist research platform registry", () => {
     expect(properties.get("official_website")).toBe("P856");
   });
 
+  it("reuses Wikidata YouTube channel IDs for YouTube and YouTube Music", () => {
+    const channelId = "UC123";
+
+    expect(RESEARCH_PLATFORM_REGISTRY.youtube_channel.wikidataProperty).toBe(
+      "P2397",
+    );
+    expect(RESEARCH_PLATFORM_REGISTRY.youtube_music.wikidataProperty).toBe(
+      RESEARCH_PLATFORM_REGISTRY.youtube_channel.wikidataProperty,
+    );
+    expect(buildResearchPlatformUrl("youtube_channel", channelId)).toBe(
+      `https://www.youtube.com/channel/${channelId}`,
+    );
+    expect(buildResearchPlatformUrl("youtube_music", channelId)).toBe(
+      `https://music.youtube.com/channel/${channelId}`,
+    );
+  });
+
   it("builds public URLs from native IDs and handles", () => {
     expect(buildResearchPlatformUrl("spotify", "abc123")).toBe(
       "https://open.spotify.com/artist/abc123",

--- a/src/lib/artistResearch/__tests__/wikidata.test.ts
+++ b/src/lib/artistResearch/__tests__/wikidata.test.ts
@@ -1,0 +1,184 @@
+import {
+  buildWikidataArtistQuery,
+  filterSafeWikidataLookupIds,
+  parseWikidataArtistBindings,
+  wikidataMatchToFindings,
+} from "../wikidata";
+
+describe("Wikidata artist research", () => {
+  it("builds Spotify- and Deezer-primary queries from the same registry", () => {
+    const spotifyQuery = buildWikidataArtistQuery("spotify", ["sp123"]);
+    const deezerQuery = buildWikidataArtistQuery("deezer", ["145"]);
+
+    expect(spotifyQuery).toContain("?item wdt:P1902 ?sourceId");
+    expect(deezerQuery).toContain("?item wdt:P2722 ?sourceId");
+    expect(deezerQuery).toContain("OPTIONAL { ?item wdt:P1902 ?spotify }");
+    expect(deezerQuery).toContain("OPTIONAL { ?item wdt:P856 ?website }");
+  });
+
+  it("filters malformed lookup IDs before SPARQL interpolation", () => {
+    expect(
+      filterSafeWikidataLookupIds([
+        "valid123",
+        "valid123",
+        "bad\" } UNION { ?s ?p ?o",
+        " ",
+      ]),
+    ).toEqual(["valid123"]);
+    expect(
+      filterSafeWikidataLookupIds(["valid123", "not-a-spotify-id"], "spotify"),
+    ).toEqual(["valid123"]);
+  });
+
+  it("can limit harvested properties for legacy callers", () => {
+    const query = buildWikidataArtistQuery(
+      "spotify",
+      ["sp123"],
+      ["deezer", "musicbrainz"],
+    );
+
+    expect(query).toContain("OPTIONAL { ?item wdt:P2722 ?deezer }");
+    expect(query).toContain("OPTIONAL { ?item wdt:P434 ?mbid }");
+    expect(query).not.toContain("P856");
+  });
+
+  it("exposes only the Deezer- and Spotify-primary lookup flow", () => {
+    expect(() =>
+      buildWikidataArtistQuery(
+        "lastfm" as never,
+        ["AC/DC"],
+      ),
+    ).toThrow("Wikidata lookup is not supported for lastfm");
+  });
+
+  it("deduplicates values while preserving first-seen order", () => {
+    const parsed = parseWikidataArtistBindings([
+      {
+        sourceId: { value: "145" },
+        item: { value: "http://www.wikidata.org/entity/Q36153" },
+        spotify: { value: "spotify-first" },
+        instagram: { value: "beyonce" },
+      },
+      {
+        sourceId: { value: "145" },
+        item: { value: "http://www.wikidata.org/entity/Q36153" },
+        spotify: { value: "spotify-first" },
+        instagram: { value: "beyonce-updated" },
+      },
+    ]);
+
+    expect(parsed.ambiguous.size).toBe(0);
+    expect(parsed.matches.get("145")).toEqual({
+      entityId: "Q36153",
+      values: {
+        wikidata: ["Q36153"],
+        spotify: ["spotify-first"],
+        instagram: ["beyonce", "beyonce-updated"],
+      },
+    });
+  });
+
+  it("rejects a source ID that resolves to multiple Wikidata entities", () => {
+    const parsed = parseWikidataArtistBindings([
+      {
+        sourceId: { value: "145" },
+        item: { value: "http://www.wikidata.org/entity/Q1" },
+      },
+      {
+        sourceId: { value: "145" },
+        item: { value: "http://www.wikidata.org/entity/Q2" },
+      },
+    ]);
+
+    expect(parsed.matches.has("145")).toBe(false);
+    expect(parsed.ambiguous.get("145")).toEqual(["Q1", "Q2"]);
+  });
+
+  it("turns a Deezer-primary entity match into allowlisted findings", () => {
+    const parsed = parseWikidataArtistBindings([
+      {
+        sourceId: { value: "145" },
+        item: { value: "http://www.wikidata.org/entity/Q36153" },
+        deezer: { value: "145" },
+        spotify: { value: "6vWDO969PvNqNYHIOW5v0m" },
+        mbid: { value: "859d0860-d480-4efd-970c-c05d5f1776b8" },
+        twitter: { value: "Beyonce" },
+        website: { value: "https://www.beyonce.com/" },
+      },
+    ]);
+    const match = parsed.matches.get("145");
+    expect(match).toBeDefined();
+
+    const result = wikidataMatchToFindings({
+      match: match!,
+      sourcePlatform: "deezer",
+    });
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "platform_id",
+          platform: "spotify",
+          value: "6vWDO969PvNqNYHIOW5v0m",
+          source: "wikidata",
+          confidence: "high",
+        }),
+        expect.objectContaining({
+          platform: "musicbrainz",
+          value: "859d0860-d480-4efd-970c-c05d5f1776b8",
+        }),
+        expect.objectContaining({
+          kind: "social_link",
+          platform: "x",
+          value: "beyonce",
+        }),
+        expect.objectContaining({
+          kind: "official_website",
+          platform: "official_website",
+          value: "https://www.beyonce.com/",
+        }),
+      ]),
+    );
+    expect(
+      result.findings.some((finding) => finding.platform === "deezer"),
+    ).toBe(false);
+    expect(result.ambiguities).toEqual([]);
+  });
+
+  it("surfaces multi-value properties for human review instead of choosing one", () => {
+    const result = wikidataMatchToFindings({
+      match: {
+        entityId: "Q123",
+        values: {
+          wikidata: ["Q123"],
+          spotify: ["spotify-one", "spotify-two"],
+          instagram: ["single-handle"],
+          x: ["SameHandle", "samehandle"],
+        },
+      },
+      sourcePlatform: "deezer",
+    });
+
+    expect(result.ambiguities).toEqual([
+      {
+        platform: "spotify",
+        values: ["spotify-one", "spotify-two"],
+      },
+    ]);
+    expect(
+      result.findings.some((finding) => finding.platform === "spotify"),
+    ).toBe(false);
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          platform: "instagram",
+          value: "single-handle",
+        }),
+        expect.objectContaining({
+          platform: "x",
+          value: "samehandle",
+        }),
+      ]),
+    );
+  });
+});

--- a/src/lib/artistResearch/deezer.ts
+++ b/src/lib/artistResearch/deezer.ts
@@ -1,0 +1,53 @@
+import { artistNamesMatch } from "./normalization";
+
+export type DeezerArtistIdentity = {
+  id: string;
+  name: string;
+};
+
+export async function fetchDeezerArtistIdentity(
+  deezerId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<DeezerArtistIdentity | null> {
+  const response = await fetchImpl(
+    `https://api.deezer.com/artist/${encodeURIComponent(deezerId)}`,
+    { signal: AbortSignal.timeout(10_000) },
+  );
+  if (!response.ok) return null;
+
+  const data = (await response.json()) as {
+    id?: number | string;
+    name?: string;
+    error?: unknown;
+  };
+  if (data.error || !data.name) return null;
+
+  return {
+    id: String(data.id ?? deezerId),
+    name: data.name,
+  };
+}
+
+export function deezerArtistMatchesName(
+  artist: DeezerArtistIdentity,
+  expectedName: string,
+): boolean {
+  return artistNamesMatch(artist.name, expectedName);
+}
+
+/**
+ * Boolean compatibility wrapper for the existing catalog resolver.
+ * HTTP errors and identity mismatches intentionally remain indistinguishable.
+ */
+export async function verifyDeezerArtistId(
+  deezerId: string,
+  expectedName: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<boolean> {
+  try {
+    const artist = await fetchDeezerArtistIdentity(deezerId, fetchImpl);
+    return artist ? deezerArtistMatchesName(artist, expectedName) : false;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/artistResearch/musicbrainz.ts
+++ b/src/lib/artistResearch/musicbrainz.ts
@@ -1,0 +1,190 @@
+import {
+  extractResearchPlatformFromUrl,
+  getResearchPlatformDefinition,
+} from "./platformRegistry";
+import { artistNamesMatch } from "./normalization";
+import type { ResearchFinding, ResearchPlatform } from "./types";
+import { ARTIST_RESEARCH_USER_AGENT } from "./wikidata";
+
+export type MusicBrainzRelation = {
+  type?: string;
+  url?: { resource?: string };
+};
+
+export type MusicBrainzResult = {
+  deezerId?: string;
+  otherUrls: { platform: ResearchPlatform; id: string }[];
+  findings: ResearchFinding[];
+  ambiguities: { platform: ResearchPlatform; values: string[] }[];
+};
+
+export type MusicBrainzSearchMatch = {
+  mbid: string;
+  name: string;
+};
+
+function findingFor(
+  platform: ResearchPlatform,
+  value: string,
+  evidenceUrl: string,
+): ResearchFinding {
+  return {
+    kind: getResearchPlatformDefinition(platform).kind,
+    platform,
+    value,
+    confidence: "high",
+    source: "musicbrainz",
+    reasoning: "Found in MusicBrainz URL relationships",
+    evidence: [{ type: "url", value: evidenceUrl }],
+  };
+}
+
+export function parseMusicBrainzRelations(
+  relations: readonly MusicBrainzRelation[],
+): MusicBrainzResult {
+  const result: MusicBrainzResult = {
+    otherUrls: [],
+    findings: [],
+    ambiguities: [],
+  };
+  const findingCandidates = new Map<
+    ResearchPlatform,
+    Map<string, ResearchFinding>
+  >();
+
+  const addFindingCandidate = (finding: ResearchFinding) => {
+    let platformCandidates = findingCandidates.get(finding.platform);
+    if (!platformCandidates) {
+      platformCandidates = new Map();
+      findingCandidates.set(finding.platform, platformCandidates);
+    }
+    platformCandidates.set(finding.value, finding);
+  };
+
+  for (const relation of relations) {
+    const url = relation.url?.resource;
+    if (!url) continue;
+
+    const extracted = extractResearchPlatformFromUrl(url);
+    if (extracted) {
+      if (extracted.platform === "deezer") {
+        // Preserve the legacy resolver's last-Deezer-link-wins behavior.
+        result.deezerId = extracted.value;
+      } else {
+        result.otherUrls.push({
+          platform: extracted.platform,
+          id: extracted.value,
+        });
+      }
+      addFindingCandidate(
+        findingFor(extracted.platform, extracted.value, url),
+      );
+      continue;
+    }
+
+    const relationType = relation.type?.toLowerCase() ?? "";
+    if (
+      relationType === "official homepage" ||
+      relationType === "official site"
+    ) {
+      try {
+        const parsed = new URL(url);
+        if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+          const normalizedUrl = parsed.toString();
+          addFindingCandidate(
+            findingFor("official_website", normalizedUrl, normalizedUrl),
+          );
+        }
+      } catch {
+        // Ignore malformed relation URLs.
+      }
+    }
+  }
+
+  for (const [platform, candidates] of findingCandidates) {
+    if (candidates.size === 1) {
+      result.findings.push([...candidates.values()][0]);
+    } else {
+      result.ambiguities.push({
+        platform,
+        values: [...candidates.keys()],
+      });
+    }
+  }
+  return result;
+}
+
+export function escapeMusicBrainzLuceneValue(value: string): string {
+  return value.replace(/([+\-!(){}[\]^"~*?:\\\/])/g, "\\$1");
+}
+
+export function selectUniqueMusicBrainzNameMatch(
+  artists: readonly { id?: string; name?: string }[],
+  expectedName: string,
+): MusicBrainzSearchMatch | null {
+  const matches = artists.filter(
+    (artist) =>
+      Boolean(artist.id && artist.name) &&
+      artistNamesMatch(artist.name ?? "", expectedName),
+  );
+  if (matches.length !== 1) return null;
+
+  return {
+    mbid: matches[0].id as string,
+    name: matches[0].name as string,
+  };
+}
+
+export async function queryMusicBrainzByMbid(
+  mbid: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<MusicBrainzResult> {
+  const response = await fetchImpl(
+    `https://musicbrainz.org/ws/2/artist/${encodeURIComponent(mbid)}?inc=url-rels&fmt=json`,
+    {
+      headers: { "User-Agent": ARTIST_RESEARCH_USER_AGENT },
+      signal: AbortSignal.timeout(10_000),
+    },
+  );
+  if (!response.ok) throw new Error(`MusicBrainz ${response.status}`);
+
+  const data = (await response.json()) as {
+    relations?: MusicBrainzRelation[];
+  };
+  const result = parseMusicBrainzRelations(data.relations ?? []);
+  result.findings = result.findings.filter(
+    (finding) => finding.platform !== "musicbrainz",
+  );
+  result.findings.unshift({
+    kind: "platform_id",
+    platform: "musicbrainz",
+    value: mbid,
+    confidence: "high",
+    source: "musicbrainz",
+    reasoning: "Resolved MusicBrainz artist record",
+    evidence: [{ type: "identifier", value: mbid, label: "MusicBrainz ID" }],
+  });
+  return result;
+}
+
+export async function queryMusicBrainzByName(
+  name: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<MusicBrainzSearchMatch | null> {
+  const escapedName = escapeMusicBrainzLuceneValue(name);
+  const response = await fetchImpl(
+    `https://musicbrainz.org/ws/2/artist/?query=artist:"${encodeURIComponent(escapedName)}"&fmt=json&limit=10`,
+    {
+      headers: { "User-Agent": ARTIST_RESEARCH_USER_AGENT },
+      signal: AbortSignal.timeout(10_000),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`MusicBrainz search ${response.status}`);
+  }
+
+  const data = (await response.json()) as {
+    artists?: { id?: string; name?: string }[];
+  };
+  return selectUniqueMusicBrainzNameMatch(data.artists ?? [], name);
+}

--- a/src/lib/artistResearch/normalization.ts
+++ b/src/lib/artistResearch/normalization.ts
@@ -1,0 +1,17 @@
+/**
+ * Preserve the normalization rules used by the existing ID-mapping script.
+ * Deliberately does not collapse punctuation or internal whitespace.
+ */
+export function normalizeArtistName(name: string): string {
+  return name
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/^the\s+/, "")
+    .replace(/\s+(feat\.?|ft\.?|featuring)\s+.*/i, "")
+    .trim();
+}
+
+export function artistNamesMatch(a: string, b: string): boolean {
+  return normalizeArtistName(a) === normalizeArtistName(b);
+}

--- a/src/lib/artistResearch/platformRegistry.ts
+++ b/src/lib/artistResearch/platformRegistry.ts
@@ -1,0 +1,454 @@
+import {
+  RESEARCH_PLATFORM_VALUES,
+  type ResearchFindingKind,
+  type ResearchPlatform,
+} from "./types";
+
+export type ResearchArtistColumn =
+  | "spotify"
+  | "deezer"
+  | "musicbrainz"
+  | "wikidata"
+  | "discogs"
+  | "lastfm"
+  | "soundcloud"
+  | "imdb"
+  | "youtubechannel"
+  | "x"
+  | "instagram"
+  | "facebook"
+  | "facebookID";
+
+export type ResearchPlatformDefinition = {
+  key: ResearchPlatform;
+  label: string;
+  kind: ResearchFindingKind;
+  artistColumn?: ResearchArtistColumn;
+  wikidataProperty?: `P${number}`;
+  wikidataVariable?: string;
+  buildUrl: (value: string) => string;
+  extractFromUrl?: (url: URL) => string | null;
+};
+
+const stripAt = (value: string) => value.replace(/^@/, "");
+const pathParts = (url: URL): string[] | null => {
+  const parts = url.pathname.split("/");
+  while (parts[0] === "") parts.shift();
+  while (parts.at(-1) === "") parts.pop();
+
+  try {
+    // Preserve empty internal segments. Dropping them can turn a malformed
+    // `/artist//later-value` URL into a valid-looking platform ID.
+    return parts.map((part) => decodeURIComponent(part));
+  } catch {
+    return null;
+  }
+};
+const normalizedHost = (url: URL) =>
+  url.hostname.toLowerCase().replace(/^www\./, "");
+const encodePathValue = (value: string) =>
+  value
+    .split("/")
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+
+function hostMatches(url: URL, ...hosts: string[]): boolean {
+  const host = normalizedHost(url);
+  return hosts.some((candidate) => host === candidate || host.endsWith(`.${candidate}`));
+}
+
+function segmentAfter(url: URL, segment: string): string | null {
+  const parts = pathParts(url);
+  if (!parts) return null;
+  const index = parts.findIndex((part) => part.toLowerCase() === segment);
+  return index >= 0 ? parts[index + 1] ?? null : null;
+}
+
+function firstPathSegment(url: URL): string | null {
+  return pathParts(url)?.[0] ?? null;
+}
+
+function matchingValue(
+  value: string | null,
+  pattern: RegExp,
+): string | null {
+  return value && pattern.test(value) ? value : null;
+}
+
+function normalizeFacebookIdUrl(rawValue: string): string {
+  let url: URL;
+  try {
+    url = new URL(rawValue);
+  } catch {
+    return "";
+  }
+  if (
+    (url.protocol !== "http:" && url.protocol !== "https:") ||
+    !hostMatches(url, "facebook.com")
+  ) {
+    return "";
+  }
+
+  const parts = pathParts(url);
+  if (!parts) return "";
+  if (parts[0]?.toLowerCase() === "profile.php") {
+    const id = url.searchParams.get("id");
+    return id && /^\d+$/.test(id)
+      ? `https://www.facebook.com/profile.php?id=${id}`
+      : "";
+  }
+  if (
+    parts[0]?.toLowerCase() === "people" &&
+    parts[1] &&
+    parts[2] &&
+    /^\d+$/.test(parts[2])
+  ) {
+    return `https://www.facebook.com/people/${encodeURIComponent(parts[1])}/${parts[2]}/`;
+  }
+  return "";
+}
+
+const DEFINITIONS: Record<ResearchPlatform, ResearchPlatformDefinition> = {
+  spotify: {
+    key: "spotify",
+    label: "Spotify",
+    kind: "platform_id",
+    artistColumn: "spotify",
+    wikidataProperty: "P1902",
+    wikidataVariable: "spotify",
+    buildUrl: (value) => `https://open.spotify.com/artist/${encodeURIComponent(value)}`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "open.spotify.com")
+        ? matchingValue(segmentAfter(url, "artist"), /^[A-Za-z0-9]+$/)
+        : null,
+  },
+  deezer: {
+    key: "deezer",
+    label: "Deezer",
+    kind: "platform_id",
+    artistColumn: "deezer",
+    wikidataProperty: "P2722",
+    wikidataVariable: "deezer",
+    buildUrl: (value) => `https://www.deezer.com/artist/${encodeURIComponent(value)}`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "deezer.com")
+        ? matchingValue(segmentAfter(url, "artist"), /^\d+$/)
+        : null,
+  },
+  apple_music: {
+    key: "apple_music",
+    label: "Apple Music",
+    kind: "platform_id",
+    wikidataProperty: "P2850",
+    wikidataVariable: "apple",
+    buildUrl: (value) => `https://music.apple.com/artist/${encodeURIComponent(value)}`,
+    extractFromUrl: (url) => {
+      if (!hostMatches(url, "music.apple.com")) return null;
+      const parts = pathParts(url);
+      if (!parts) return null;
+      const artistIndex = parts.findIndex((part) => part.toLowerCase() === "artist");
+      return artistIndex >= 0
+        ? matchingValue(parts.at(-1) ?? null, /^\d+$/)
+        : null;
+    },
+  },
+  musicbrainz: {
+    key: "musicbrainz",
+    label: "MusicBrainz",
+    kind: "platform_id",
+    artistColumn: "musicbrainz",
+    wikidataProperty: "P434",
+    wikidataVariable: "mbid",
+    buildUrl: (value) => `https://musicbrainz.org/artist/${encodeURIComponent(value)}`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "musicbrainz.org") ? segmentAfter(url, "artist") : null,
+  },
+  wikidata: {
+    key: "wikidata",
+    label: "Wikidata",
+    kind: "platform_id",
+    artistColumn: "wikidata",
+    buildUrl: (value) => `https://www.wikidata.org/wiki/${encodeURIComponent(value)}`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "wikidata.org") ? segmentAfter(url, "wiki") : null,
+  },
+  tidal: {
+    key: "tidal",
+    label: "TIDAL",
+    kind: "platform_id",
+    wikidataProperty: "P4576",
+    wikidataVariable: "tidal",
+    buildUrl: (value) => `https://tidal.com/browse/artist/${encodeURIComponent(value)}`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "tidal.com")
+        ? matchingValue(segmentAfter(url, "artist"), /^\d+$/)
+        : null,
+  },
+  amazon_music: {
+    key: "amazon_music",
+    label: "Amazon Music",
+    kind: "platform_id",
+    wikidataProperty: "P6276",
+    wikidataVariable: "amazonMusic",
+    buildUrl: (value) => `https://music.amazon.com/artists/${encodeURIComponent(value)}`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "music.amazon.com") ? segmentAfter(url, "artists") : null,
+  },
+  youtube_music: {
+    key: "youtube_music",
+    label: "YouTube Music",
+    kind: "platform_id",
+    wikidataProperty: "P2397",
+    wikidataVariable: "youtubeMusic",
+    buildUrl: (value) => `https://music.youtube.com/channel/${encodeURIComponent(value)}`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "music.youtube.com") ? segmentAfter(url, "channel") : null,
+  },
+  genius: {
+    key: "genius",
+    label: "Genius",
+    kind: "platform_id",
+    wikidataProperty: "P2373",
+    wikidataVariable: "genius",
+    buildUrl: (value) => `https://genius.com/artists/${encodePathValue(value)}`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "genius.com") ? segmentAfter(url, "artists") : null,
+  },
+  allmusic: {
+    key: "allmusic",
+    label: "AllMusic",
+    kind: "platform_id",
+    wikidataProperty: "P1728",
+    wikidataVariable: "allmusic",
+    buildUrl: (value) => `https://www.allmusic.com/artist/${encodeURIComponent(value)}`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "allmusic.com") ? segmentAfter(url, "artist") : null,
+  },
+  billboard: {
+    key: "billboard",
+    label: "Billboard",
+    kind: "platform_id",
+    wikidataProperty: "P4208",
+    wikidataVariable: "billboard",
+    buildUrl: (value) => `https://www.billboard.com/artist/${encodePathValue(value)}/`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "billboard.com") ? segmentAfter(url, "artist") : null,
+  },
+  rolling_stone: {
+    key: "rolling_stone",
+    label: "Rolling Stone",
+    kind: "platform_id",
+    wikidataProperty: "P3017",
+    wikidataVariable: "rollingStone",
+    buildUrl: (value) =>
+      `https://www.rollingstone.com/music/music-artists/${encodePathValue(value)}/`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "rollingstone.com")
+        ? segmentAfter(url, "music-artists")
+        : null,
+  },
+  discogs: {
+    key: "discogs",
+    label: "Discogs",
+    kind: "platform_id",
+    artistColumn: "discogs",
+    wikidataProperty: "P1953",
+    wikidataVariable: "discogs",
+    buildUrl: (value) => `https://www.discogs.com/artist/${encodeURIComponent(value)}`,
+    extractFromUrl: (url) => {
+      if (!hostMatches(url, "discogs.com")) return null;
+      const value = segmentAfter(url, "artist");
+      return matchingValue(value?.split("-")[0] ?? null, /^\d+$/);
+    },
+  },
+  lastfm: {
+    key: "lastfm",
+    label: "Last.fm",
+    kind: "platform_id",
+    artistColumn: "lastfm",
+    wikidataProperty: "P3192",
+    wikidataVariable: "lastfm",
+    buildUrl: (value) => `https://www.last.fm/music/${encodePathValue(value)}`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "last.fm") ? segmentAfter(url, "music") : null,
+  },
+  soundcloud: {
+    key: "soundcloud",
+    label: "SoundCloud",
+    kind: "social_link",
+    artistColumn: "soundcloud",
+    wikidataProperty: "P3040",
+    wikidataVariable: "soundcloud",
+    buildUrl: (value) => `https://soundcloud.com/${encodePathValue(stripAt(value))}`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "soundcloud.com") ? firstPathSegment(url) : null,
+  },
+  imdb: {
+    key: "imdb",
+    label: "IMDb",
+    kind: "platform_id",
+    artistColumn: "imdb",
+    wikidataProperty: "P345",
+    wikidataVariable: "imdb",
+    buildUrl: (value) => `https://www.imdb.com/name/${encodeURIComponent(value)}/`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "imdb.com") ? segmentAfter(url, "name") : null,
+  },
+  youtube_channel: {
+    key: "youtube_channel",
+    label: "YouTube",
+    kind: "social_link",
+    artistColumn: "youtubechannel",
+    wikidataProperty: "P2397",
+    wikidataVariable: "youtube",
+    buildUrl: (value) => `https://www.youtube.com/channel/${encodeURIComponent(value)}`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "youtube.com") ? segmentAfter(url, "channel") : null,
+  },
+  x: {
+    key: "x",
+    label: "X",
+    kind: "social_link",
+    artistColumn: "x",
+    wikidataProperty: "P2002",
+    wikidataVariable: "twitter",
+    buildUrl: (value) => `https://x.com/${encodeURIComponent(stripAt(value))}`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "x.com", "twitter.com") ? firstPathSegment(url) : null,
+  },
+  instagram: {
+    key: "instagram",
+    label: "Instagram",
+    kind: "social_link",
+    artistColumn: "instagram",
+    wikidataProperty: "P2003",
+    wikidataVariable: "instagram",
+    buildUrl: (value) =>
+      `https://www.instagram.com/${encodeURIComponent(stripAt(value))}/`,
+    extractFromUrl: (url) =>
+      hostMatches(url, "instagram.com") ? firstPathSegment(url) : null,
+  },
+  facebook: {
+    key: "facebook",
+    label: "Facebook",
+    kind: "social_link",
+    artistColumn: "facebook",
+    wikidataProperty: "P2013",
+    wikidataVariable: "facebook",
+    buildUrl: (value) =>
+      `https://www.facebook.com/${encodePathValue(stripAt(value))}`,
+    extractFromUrl: (url) => {
+      if (!hostMatches(url, "facebook.com")) return null;
+      const parts = pathParts(url);
+      if (!parts || parts.length !== 1) return null;
+      const username = parts[0];
+      if (
+        !username ||
+        /^(?:profile\.php|people|pages|groups|events|watch|marketplace)$/i.test(
+          username,
+        ) ||
+        /^\d+$/.test(username) ||
+        !/^[A-Za-z0-9.-]+$/.test(username)
+      ) {
+        return null;
+      }
+      return username;
+    },
+  },
+  facebook_id: {
+    key: "facebook_id",
+    label: "Facebook",
+    kind: "social_link",
+    artistColumn: "facebookID",
+    buildUrl: (value) => value,
+    extractFromUrl: (url) => normalizeFacebookIdUrl(url.toString()) || null,
+  },
+  official_website: {
+    key: "official_website",
+    label: "Official website",
+    kind: "official_website",
+    wikidataProperty: "P856",
+    wikidataVariable: "website",
+    buildUrl: (value) => value,
+  },
+};
+
+export const RESEARCH_PLATFORM_REGISTRY = Object.freeze(DEFINITIONS);
+
+export const WIKIDATA_PLATFORM_DEFINITIONS = RESEARCH_PLATFORM_VALUES.map(
+  (platform) => DEFINITIONS[platform],
+).filter(
+  (
+    definition,
+  ): definition is ResearchPlatformDefinition & {
+    wikidataProperty: `P${number}`;
+    wikidataVariable: string;
+  } => Boolean(definition.wikidataProperty && definition.wikidataVariable),
+);
+
+export function isResearchPlatform(value: string): value is ResearchPlatform {
+  return Object.prototype.hasOwnProperty.call(RESEARCH_PLATFORM_REGISTRY, value);
+}
+
+export function getResearchPlatformDefinition(
+  platform: ResearchPlatform,
+): ResearchPlatformDefinition {
+  return RESEARCH_PLATFORM_REGISTRY[platform];
+}
+
+export function normalizeResearchPlatformValue(
+  platform: ResearchPlatform,
+  rawValue: string,
+): string {
+  const value = rawValue.trim();
+  if (!value) return "";
+
+  if (platform === "official_website") {
+    try {
+      const url = new URL(value);
+      return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : "";
+    } catch {
+      return "";
+    }
+  }
+
+  if (platform === "facebook_id") {
+    return normalizeFacebookIdUrl(value);
+  }
+
+  if (platform === "x" || platform === "instagram" || platform === "facebook") {
+    return stripAt(value).toLowerCase();
+  }
+
+  return value;
+}
+
+export function buildResearchPlatformUrl(
+  platform: ResearchPlatform,
+  value: string,
+): string {
+  const normalized = normalizeResearchPlatformValue(platform, value);
+  if (!normalized) return "";
+  return RESEARCH_PLATFORM_REGISTRY[platform].buildUrl(normalized);
+}
+
+export function extractResearchPlatformFromUrl(
+  rawUrl: string,
+): { platform: ResearchPlatform; value: string } | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  for (const platform of RESEARCH_PLATFORM_VALUES) {
+    const definition = RESEARCH_PLATFORM_REGISTRY[platform];
+    const extracted = definition.extractFromUrl?.(url);
+    if (!extracted) continue;
+    const value = normalizeResearchPlatformValue(platform, extracted);
+    if (value) return { platform, value };
+  }
+
+  return null;
+}

--- a/src/lib/artistResearch/platformRegistry.ts
+++ b/src/lib/artistResearch/platformRegistry.ts
@@ -68,6 +68,10 @@ function firstPathSegment(url: URL): string | null {
   return pathParts(url)?.[0] ?? null;
 }
 
+// Wikidata P2397 stores a YouTube channel ID. The same channel ID resolves on
+// both YouTube and YouTube Music, so those platforms intentionally share it.
+const YOUTUBE_CHANNEL_ID_WIKIDATA_PROPERTY = "P2397";
+
 function matchingValue(
   value: string | null,
   pattern: RegExp,
@@ -198,7 +202,7 @@ const DEFINITIONS: Record<ResearchPlatform, ResearchPlatformDefinition> = {
     key: "youtube_music",
     label: "YouTube Music",
     kind: "platform_id",
-    wikidataProperty: "P2397",
+    wikidataProperty: YOUTUBE_CHANNEL_ID_WIKIDATA_PROPERTY,
     wikidataVariable: "youtubeMusic",
     buildUrl: (value) => `https://music.youtube.com/channel/${encodeURIComponent(value)}`,
     extractFromUrl: (url) =>
@@ -299,7 +303,7 @@ const DEFINITIONS: Record<ResearchPlatform, ResearchPlatformDefinition> = {
     label: "YouTube",
     kind: "social_link",
     artistColumn: "youtubechannel",
-    wikidataProperty: "P2397",
+    wikidataProperty: YOUTUBE_CHANNEL_ID_WIKIDATA_PROPERTY,
     wikidataVariable: "youtube",
     buildUrl: (value) => `https://www.youtube.com/channel/${encodeURIComponent(value)}`,
     extractFromUrl: (url) =>

--- a/src/lib/artistResearch/types.ts
+++ b/src/lib/artistResearch/types.ts
@@ -1,0 +1,91 @@
+export const RESEARCH_PLATFORM_VALUES = [
+  "spotify",
+  "deezer",
+  "apple_music",
+  "musicbrainz",
+  "wikidata",
+  "tidal",
+  "amazon_music",
+  "youtube_music",
+  "genius",
+  "allmusic",
+  "billboard",
+  "rolling_stone",
+  "discogs",
+  "lastfm",
+  "soundcloud",
+  "imdb",
+  "youtube_channel",
+  "x",
+  "instagram",
+  "facebook",
+  "facebook_id",
+  "official_website",
+] as const;
+
+export type ResearchPlatform = (typeof RESEARCH_PLATFORM_VALUES)[number];
+
+export const ID_MAPPING_PLATFORM_VALUES = [
+  "spotify",
+  "deezer",
+  "apple_music",
+  "musicbrainz",
+  "wikidata",
+  "tidal",
+  "amazon_music",
+  "youtube_music",
+  "genius",
+  "allmusic",
+  "billboard",
+  "rolling_stone",
+  "discogs",
+  "lastfm",
+  "imdb",
+] as const satisfies readonly ResearchPlatform[];
+
+export const RESEARCH_SOURCE_VALUES = [
+  "wikidata",
+  "musicbrainz",
+  "name_search",
+  "web_search",
+  "manual",
+] as const;
+
+export type ResearchSource = (typeof RESEARCH_SOURCE_VALUES)[number];
+
+export const RESEARCH_CONFIDENCE_VALUES = [
+  "high",
+  "medium",
+  "low",
+  "manual",
+] as const;
+
+export type ResearchConfidence = (typeof RESEARCH_CONFIDENCE_VALUES)[number];
+
+export type ResearchFindingKind =
+  | "platform_id"
+  | "social_link"
+  | "official_website";
+
+export type ResearchEvidence = {
+  type: "entity" | "url" | "name_match" | "identifier";
+  value: string;
+  label?: string;
+};
+
+/**
+ * Source-neutral output shared by deterministic resolvers and the future
+ * asynchronous research worker.
+ *
+ * `value` is the platform-native value (ID, handle, slug, or URL), not a
+ * rendered public URL. The platform registry owns normalization/rendering.
+ */
+export type ResearchFinding = {
+  kind: ResearchFindingKind;
+  platform: ResearchPlatform;
+  value: string;
+  confidence: ResearchConfidence;
+  source: ResearchSource;
+  reasoning?: string;
+  evidence?: ResearchEvidence[];
+};

--- a/src/lib/artistResearch/wikidata.ts
+++ b/src/lib/artistResearch/wikidata.ts
@@ -1,0 +1,253 @@
+import {
+  WIKIDATA_PLATFORM_DEFINITIONS,
+  getResearchPlatformDefinition,
+  normalizeResearchPlatformValue,
+} from "./platformRegistry";
+import type { ResearchFinding, ResearchPlatform } from "./types";
+
+const WIKIDATA_ENDPOINT = "https://query.wikidata.org/sparql";
+const WIKIDATA_ENTITY_PREFIX = "http://www.wikidata.org/entity/";
+
+export type WikidataLookupSourcePlatform = "spotify" | "deezer";
+
+export const ARTIST_RESEARCH_USER_AGENT =
+  "MusicNerdWeb/1.0 (https://musicnerd.xyz; contact@musicnerd.xyz)";
+
+export type WikidataBindingValue = {
+  type?: string;
+  value?: string;
+};
+
+export type WikidataBinding = Record<string, WikidataBindingValue | undefined>;
+
+export type WikidataEntityMatch = {
+  entityId: string;
+  values: Partial<Record<ResearchPlatform, string[]>>;
+};
+
+export type ParsedWikidataResults = {
+  matches: Map<string, WikidataEntityMatch>;
+  ambiguous: Map<string, string[]>;
+};
+
+export type WikidataFindingAmbiguity = {
+  platform: ResearchPlatform;
+  values: string[];
+};
+
+export type WikidataFindingsResult = {
+  findings: ResearchFinding[];
+  ambiguities: WikidataFindingAmbiguity[];
+};
+
+function isSafeWikidataLookupId(
+  value: string,
+  sourcePlatform?: WikidataLookupSourcePlatform,
+): boolean {
+  if (sourcePlatform === "spotify") return /^[A-Za-z0-9]+$/.test(value);
+  if (sourcePlatform === "deezer") return /^\d+$/.test(value);
+  return /^[A-Za-z0-9._:-]+$/.test(value);
+}
+
+function extractEntityId(value: string | undefined): string | null {
+  if (!value) return null;
+  const entityId = value.replace(WIKIDATA_ENTITY_PREFIX, "");
+  return /^Q\d+$/.test(entityId) ? entityId : null;
+}
+
+export function filterSafeWikidataLookupIds(
+  ids: readonly string[],
+  sourcePlatform?: WikidataLookupSourcePlatform,
+): string[] {
+  return [
+    ...new Set(
+      ids
+        .map((id) => id.trim())
+        .filter((id) => isSafeWikidataLookupId(id, sourcePlatform)),
+    ),
+  ];
+}
+
+export function buildWikidataArtistQuery(
+  sourcePlatform: WikidataLookupSourcePlatform,
+  sourceIds: readonly string[],
+  targetPlatforms?: readonly ResearchPlatform[],
+): string {
+  if (sourcePlatform !== "spotify" && sourcePlatform !== "deezer") {
+    throw new Error(`Wikidata lookup is not supported for ${sourcePlatform}`);
+  }
+  const sourceDefinition = getResearchPlatformDefinition(sourcePlatform);
+  if (!sourceDefinition.wikidataProperty) {
+    throw new Error(`Wikidata lookup is not supported for ${sourcePlatform}`);
+  }
+
+  const safeIds = filterSafeWikidataLookupIds(sourceIds, sourcePlatform);
+  if (safeIds.length === 0) {
+    throw new Error("At least one valid source ID is required");
+  }
+
+  const values = safeIds.map((id) => `"${id}"`).join(" ");
+  const targetPlatformSet = targetPlatforms
+    ? new Set<ResearchPlatform>(targetPlatforms)
+    : null;
+  const targetDefinitions = targetPlatformSet
+    ? WIKIDATA_PLATFORM_DEFINITIONS.filter((definition) =>
+        targetPlatformSet.has(definition.key),
+      )
+    : WIKIDATA_PLATFORM_DEFINITIONS;
+  const selectVariables = targetDefinitions.map(
+    ({ wikidataVariable }) => `?${wikidataVariable}`,
+  ).join(" ");
+  const optionals = targetDefinitions.map(
+    ({ wikidataProperty, wikidataVariable }) =>
+      `  OPTIONAL { ?item wdt:${wikidataProperty} ?${wikidataVariable} }`,
+  ).join("\n");
+
+  return `
+SELECT ?item ?sourceId ${selectVariables}
+WHERE {
+  VALUES ?sourceId { ${values} }
+  ?item wdt:${sourceDefinition.wikidataProperty} ?sourceId .
+${optionals}
+}`.trim();
+}
+
+export function parseWikidataArtistBindings(
+  bindings: readonly WikidataBinding[],
+): ParsedWikidataResults {
+  const grouped = new Map<
+    string,
+    {
+      entities: Set<string>;
+      values: Map<ResearchPlatform, Set<string>>;
+    }
+  >();
+
+  for (const row of bindings) {
+    const sourceId = row.sourceId?.value;
+    const entityId = extractEntityId(row.item?.value);
+    if (!sourceId || !entityId) continue;
+
+    let entry = grouped.get(sourceId);
+    if (!entry) {
+      entry = { entities: new Set(), values: new Map() };
+      grouped.set(sourceId, entry);
+    }
+    entry.entities.add(entityId);
+
+    for (const definition of WIKIDATA_PLATFORM_DEFINITIONS) {
+      const value = row[definition.wikidataVariable]?.value;
+      if (!value) continue;
+      let platformValues = entry.values.get(definition.key);
+      if (!platformValues) {
+        platformValues = new Set();
+        entry.values.set(definition.key, platformValues);
+      }
+      platformValues.add(value);
+    }
+  }
+
+  const matches = new Map<string, WikidataEntityMatch>();
+  const ambiguous = new Map<string, string[]>();
+
+  for (const [sourceId, entry] of grouped) {
+    if (entry.entities.size !== 1) {
+      ambiguous.set(sourceId, [...entry.entities]);
+      continue;
+    }
+
+    const entityId = [...entry.entities][0];
+    const values: Partial<Record<ResearchPlatform, string[]>> = {
+      wikidata: [entityId],
+    };
+    for (const [platform, platformValues] of entry.values) {
+      values[platform] = [...platformValues];
+    }
+    matches.set(sourceId, { entityId, values });
+  }
+
+  return { matches, ambiguous };
+}
+
+export async function lookupWikidataArtists(params: {
+  sourcePlatform: WikidataLookupSourcePlatform;
+  sourceIds: readonly string[];
+  targetPlatforms?: readonly ResearchPlatform[];
+  fetchImpl?: typeof fetch;
+}): Promise<ParsedWikidataResults> {
+  const {
+    sourcePlatform,
+    sourceIds,
+    targetPlatforms,
+    fetchImpl = fetch,
+  } = params;
+  const query = buildWikidataArtistQuery(
+    sourcePlatform,
+    sourceIds,
+    targetPlatforms,
+  );
+  const response = await fetchImpl(WIKIDATA_ENDPOINT, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "User-Agent": ARTIST_RESEARCH_USER_AGENT,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: `query=${encodeURIComponent(query)}`,
+    signal: AbortSignal.timeout(30_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Wikidata SPARQL error: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const data = (await response.json()) as {
+    results?: { bindings?: WikidataBinding[] };
+  };
+  return parseWikidataArtistBindings(data.results?.bindings ?? []);
+}
+
+export function wikidataMatchToFindings(params: {
+  match: WikidataEntityMatch;
+  sourcePlatform?: ResearchPlatform;
+}): WikidataFindingsResult {
+  const { match, sourcePlatform } = params;
+  const findings: ResearchFinding[] = [];
+  const ambiguities: WikidataFindingAmbiguity[] = [];
+
+  for (const [platform, values] of Object.entries(match.values) as [
+    ResearchPlatform,
+    string[],
+  ][]) {
+    if (platform === sourcePlatform || values.length === 0) continue;
+    const normalizedValues = [
+      ...new Set(
+        values
+          .map((value) => normalizeResearchPlatformValue(platform, value))
+          .filter(Boolean),
+      ),
+    ];
+    if (normalizedValues.length === 0) continue;
+    if (normalizedValues.length > 1) {
+      ambiguities.push({ platform, values: normalizedValues });
+      continue;
+    }
+    const definition = getResearchPlatformDefinition(platform);
+    const value = normalizedValues[0];
+    findings.push({
+      kind: definition.kind,
+      platform,
+      value,
+      confidence: "high",
+      source: "wikidata",
+      reasoning: `Found on Wikidata entity ${match.entityId}`,
+      evidence: [
+        { type: "entity", value: match.entityId, label: "Wikidata entity" },
+      ],
+    });
+  }
+
+  return { findings, ambiguities };
+}

--- a/src/server/utils/__tests__/artistLinkService.test.ts
+++ b/src/server/utils/__tests__/artistLinkService.test.ts
@@ -17,8 +17,8 @@ describe("artistLinkService", () => {
     // Mock artist existence check - return a found artist by default
     (db as any).query.artists.findFirst = jest.fn().mockResolvedValue({ id: "artist-123", name: "Test Artist" });
     const { regenerateArtistBio } = await import("@/server/utils/queries/artistBioQuery");
-    const { setArtistLink, clearArtistLink, sanitizeColumnName, BIO_RELEVANT_COLUMNS } = await import("../artistLinkService");
-    return { db, setArtistLink, clearArtistLink, sanitizeColumnName, BIO_RELEVANT_COLUMNS, regenerateArtistBio };
+    const { setArtistLink, clearArtistLink, writeArtistLinkValue, sanitizeColumnName, BIO_RELEVANT_COLUMNS } = await import("../artistLinkService");
+    return { db, setArtistLink, clearArtistLink, writeArtistLinkValue, sanitizeColumnName, BIO_RELEVANT_COLUMNS, regenerateArtistBio };
   }
 
   // 1. sanitizeColumnName strips non-alphanumeric/underscore
@@ -173,5 +173,123 @@ describe("artistLinkService", () => {
     (db as any).query.artists.findFirst.mockResolvedValue({ id: "artist-123", x: "old-handle" });
     const result = await clearArtistLink("artist-123", "x");
     expect(result).toEqual({ oldValue: "old-handle" });
+  });
+
+  it("research fill_empty mode preserves a populated artist link", async () => {
+    const { db, writeArtistLinkValue, regenerateArtistBio } = await setup();
+    (db as any).query.artists.findFirst.mockResolvedValue({
+      id: "artist-123",
+      name: "Test Artist",
+      instagram: "curated-handle",
+    });
+
+    const result = await writeArtistLinkValue({
+      database: db,
+      artistId: "artist-123",
+      siteName: "instagram",
+      value: "research-handle",
+      mode: "fill_empty",
+      bioMode: "preserve",
+    });
+
+    expect(result.status).toBe("conflict");
+    expect(result.oldValue).toBe("curated-handle");
+    expect(db.execute).not.toHaveBeenCalled();
+    expect(regenerateArtistBio).not.toHaveBeenCalled();
+  });
+
+  it("research fill_empty mode writes an empty link without bio work", async () => {
+    const { db, writeArtistLinkValue, regenerateArtistBio } = await setup();
+    db.execute = jest.fn().mockResolvedValue([{ id: "artist-123" }]);
+
+    const result = await writeArtistLinkValue({
+      database: db,
+      artistId: "artist-123",
+      siteName: "instagram",
+      value: "research-handle",
+      mode: "fill_empty",
+      bioMode: "preserve",
+    });
+
+    expect(result.status).toBe("written");
+    expect(db.execute).toHaveBeenCalledTimes(1);
+    expect(regenerateArtistBio).not.toHaveBeenCalled();
+  });
+
+  it("research fill_empty mode does not overwrite a concurrent link write", async () => {
+    const { db, writeArtistLinkValue } = await setup();
+    (db as any).query.artists.findFirst
+      .mockResolvedValueOnce({
+        id: "artist-123",
+        name: "Test Artist",
+        instagram: null,
+      })
+      .mockResolvedValueOnce({
+        id: "artist-123",
+        name: "Test Artist",
+        instagram: "concurrent-handle",
+      });
+    db.execute = jest.fn().mockResolvedValue([]);
+
+    const result = await writeArtistLinkValue({
+      database: db,
+      artistId: "artist-123",
+      siteName: "instagram",
+      value: "research-handle",
+      mode: "fill_empty",
+      bioMode: "preserve",
+    });
+
+    expect(result).toEqual({
+      oldValue: "concurrent-handle",
+      artistName: "Test Artist",
+      status: "conflict",
+    });
+  });
+
+  it("research can replace the exact value mirrored by an older mapping", async () => {
+    const { db, writeArtistLinkValue } = await setup();
+    (db as any).query.artists.findFirst.mockResolvedValue({
+      id: "artist-123",
+      name: "Test Artist",
+      spotify: "older-mirrored-id",
+    });
+    db.execute = jest.fn().mockResolvedValue([{ id: "artist-123" }]);
+
+    const result = await writeArtistLinkValue({
+      database: db,
+      artistId: "artist-123",
+      siteName: "spotify",
+      value: "stronger-id",
+      mode: "fill_empty",
+      bioMode: "preserve",
+      replaceIfValue: "older-mirrored-id",
+    });
+
+    expect(result.status).toBe("written");
+    expect(result.oldValue).toBe("older-mirrored-id");
+    expect(db.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("research does not replace a value that diverged from the older mapping", async () => {
+    const { db, writeArtistLinkValue } = await setup();
+    (db as any).query.artists.findFirst.mockResolvedValue({
+      id: "artist-123",
+      name: "Test Artist",
+      spotify: "curated-id",
+    });
+
+    const result = await writeArtistLinkValue({
+      database: db,
+      artistId: "artist-123",
+      siteName: "spotify",
+      value: "stronger-id",
+      mode: "fill_empty",
+      bioMode: "preserve",
+      replaceIfValue: "older-mirrored-id",
+    });
+
+    expect(result.status).toBe("conflict");
+    expect(db.execute).not.toHaveBeenCalled();
   });
 });

--- a/src/server/utils/__tests__/idMappingService.test.ts
+++ b/src/server/utils/__tests__/idMappingService.test.ts
@@ -8,7 +8,7 @@ describe("idMappingService", () => {
 
   async function setup() {
     const { db } = await import("@/server/db/drizzle");
-    db.execute = jest.fn().mockResolvedValue([]);
+    db.execute = jest.fn().mockResolvedValue([{ id: "mapping-1" }]);
     (db as any).query.artists = {
       findFirst: jest.fn().mockResolvedValue({ id: "artist-123" }),
       findMany: jest.fn(),
@@ -151,6 +151,27 @@ describe("idMappingService", () => {
     expect(db.execute).toHaveBeenCalled();
   });
 
+  it("accepts spotify as a mapping target", async () => {
+    const { resolveArtistMapping, VALID_MAPPING_PLATFORMS } = await setup();
+    expect(VALID_MAPPING_PLATFORMS.has("spotify")).toBe(true);
+    expect(VALID_MAPPING_PLATFORMS.has("instagram")).toBe(false);
+    expect(VALID_MAPPING_PLATFORMS.has("official_website")).toBe(false);
+
+    await expect(
+      resolveArtistMapping({
+        artistId: "artist-123",
+        platform: "spotify",
+        platformId: "6vWDO969PvNqNYHIOW5v0m",
+        confidence: "high",
+        source: "wikidata",
+      }),
+    ).resolves.toEqual({
+      created: true,
+      updated: false,
+      skipped: false,
+    });
+  });
+
   it("creates new mapping", async () => {
     const { db, resolveArtistMapping } = await setup();
     const result = await resolveArtistMapping({
@@ -202,6 +223,70 @@ describe("idMappingService", () => {
     expect(result.previousMapping).toEqual({ platformId: "existing-id", confidence: "manual" });
   });
 
+  it("does not let a delayed lower-confidence update overwrite a stronger concurrent write", async () => {
+    const { db, resolveArtistMapping } = await setup();
+    (db as any).query.artistIdMappings.findFirst
+      .mockResolvedValueOnce({
+        artistId: "artist-123",
+        platformId: "initial-low",
+        confidence: "low",
+      })
+      .mockResolvedValueOnce({
+        artistId: "artist-123",
+        platformId: "concurrent-high",
+        confidence: "high",
+      });
+    db.execute = jest.fn().mockResolvedValue([]);
+
+    const result = await resolveArtistMapping({
+      artistId: "artist-123",
+      platform: "deezer",
+      platformId: "delayed-medium",
+      confidence: "medium",
+      source: "musicbrainz",
+    });
+
+    expect(result).toEqual({
+      created: false,
+      updated: false,
+      skipped: true,
+      previousMapping: {
+        platformId: "concurrent-high",
+        confidence: "high",
+      },
+    });
+  });
+
+  it("arbitrates confidence after a concurrent insert", async () => {
+    const { db, resolveArtistMapping } = await setup();
+    (db as any).query.artistIdMappings.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        artistId: "artist-123",
+        platformId: "concurrent-manual",
+        confidence: "manual",
+      });
+    db.execute = jest.fn().mockResolvedValue([]);
+
+    const result = await resolveArtistMapping({
+      artistId: "artist-123",
+      platform: "deezer",
+      platformId: "incoming-high",
+      confidence: "high",
+      source: "wikidata",
+    });
+
+    expect(result).toEqual({
+      created: false,
+      updated: false,
+      skipped: true,
+      previousMapping: {
+        platformId: "concurrent-manual",
+        confidence: "manual",
+      },
+    });
+  });
+
   // getUnmappedArtists
   it("returns unmapped artists for valid platform", async () => {
     const { db, getUnmappedArtists } = await setup();
@@ -232,7 +317,7 @@ describe("idMappingService", () => {
     expect(stats.totalArtistsWithSpotify).toBe(100);
     expect(stats.totalArtistsWithDeezer).toBe(390);
     // All valid platforms should be present
-    expect(stats.platformStats).toHaveLength(11);
+    expect(stats.platformStats).toHaveLength(15);
     const deezer = stats.platformStats.find(s => s.platform === "deezer");
     expect(deezer.mappedCount).toBe(50);
     expect(deezer.percentage).toBe(50);

--- a/src/server/utils/artistLinkService.ts
+++ b/src/server/utils/artistLinkService.ts
@@ -29,6 +29,15 @@ const ARTIST_ROW_PROPERTY_BY_COLUMN: Record<string, string> = {
   tiktokID: "tiktokId",
 };
 
+export type ArtistLinkExecutor = Pick<typeof db, "query" | "execute">;
+export type ArtistLinkWriteMode = "overwrite" | "fill_empty";
+export type ArtistLinkBioMode = "invalidate" | "preserve";
+export type ArtistLinkWriteResult = {
+  oldValue: string | null;
+  artistName: string | null;
+  status: "written" | "unchanged" | "conflict";
+};
+
 export function sanitizeColumnName(siteName: string): string {
   return siteName.replace(/[^a-zA-Z0-9_]/g, "");
 }
@@ -50,38 +59,144 @@ function getArtistLinkValue(artist: object, columnName: string): string | null {
   return ((artist as Record<string, unknown>)[propertyName] as string | null | undefined) ?? null;
 }
 
+/**
+ * Transaction-aware primitive for artist link/ID columns.
+ *
+ * Existing edit flows use overwrite + invalidate. Automated research uses
+ * fill_empty + preserve so it cannot replace curated data or trigger content
+ * work that is outside the research phase.
+ */
+export async function writeArtistLinkValue(params: {
+  database: ArtistLinkExecutor;
+  artistId: string;
+  siteName: string;
+  value: string;
+  mode: ArtistLinkWriteMode;
+  bioMode: ArtistLinkBioMode;
+  replaceIfValue?: string;
+}): Promise<ArtistLinkWriteResult> {
+  const {
+    database,
+    artistId,
+    siteName,
+    value,
+    mode,
+    bioMode,
+    replaceIfValue,
+  } = params;
+  const columnName = sanitizeColumnName(siteName);
+  assertWritable(columnName);
+
+  const artist = await database.query.artists.findFirst({
+    where: eq(artists.id, artistId),
+  });
+  if (!artist) {
+    throw new Error(`Artist not found: ${artistId}`);
+  }
+  if (!value) {
+    throw new Error("Value must not be empty");
+  }
+
+  const oldValue = getArtistLinkValue(artist, columnName);
+  const hasExistingValue = Boolean(oldValue?.trim());
+  if (mode === "fill_empty" && hasExistingValue) {
+    if (oldValue === value) {
+      return {
+        oldValue,
+        artistName: artist.name ?? null,
+        status: "unchanged",
+      };
+    }
+    if (replaceIfValue === undefined || oldValue !== replaceIfValue) {
+      return {
+        oldValue,
+        artistName: artist.name ?? null,
+        status: "conflict",
+      };
+    }
+  }
+
+  const shouldInvalidateBio =
+    bioMode === "invalidate" && BIO_RELEVANT_COLUMNS.includes(columnName);
+  if (mode === "fill_empty") {
+    const canReplaceExpectedValue = replaceIfValue !== undefined;
+    const writtenRows = shouldInvalidateBio
+      ? await database.execute<{ id: string }>(
+          sql`UPDATE artists
+              SET ${sql.identifier(columnName)} = ${value}, bio = NULL
+              WHERE id = ${artistId}
+                AND (
+                  ${sql.identifier(columnName)} IS NULL
+                  OR BTRIM(${sql.identifier(columnName)}) = ''
+                  OR (${canReplaceExpectedValue} AND ${sql.identifier(columnName)} = ${replaceIfValue ?? ""})
+                )
+              RETURNING id`,
+        )
+      : await database.execute<{ id: string }>(
+          sql`UPDATE artists
+              SET ${sql.identifier(columnName)} = ${value}
+              WHERE id = ${artistId}
+                AND (
+                  ${sql.identifier(columnName)} IS NULL
+                  OR BTRIM(${sql.identifier(columnName)}) = ''
+                  OR (${canReplaceExpectedValue} AND ${sql.identifier(columnName)} = ${replaceIfValue ?? ""})
+                )
+              RETURNING id`,
+        );
+
+    if (writtenRows.length === 0) {
+      // A concurrent write populated the field after the read above. Re-read
+      // rather than overwriting it.
+      const latestArtist = await database.query.artists.findFirst({
+        where: eq(artists.id, artistId),
+      });
+      if (!latestArtist) {
+        throw new Error(`Artist not found: ${artistId}`);
+      }
+      const latestValue = getArtistLinkValue(latestArtist, columnName);
+      return {
+        oldValue: latestValue,
+        artistName: latestArtist.name ?? null,
+        status: latestValue === value ? "unchanged" : "conflict",
+      };
+    }
+  } else if (shouldInvalidateBio) {
+    await database.execute(
+      sql`UPDATE artists SET ${sql.identifier(columnName)} = ${value}, bio = NULL WHERE id = ${artistId}`,
+    );
+  } else {
+    await database.execute(
+      sql`UPDATE artists SET ${sql.identifier(columnName)} = ${value} WHERE id = ${artistId}`,
+    );
+  }
+
+  return {
+    oldValue,
+    artistName: artist.name ?? null,
+    status: "written",
+  };
+}
+
 export async function setArtistLink(
   artistId: string,
   siteName: string,
   value: string
 ): Promise<{ oldValue: string | null; artistName: string | null }> {
   const columnName = sanitizeColumnName(siteName);
-  assertWritable(columnName);
-
-  // Fetch full row to capture oldValue for audit trail (MCP callers use the return value)
-  const artist = await db.query.artists.findFirst({
-    where: eq(artists.id, artistId),
+  const result = await writeArtistLinkValue({
+    database: db,
+    artistId,
+    siteName: columnName,
+    value,
+    mode: "overwrite",
+    bioMode: "invalidate",
   });
-  if (!artist) {
-    throw new Error(`Artist not found: ${artistId}`);
-  }
 
-  if (!value) {
-    throw new Error("Value must not be empty");
-  }
-
-  // Safe: assertWritable() above guarantees columnName is a known text column from the whitelist
-  const oldValue = getArtistLinkValue(artist, columnName);
-
-  // For bio-relevant columns, set value and null bio in a single statement
   if (BIO_RELEVANT_COLUMNS.includes(columnName)) {
-    await db.execute(sql`UPDATE artists SET ${sql.identifier(columnName)} = ${value}, bio = NULL WHERE id = ${artistId}`);
     regenerateArtistBio(artistId).catch((e) => console.error("[artistLinkService] Bio regen failed", e));
-  } else {
-    await db.execute(sql`UPDATE artists SET ${sql.identifier(columnName)} = ${value} WHERE id = ${artistId}`);
   }
 
-  return { oldValue, artistName: artist.name ?? null };
+  return { oldValue: result.oldValue, artistName: result.artistName };
 }
 
 export async function clearArtistLink(

--- a/src/server/utils/artistResearch/__tests__/applyResearchFindings.test.ts
+++ b/src/server/utils/artistResearch/__tests__/applyResearchFindings.test.ts
@@ -1,0 +1,447 @@
+// @ts-nocheck
+import { jest } from "@jest/globals";
+
+jest.mock("@/server/utils/queries/artistBioQuery", () => ({
+  regenerateArtistBio: jest.fn().mockResolvedValue("unused"),
+}));
+
+describe("applyResearchFindings", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  async function setup(artist = {
+    id: "artist-123",
+    name: "Test Artist",
+    spotify: null,
+    deezer: "145",
+    instagram: null,
+  }) {
+    const { db } = await import("@/server/db/drizzle");
+    db.execute = jest.fn().mockResolvedValue([{}]);
+    db.query.artists.findFirst = jest.fn().mockResolvedValue(artist);
+    db.query.artistIdMappings.findFirst = jest.fn().mockResolvedValue(null);
+
+    let rolledBack = false;
+    db.transaction = jest.fn(async (callback) => {
+      try {
+        return await callback(db);
+      } catch (error) {
+        rolledBack = true;
+        throw error;
+      }
+    });
+
+    const { applyResearchFindings } = await import("../applyResearchFindings");
+    const { regenerateArtistBio } = await import(
+      "@/server/utils/queries/artistBioQuery"
+    );
+    return {
+      db,
+      applyResearchFindings,
+      regenerateArtistBio,
+      wasRolledBack: () => rolledBack,
+    };
+  }
+
+  const spotifyFinding = {
+    kind: "platform_id",
+    platform: "spotify",
+    value: "6vWDO969PvNqNYHIOW5v0m",
+    confidence: "high",
+    source: "wikidata",
+  };
+
+  it("atomically creates a Spotify mapping and fills artists.spotify", async () => {
+    const { db, applyResearchFindings, regenerateArtistBio } = await setup();
+
+    const result = await applyResearchFindings({
+      artistId: "artist-123",
+      findings: [spotifyFinding],
+    });
+
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(db.execute).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(
+      expect.objectContaining({
+        appliedCount: 1,
+        conflictCount: 0,
+        errorCount: 0,
+      }),
+    );
+    expect(result.results[0]).toEqual(
+      expect.objectContaining({
+        status: "applied",
+        mutated: true,
+        winningValue: "6vWDO969PvNqNYHIOW5v0m",
+        mapping: expect.objectContaining({ created: true }),
+        artistField: expect.objectContaining({
+          column: "spotify",
+          status: "written",
+        }),
+      }),
+    );
+    expect(regenerateArtistBio).not.toHaveBeenCalled();
+  });
+
+  it("rolls back both sides when a populated artist column conflicts", async () => {
+    const { applyResearchFindings, wasRolledBack } = await setup({
+      id: "artist-123",
+      name: "Test Artist",
+      spotify: "existing-spotify-id",
+      deezer: "145",
+      instagram: null,
+    });
+
+    const result = await applyResearchFindings({
+      artistId: "artist-123",
+      findings: [spotifyFinding],
+    });
+
+    expect(wasRolledBack()).toBe(true);
+    expect(result.results[0]).toEqual(
+      expect.objectContaining({
+        status: "conflict",
+        mutated: false,
+        conflict: {
+          reason: "existing_artist_value",
+          field: "spotify",
+          existingValue: "existing-spotify-id",
+        },
+      }),
+    );
+  });
+
+  it("reports the other artist that already owns a Spotify ID", async () => {
+    const { db, applyResearchFindings, wasRolledBack } = await setup();
+    db.query.artists.findFirst
+      .mockResolvedValueOnce({ id: "artist-123", spotify: null })
+      .mockResolvedValueOnce({ id: "other-artist" })
+      .mockResolvedValue({ id: "artist-123", spotify: null });
+
+    const result = await applyResearchFindings({
+      artistId: "artist-123",
+      findings: [spotifyFinding],
+    });
+
+    expect(result.results[0]).toEqual(
+      expect.objectContaining({
+        status: "conflict",
+        conflict: {
+          reason: "platform_id_owned_by_another_artist",
+          conflictingArtistId: "other-artist",
+        },
+      }),
+    );
+    expect(wasRolledBack()).toBe(true);
+    expect(db.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("classifies a concurrent artist-column unique violation as a conflict", async () => {
+    const { db, applyResearchFindings, wasRolledBack } = await setup();
+    const uniqueError = Object.assign(new Error("duplicate key"), {
+      code: "23505",
+      constraint: "artists_spotify_uniq",
+    });
+    db.execute
+      .mockResolvedValueOnce([{ id: "mapping-1" }])
+      .mockRejectedValueOnce(uniqueError);
+
+    const result = await applyResearchFindings({
+      artistId: "artist-123",
+      findings: [spotifyFinding],
+    });
+
+    expect(wasRolledBack()).toBe(true);
+    expect(result.results[0]).toEqual(
+      expect.objectContaining({
+        status: "conflict",
+        mutated: false,
+        conflict: {
+          reason: "platform_id_owned_by_another_artist",
+        },
+      }),
+    );
+  });
+
+  it("uses the higher-confidence existing mapping to repair an empty mirror", async () => {
+    const { db, applyResearchFindings } = await setup();
+    db.query.artistIdMappings.findFirst
+      .mockResolvedValueOnce({
+        artistId: "artist-123",
+        platform: "spotify",
+        platformId: "trusted-existing-id",
+        confidence: "manual",
+      });
+
+    const result = await applyResearchFindings({
+      artistId: "artist-123",
+      findings: [spotifyFinding],
+    });
+
+    expect(result.results[0]).toEqual(
+      expect.objectContaining({
+        status: "applied",
+        winningValue: "trusted-existing-id",
+        mapping: expect.objectContaining({ skipped: true }),
+        artistField: expect.objectContaining({ status: "written" }),
+      }),
+    );
+    // Mapping was skipped; only the artist mirror was written.
+    expect(db.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("atomically upgrades the exact artist-column mirror with a stronger mapping", async () => {
+    const { db, applyResearchFindings, wasRolledBack } = await setup({
+      id: "artist-123",
+      name: "Test Artist",
+      spotify: "older-mirrored-id",
+      deezer: "145",
+      instagram: null,
+    });
+    db.query.artistIdMappings.findFirst.mockResolvedValueOnce({
+      artistId: "artist-123",
+      platform: "spotify",
+      platformId: "older-mirrored-id",
+      confidence: "low",
+    });
+
+    const result = await applyResearchFindings({
+      artistId: "artist-123",
+      findings: [spotifyFinding],
+    });
+
+    expect(wasRolledBack()).toBe(false);
+    expect(result.results[0]).toEqual(
+      expect.objectContaining({
+        status: "applied",
+        winningValue: spotifyFinding.value,
+        mapping: expect.objectContaining({
+          updated: true,
+          previousMapping: {
+            platformId: "older-mirrored-id",
+            confidence: "low",
+          },
+        }),
+        artistField: expect.objectContaining({ status: "written" }),
+      }),
+    );
+    expect(db.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not replace an existing mirror with an equal-confidence candidate", async () => {
+    const { db, applyResearchFindings, wasRolledBack } = await setup({
+      id: "artist-123",
+      name: "Test Artist",
+      spotify: "existing-high-id",
+      deezer: "145",
+      instagram: null,
+    });
+    db.query.artistIdMappings.findFirst.mockResolvedValueOnce({
+      artistId: "artist-123",
+      platform: "spotify",
+      platformId: "existing-high-id",
+      confidence: "high",
+    });
+
+    const result = await applyResearchFindings({
+      artistId: "artist-123",
+      findings: [spotifyFinding],
+    });
+
+    expect(wasRolledBack()).toBe(true);
+    expect(result.results[0]).toEqual(
+      expect.objectContaining({
+        status: "conflict",
+        mutated: false,
+        conflict: {
+          reason: "existing_artist_value",
+          field: "spotify",
+          existingValue: "existing-high-id",
+        },
+      }),
+    );
+    // The mapping update was attempted inside the transaction and rolled back.
+    expect(db.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues after one finding conflicts", async () => {
+    const { applyResearchFindings } = await setup({
+      id: "artist-123",
+      name: "Test Artist",
+      spotify: "existing-spotify-id",
+      deezer: "145",
+      instagram: null,
+    });
+
+    const result = await applyResearchFindings({
+      artistId: "artist-123",
+      findings: [
+        spotifyFinding,
+        {
+          kind: "social_link",
+          platform: "instagram",
+          value: "@testartist",
+          confidence: "high",
+          source: "wikidata",
+        },
+      ],
+    });
+
+    expect(result.conflictCount).toBe(1);
+    expect(result.appliedCount).toBe(1);
+    expect(result.results[0].status).toBe("conflict");
+    expect(result.results[1]).toEqual(
+      expect.objectContaining({
+        status: "applied",
+        finding: expect.objectContaining({
+          platform: "instagram",
+          value: "testartist",
+        }),
+      }),
+    );
+    expect(result.results[1].mapping).toBeUndefined();
+  });
+
+  it("rejects order-dependent duplicate findings before starting work", async () => {
+    const { db, applyResearchFindings } = await setup();
+
+    await expect(
+      applyResearchFindings({
+        artistId: "artist-123",
+        findings: [
+          spotifyFinding,
+          { ...spotifyFinding, value: "different-id" },
+        ],
+      }),
+    ).rejects.toThrow("Conflicting findings for spotify");
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it("deterministically keeps the strongest equivalent finding", async () => {
+    const { applyResearchFindings } = await setup();
+    const result = await applyResearchFindings({
+      artistId: "artist-123",
+      findings: [
+        {
+          ...spotifyFinding,
+          confidence: "low",
+          source: "web_search",
+          reasoning: "fallback result",
+        },
+        {
+          ...spotifyFinding,
+          confidence: "high",
+          source: "wikidata",
+          reasoning: "deterministic result",
+        },
+      ],
+    });
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].finding).toEqual(
+      expect.objectContaining({
+        confidence: "high",
+        source: "wikidata",
+        reasoning: "deterministic result | fallback result",
+      }),
+    );
+  });
+
+  it("leaves official websites for the research findings store", async () => {
+    const { db, applyResearchFindings } = await setup();
+    const result = await applyResearchFindings({
+      artistId: "artist-123",
+      findings: [
+        {
+          kind: "official_website",
+          platform: "official_website",
+          value: "https://artist.example",
+          confidence: "high",
+          source: "wikidata",
+        },
+      ],
+    });
+
+    expect(result.results[0]).toEqual(
+      expect.objectContaining({
+        status: "skipped",
+        mutated: false,
+        winningValue: "https://artist.example/",
+        skipReason: "no_storage_target",
+      }),
+    );
+    expect(db.transaction).not.toHaveBeenCalled();
+    expect(db.execute).not.toHaveBeenCalled();
+  });
+
+  it("does not let competing websites block a valid platform finding", async () => {
+    const { db, applyResearchFindings } = await setup();
+    const result = await applyResearchFindings({
+      artistId: "artist-123",
+      findings: [
+        {
+          kind: "official_website",
+          platform: "official_website",
+          value: "https://first.example",
+          confidence: "high",
+          source: "wikidata",
+        },
+        {
+          kind: "official_website",
+          platform: "official_website",
+          value: "https://second.example",
+          confidence: "high",
+          source: "musicbrainz",
+        },
+        spotifyFinding,
+      ],
+    });
+
+    expect(result.appliedCount).toBe(1);
+    expect(result.conflictCount).toBe(0);
+    expect(result.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          finding: expect.objectContaining({ platform: "spotify" }),
+          status: "applied",
+        }),
+        expect.objectContaining({
+          finding: expect.objectContaining({
+            value: "https://first.example/",
+          }),
+          status: "skipped",
+          skipReason: "no_storage_target",
+        }),
+        expect.objectContaining({
+          finding: expect.objectContaining({
+            value: "https://second.example/",
+          }),
+          status: "skipped",
+          skipReason: "no_storage_target",
+        }),
+      ]),
+    );
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects unsafe official website values", async () => {
+    const { db, applyResearchFindings } = await setup();
+
+    await expect(
+      applyResearchFindings({
+        artistId: "artist-123",
+        findings: [
+          {
+            kind: "official_website",
+            platform: "official_website",
+            value: "javascript:alert(1)",
+            confidence: "high",
+            source: "wikidata",
+          },
+        ],
+      }),
+    ).rejects.toThrow("Invalid or empty value for official_website");
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/utils/artistResearch/__tests__/applyResearchFindings.test.ts
+++ b/src/server/utils/artistResearch/__tests__/applyResearchFindings.test.ts
@@ -303,19 +303,99 @@ describe("applyResearchFindings", () => {
     expect(result.results[1].mapping).toBeUndefined();
   });
 
-  it("rejects order-dependent duplicate findings before starting work", async () => {
+  it("isolates competing platform values and applies unrelated findings", async () => {
     const { db, applyResearchFindings } = await setup();
 
-    await expect(
-      applyResearchFindings({
-        artistId: "artist-123",
-        findings: [
-          spotifyFinding,
-          { ...spotifyFinding, value: "different-id" },
-        ],
+    const result = await applyResearchFindings({
+      artistId: "artist-123",
+      findings: [
+        {
+          ...spotifyFinding,
+          value: "z-spotify-id",
+          confidence: "low",
+          source: "web_search",
+          reasoning: "fallback candidate",
+          evidence: [
+            {
+              type: "url",
+              value: "https://open.spotify.com/artist/z-spotify-id",
+            },
+          ],
+        },
+        {
+          kind: "social_link",
+          platform: "instagram",
+          value: "@testartist",
+          confidence: "high",
+          source: "wikidata",
+        },
+        {
+          ...spotifyFinding,
+          value: "a-spotify-id",
+          evidence: [{ type: "identifier", value: "a-spotify-id" }],
+        },
+        {
+          ...spotifyFinding,
+          value: "z-spotify-id",
+          source: "musicbrainz",
+          reasoning: "stronger candidate evidence",
+          evidence: [{ type: "identifier", value: "z-spotify-id" }],
+        },
+      ],
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        appliedCount: 1,
+        conflictCount: 1,
+        errorCount: 0,
       }),
-    ).rejects.toThrow("Conflicting findings for spotify");
-    expect(db.transaction).not.toHaveBeenCalled();
+    );
+    expect(result.results[0]).toEqual(
+      expect.objectContaining({
+        finding: expect.objectContaining({
+          platform: "spotify",
+          value: "a-spotify-id",
+        }),
+        status: "conflict",
+        mutated: false,
+        conflict: {
+          reason: "conflicting_findings",
+          candidateValues: ["a-spotify-id", "z-spotify-id"],
+          candidateFindings: [
+            expect.objectContaining({
+              value: "a-spotify-id",
+              evidence: [{ type: "identifier", value: "a-spotify-id" }],
+            }),
+            expect.objectContaining({
+              value: "z-spotify-id",
+              confidence: "high",
+              source: "musicbrainz",
+              reasoning: "fallback candidate | stronger candidate evidence",
+              evidence: expect.arrayContaining([
+                { type: "identifier", value: "z-spotify-id" },
+                {
+                  type: "url",
+                  value: "https://open.spotify.com/artist/z-spotify-id",
+                },
+              ]),
+            }),
+          ],
+        },
+      }),
+    );
+    expect(result.results[1]).toEqual(
+      expect.objectContaining({
+        finding: expect.objectContaining({
+          platform: "instagram",
+          value: "testartist",
+        }),
+        status: "applied",
+      }),
+    );
+    // Only Instagram gets a transaction; neither Spotify candidate is stored.
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(db.execute).toHaveBeenCalledTimes(1);
   });
 
   it("deterministically keeps the strongest equivalent finding", async () => {

--- a/src/server/utils/artistResearch/applyResearchFindings.ts
+++ b/src/server/utils/artistResearch/applyResearchFindings.ts
@@ -30,15 +30,22 @@ import {
 
 type ResearchDatabase = Pick<typeof db, "transaction">;
 
-export type ResearchFindingConflict = {
-  reason:
-    | "existing_artist_value"
-    | "platform_id_owned_by_another_artist"
-    | "mapping_conflict";
-  field?: string;
-  existingValue?: string;
-  conflictingArtistId?: string;
-};
+export type ResearchFindingConflict =
+  | {
+      reason: "existing_artist_value";
+      field: string;
+      existingValue?: string;
+    }
+  | {
+      reason: "platform_id_owned_by_another_artist";
+      conflictingArtistId?: string;
+    }
+  | { reason: "mapping_conflict" }
+  | {
+      reason: "conflicting_findings";
+      candidateValues: string[];
+      candidateFindings: ResearchFinding[];
+    };
 
 export type ApplyResearchFindingResult = {
   finding: ResearchFinding;
@@ -155,12 +162,26 @@ function mergeEquivalentFindings(
   };
 }
 
+type NormalizedResearchWorkItem =
+  | { type: "finding"; finding: ResearchFinding }
+  | {
+      type: "conflict";
+      finding: ResearchFinding;
+      conflict: Extract<
+        ResearchFindingConflict,
+        { reason: "conflicting_findings" }
+      >;
+    };
+
 function validateAndNormalizeFindings(
   findings: readonly ResearchFinding[],
-): ResearchFinding[] {
+): NormalizedResearchWorkItem[] {
   const confidenceValues = new Set<string>(RESEARCH_CONFIDENCE_VALUES);
   const sourceValues = new Set<string>(RESEARCH_SOURCE_VALUES);
-  const byPlatform = new Map<ResearchPlatform, ResearchFinding>();
+  const byPlatform = new Map<
+    ResearchPlatform,
+    Map<string, ResearchFinding>
+  >();
   const withoutStorageByPlatformValue = new Map<string, ResearchFinding>();
 
   for (const finding of findings) {
@@ -201,27 +222,45 @@ function validateAndNormalizeFindings(
       continue;
     }
 
-    const existing = byPlatform.get(finding.platform);
-    if (existing && existing.value !== value) {
-      throw new Error(
-        `Conflicting findings for ${finding.platform}: ${existing.value} and ${value}`,
-      );
-    }
+    const findingsByValue = byPlatform.get(finding.platform) ?? new Map();
+    const existing = findingsByValue.get(value);
     if (existing) {
-      byPlatform.set(
-        finding.platform,
+      findingsByValue.set(
+        value,
         mergeEquivalentFindings(existing, normalizedFinding),
       );
     } else {
-      byPlatform.set(finding.platform, normalizedFinding);
+      findingsByValue.set(value, normalizedFinding);
     }
+    byPlatform.set(finding.platform, findingsByValue);
   }
 
   return [
-    ...byPlatform.values(),
+    ...[...byPlatform.values()].map((findingsByValue) => {
+      const candidateFindings = [...findingsByValue.values()].sort((a, b) =>
+        a.value.localeCompare(b.value),
+      );
+      const finding = candidateFindings[0];
+
+      if (candidateFindings.length === 1) {
+        return { type: "finding" as const, finding };
+      }
+
+      return {
+        type: "conflict" as const,
+        // `finding` remains populated for the existing per-result contract,
+        // but no candidate is selected as a winner or sent to storage.
+        finding,
+        conflict: {
+          reason: "conflicting_findings" as const,
+          candidateValues: candidateFindings.map((candidate) => candidate.value),
+          candidateFindings,
+        },
+      };
+    }),
     ...[...withoutStorageByPlatformValue.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(([, finding]) => finding),
+      .map(([, finding]) => ({ type: "finding" as const, finding })),
   ];
 }
 
@@ -398,14 +437,24 @@ export async function applyResearchFindings(
   },
   database: ResearchDatabase = db,
 ): Promise<ApplyResearchFindingsResult> {
-  const findings = validateAndNormalizeFindings(params.findings);
+  const workItems = validateAndNormalizeFindings(params.findings);
   const results: ApplyResearchFindingResult[] = [];
 
-  for (const finding of findings) {
+  for (const workItem of workItems) {
+    if (workItem.type === "conflict") {
+      results.push({
+        finding: workItem.finding,
+        status: "conflict",
+        mutated: false,
+        conflict: workItem.conflict,
+      });
+      continue;
+    }
+
     results.push(
       await applySingleResearchFinding(
         params.artistId,
-        finding,
+        workItem.finding,
         params.apiKeyHash,
         database,
       ),

--- a/src/server/utils/artistResearch/applyResearchFindings.ts
+++ b/src/server/utils/artistResearch/applyResearchFindings.ts
@@ -1,0 +1,422 @@
+import { eq } from "drizzle-orm";
+
+import {
+  getResearchPlatformDefinition,
+  isResearchPlatform,
+  normalizeResearchPlatformValue,
+} from "@/lib/artistResearch/platformRegistry";
+import {
+  ID_MAPPING_PLATFORM_VALUES,
+  RESEARCH_CONFIDENCE_VALUES,
+  RESEARCH_SOURCE_VALUES,
+  type ResearchConfidence,
+  type ResearchFinding,
+  type ResearchPlatform,
+  type ResearchSource,
+} from "@/lib/artistResearch/types";
+import { db } from "@/server/db/drizzle";
+import { artists } from "@/server/db/schema";
+import {
+  writeArtistLinkValue,
+  type ArtistLinkExecutor,
+  type ArtistLinkWriteResult,
+} from "@/server/utils/artistLinkService";
+import {
+  MappingConflictError,
+  resolveArtistMappingWithExecutor,
+  type MappingExecutor,
+  type ResolveArtistMappingResult,
+} from "@/server/utils/idMappingService";
+
+type ResearchDatabase = Pick<typeof db, "transaction">;
+
+export type ResearchFindingConflict = {
+  reason:
+    | "existing_artist_value"
+    | "platform_id_owned_by_another_artist"
+    | "mapping_conflict";
+  field?: string;
+  existingValue?: string;
+  conflictingArtistId?: string;
+};
+
+export type ApplyResearchFindingResult = {
+  finding: ResearchFinding;
+  status: "applied" | "unchanged" | "skipped" | "conflict" | "error";
+  mutated: boolean;
+  winningValue?: string;
+  mapping?: ResolveArtistMappingResult;
+  artistField?: {
+    column: string;
+    status: ArtistLinkWriteResult["status"];
+    previousValue: string | null;
+  };
+  conflict?: ResearchFindingConflict;
+  skipReason?: "no_storage_target";
+  error?: string;
+};
+
+export type ApplyResearchFindingsResult = {
+  results: ApplyResearchFindingResult[];
+  appliedCount: number;
+  conflictCount: number;
+  errorCount: number;
+};
+
+class ExpectedResearchConflict extends Error {
+  constructor(public readonly details: ResearchFindingConflict) {
+    super(details.reason);
+    this.name = "ExpectedResearchConflict";
+  }
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  for (const candidate of [
+    error,
+    error && typeof error === "object" && "cause" in error
+      ? (error as { cause: unknown }).cause
+      : null,
+  ]) {
+    if (
+      candidate &&
+      typeof candidate === "object" &&
+      "code" in candidate &&
+      (candidate as { code?: unknown }).code === "23505"
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const UNIQUE_ARTIST_ID_COLUMNS = {
+  spotify: artists.spotify,
+  deezer: artists.deezer,
+} as const;
+const RESEARCH_MAPPING_STORAGE_PLATFORMS = new Set<string>(
+  ID_MAPPING_PLATFORM_VALUES,
+);
+const RESEARCH_CONFIDENCE_PRIORITY: Record<ResearchConfidence, number> = {
+  manual: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+const RESEARCH_SOURCE_PRIORITY: Record<ResearchSource, number> = {
+  manual: 5,
+  wikidata: 4,
+  musicbrainz: 3,
+  web_search: 2,
+  name_search: 1,
+};
+
+function mergeEquivalentFindings(
+  left: ResearchFinding,
+  right: ResearchFinding,
+): ResearchFinding {
+  const candidates = [left, right].sort((a, b) => {
+    const confidenceDifference =
+      RESEARCH_CONFIDENCE_PRIORITY[b.confidence] -
+      RESEARCH_CONFIDENCE_PRIORITY[a.confidence];
+    if (confidenceDifference !== 0) return confidenceDifference;
+
+    const sourceDifference =
+      RESEARCH_SOURCE_PRIORITY[b.source] - RESEARCH_SOURCE_PRIORITY[a.source];
+    if (sourceDifference !== 0) return sourceDifference;
+
+    return (a.reasoning ?? "").localeCompare(b.reasoning ?? "");
+  });
+  const winner = candidates[0];
+  const evidenceByKey = new Map(
+    [left, right]
+      .flatMap((finding) => finding.evidence ?? [])
+      .map((evidence) => [
+        `${evidence.type}\u0000${evidence.value}\u0000${evidence.label ?? ""}`,
+        evidence,
+      ]),
+  );
+  const reasoning = [
+    ...new Set(
+      [left.reasoning, right.reasoning].filter(
+        (value): value is string => Boolean(value),
+      ),
+    ),
+  ].sort();
+
+  return {
+    ...winner,
+    reasoning: reasoning.length > 0 ? reasoning.join(" | ") : undefined,
+    evidence:
+      evidenceByKey.size > 0
+        ? [...evidenceByKey.entries()]
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([, evidence]) => evidence)
+        : undefined,
+  };
+}
+
+function validateAndNormalizeFindings(
+  findings: readonly ResearchFinding[],
+): ResearchFinding[] {
+  const confidenceValues = new Set<string>(RESEARCH_CONFIDENCE_VALUES);
+  const sourceValues = new Set<string>(RESEARCH_SOURCE_VALUES);
+  const byPlatform = new Map<ResearchPlatform, ResearchFinding>();
+  const withoutStorageByPlatformValue = new Map<string, ResearchFinding>();
+
+  for (const finding of findings) {
+    if (!isResearchPlatform(finding.platform)) {
+      throw new Error(`Invalid research platform: ${finding.platform}`);
+    }
+    const definition = getResearchPlatformDefinition(finding.platform);
+    if (definition.kind !== finding.kind) {
+      throw new Error(
+        `Invalid finding kind for ${finding.platform}: expected ${definition.kind}`,
+      );
+    }
+    if (!confidenceValues.has(finding.confidence)) {
+      throw new Error(`Invalid confidence level: ${finding.confidence}`);
+    }
+    if (!sourceValues.has(finding.source)) {
+      throw new Error(`Invalid research source: ${finding.source}`);
+    }
+
+    const value = normalizeResearchPlatformValue(
+      finding.platform,
+      finding.value,
+    );
+    if (!value) {
+      throw new Error(`Invalid or empty value for ${finding.platform}`);
+    }
+
+    const normalizedFinding = { ...finding, value };
+    if (definition.kind !== "platform_id" && !definition.artistColumn) {
+      const key = `${finding.platform}\u0000${value}`;
+      const equivalent = withoutStorageByPlatformValue.get(key);
+      withoutStorageByPlatformValue.set(
+        key,
+        equivalent
+          ? mergeEquivalentFindings(equivalent, normalizedFinding)
+          : normalizedFinding,
+      );
+      continue;
+    }
+
+    const existing = byPlatform.get(finding.platform);
+    if (existing && existing.value !== value) {
+      throw new Error(
+        `Conflicting findings for ${finding.platform}: ${existing.value} and ${value}`,
+      );
+    }
+    if (existing) {
+      byPlatform.set(
+        finding.platform,
+        mergeEquivalentFindings(existing, normalizedFinding),
+      );
+    } else {
+      byPlatform.set(finding.platform, normalizedFinding);
+    }
+  }
+
+  return [
+    ...byPlatform.values(),
+    ...[...withoutStorageByPlatformValue.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([, finding]) => finding),
+  ];
+}
+
+async function findUniqueArtistIdOwner(
+  database: MappingExecutor,
+  artistId: string,
+  platform: ResearchPlatform,
+  platformId: string,
+): Promise<string | null> {
+  if (platform !== "spotify" && platform !== "deezer") return null;
+  const column = UNIQUE_ARTIST_ID_COLUMNS[platform];
+  const owner = await database.query.artists.findFirst({
+    where: eq(column, platformId),
+    columns: { id: true },
+  });
+  return owner && owner.id !== artistId ? owner.id : null;
+}
+
+async function applySingleResearchFinding(
+  artistId: string,
+  finding: ResearchFinding,
+  apiKeyHash: string | undefined,
+  database: ResearchDatabase,
+): Promise<ApplyResearchFindingResult> {
+  const definition = getResearchPlatformDefinition(finding.platform);
+  const storesMapping = finding.kind === "platform_id";
+  if (!storesMapping && !definition.artistColumn) {
+    // Official websites are part of the discovery contract, but the existing
+    // globally-unique ID mapping table is not valid storage for shared or
+    // historical websites. A research-run findings store will own them in the
+    // job/status phase.
+    return {
+      finding,
+      status: "skipped",
+      mutated: false,
+      winningValue: finding.value,
+      skipReason: "no_storage_target",
+    };
+  }
+
+  try {
+    return await database.transaction(async (transaction) => {
+      const executor = transaction as MappingExecutor & ArtistLinkExecutor;
+      const mapping = storesMapping
+        ? await resolveArtistMappingWithExecutor(
+            executor,
+            {
+              artistId,
+              platform: finding.platform,
+              platformId: finding.value,
+              confidence: finding.confidence,
+              source: finding.source,
+              reasoning: finding.reasoning,
+              apiKeyHash,
+            },
+            { validPlatforms: RESEARCH_MAPPING_STORAGE_PLATFORMS },
+          )
+        : undefined;
+      const winningValue = mapping?.skipped
+        ? mapping.previousMapping?.platformId ?? finding.value
+        : finding.value;
+
+      let artistField:
+        | ApplyResearchFindingResult["artistField"]
+        | undefined;
+      if (definition.artistColumn) {
+        const artistColumnOwner = await findUniqueArtistIdOwner(
+          executor,
+          artistId,
+          finding.platform,
+          winningValue,
+        );
+        if (artistColumnOwner) {
+          throw new ExpectedResearchConflict({
+            reason: "platform_id_owned_by_another_artist",
+            conflictingArtistId: artistColumnOwner,
+          });
+        }
+
+        const previousConfidence = mapping?.previousMapping?.confidence;
+        const canReplacePreviousMirror =
+          Boolean(mapping?.updated && previousConfidence) &&
+          RESEARCH_CONFIDENCE_PRIORITY[finding.confidence] >
+            (RESEARCH_CONFIDENCE_PRIORITY[
+              previousConfidence as ResearchConfidence
+            ] ?? 0);
+        const fieldResult = await writeArtistLinkValue({
+          database: executor,
+          artistId,
+          siteName: definition.artistColumn,
+          value: winningValue,
+          mode: "fill_empty",
+          bioMode: "preserve",
+          replaceIfValue: canReplacePreviousMirror
+            ? mapping?.previousMapping?.platformId
+            : undefined,
+        });
+        if (fieldResult.status === "conflict") {
+          throw new ExpectedResearchConflict({
+            reason: "existing_artist_value",
+            field: definition.artistColumn,
+            existingValue: fieldResult.oldValue ?? undefined,
+          });
+        }
+        artistField = {
+          column: definition.artistColumn,
+          status: fieldResult.status,
+          previousValue: fieldResult.oldValue,
+        };
+      }
+
+      const mappingMutated = Boolean(mapping?.created || mapping?.updated);
+      const artistFieldMutated = artistField?.status === "written";
+      const mutated = mappingMutated || artistFieldMutated;
+      const status: ApplyResearchFindingResult["status"] = mutated
+        ? "applied"
+        : mapping?.skipped
+          ? "skipped"
+          : "unchanged";
+
+      return {
+        finding,
+        status,
+        mutated,
+        winningValue,
+        mapping,
+        artistField,
+      };
+    });
+  } catch (error) {
+    if (error instanceof ExpectedResearchConflict) {
+      return {
+        finding,
+        status: "conflict",
+        mutated: false,
+        conflict: error.details,
+      };
+    }
+    if (error instanceof MappingConflictError) {
+      return {
+        finding,
+        status: "conflict",
+        mutated: false,
+        conflict: { reason: "mapping_conflict" },
+      };
+    }
+    if (isUniqueViolation(error)) {
+      return {
+        finding,
+        status: "conflict",
+        mutated: false,
+        conflict: { reason: "platform_id_owned_by_another_artist" },
+      };
+    }
+    return {
+      finding,
+      status: "error",
+      mutated: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Applies each finding in its own transaction. A conflict for one platform
+ * cannot roll back successful findings for other platforms, while each
+ * mapping + first-class artist-column mirror remains atomic.
+ */
+export async function applyResearchFindings(
+  params: {
+    artistId: string;
+    findings: readonly ResearchFinding[];
+    apiKeyHash?: string;
+  },
+  database: ResearchDatabase = db,
+): Promise<ApplyResearchFindingsResult> {
+  const findings = validateAndNormalizeFindings(params.findings);
+  const results: ApplyResearchFindingResult[] = [];
+
+  for (const finding of findings) {
+    results.push(
+      await applySingleResearchFinding(
+        params.artistId,
+        finding,
+        params.apiKeyHash,
+        database,
+      ),
+    );
+  }
+
+  return {
+    results,
+    appliedCount: results.filter((result) => result.status === "applied").length,
+    conflictCount: results.filter((result) => result.status === "conflict")
+      .length,
+    errorCount: results.filter((result) => result.status === "error").length,
+  };
+}

--- a/src/server/utils/idMappingService.ts
+++ b/src/server/utils/idMappingService.ts
@@ -5,6 +5,7 @@
 import { db } from "@/server/db/drizzle";
 import { eq, and, sql, asc } from "drizzle-orm";
 import { artists, artistIdMappings, artistMappingExclusions } from "@/server/db/schema";
+import { ID_MAPPING_PLATFORM_VALUES } from "@/lib/artistResearch/types";
 
 export class MappingNotFoundError extends Error {
   constructor(message: string) { super(message); this.name = "MappingNotFoundError"; }
@@ -22,11 +23,9 @@ export class MappingValidationError extends Error {
   constructor(message: string) { super(message); this.name = "MappingValidationError"; }
 }
 
-export const VALID_MAPPING_PLATFORMS = new Set([
-  "deezer", "apple_music", "musicbrainz", "wikidata",
-  "tidal", "amazon_music", "youtube_music",
-  "genius", "allmusic", "billboard", "rolling_stone",
-]);
+export const VALID_MAPPING_PLATFORMS = new Set<string>(
+  ID_MAPPING_PLATFORM_VALUES,
+);
 
 export const VALID_SOURCES = new Set([
   "wikidata", "musicbrainz", "name_search", "web_search", "manual",
@@ -39,6 +38,7 @@ export const VALID_EXCLUSION_REASONS = new Set<ExclusionReason>(EXCLUSION_REASON
 
 export type MappingConfidence = "high" | "medium" | "low" | "manual";
 export type MappingSource = "wikidata" | "musicbrainz" | "name_search" | "web_search" | "manual";
+export type MappingExecutor = Pick<typeof db, "query" | "execute">;
 
 const CONFIDENCE_PRIORITY: Record<string, number> = {
   manual: 4, high: 3, medium: 2, low: 1,
@@ -81,14 +81,20 @@ export async function getUnmappedArtists(
   }
 
   const baseFilter = basePlatform === 'deezer'
-    ? sql`a.deezer IS NOT NULL`
-    : sql`a.spotify IS NOT NULL`;
+    ? sql`a.deezer IS NOT NULL AND BTRIM(a.deezer) <> ''`
+    : sql`a.spotify IS NOT NULL AND BTRIM(a.spotify) <> ''`;
+  // Spotify was added as a reverse-mapping target for Deezer-primary artists.
+  // Do not research artists whose first-class Spotify field is already known.
+  const targetFilter = platform === "spotify"
+    ? sql`(a.spotify IS NULL OR BTRIM(a.spotify) = '')`
+    : sql`true`;
 
   const [countResult, result] = await Promise.all([
     db.execute<{ total: number }>(sql`
       SELECT COUNT(*)::int AS total
       FROM artists a
       WHERE ${baseFilter}
+        AND ${targetFilter}
         AND NOT EXISTS (
           SELECT 1 FROM artist_id_mappings m
           WHERE m.artist_id = a.id AND m.platform = ${platform}
@@ -102,6 +108,7 @@ export async function getUnmappedArtists(
       SELECT a.id, a.name, a.spotify, a.deezer
       FROM artists a
       WHERE ${baseFilter}
+        AND ${targetFilter}
         AND NOT EXISTS (
           SELECT 1 FROM artist_id_mappings m
           WHERE m.artist_id = a.id AND m.platform = ${platform}
@@ -121,7 +128,7 @@ export async function getUnmappedArtists(
   };
 }
 
-export async function resolveArtistMapping(params: {
+export type ResolveArtistMappingParams = {
   artistId: string;
   platform: string;
   platformId: string;
@@ -129,10 +136,28 @@ export async function resolveArtistMapping(params: {
   source: string;
   reasoning?: string;
   apiKeyHash?: string;
-}): Promise<{ created: boolean; updated: boolean; skipped: boolean; previousMapping?: { platformId: string; confidence: string } }> {
-  const { artistId, platform, platformId, confidence, source, reasoning, apiKeyHash } = params;
+};
 
-  if (!VALID_MAPPING_PLATFORMS.has(platform)) {
+export type ResolveArtistMappingResult = {
+  created: boolean;
+  updated: boolean;
+  skipped: boolean;
+  previousMapping?: { platformId: string; confidence: string };
+};
+
+/**
+ * Transaction-aware mapping primitive. Callers that need to atomically mirror
+ * a mapping into an artist column can pass a Drizzle transaction here.
+ */
+export async function resolveArtistMappingWithExecutor(
+  database: MappingExecutor,
+  params: ResolveArtistMappingParams,
+  options: { validPlatforms?: ReadonlySet<string> } = {},
+): Promise<ResolveArtistMappingResult> {
+  const { artistId, platform, platformId, confidence, source, reasoning, apiKeyHash } = params;
+  const validPlatforms = options.validPlatforms ?? VALID_MAPPING_PLATFORMS;
+
+  if (!validPlatforms.has(platform)) {
     throw new MappingValidationError(`Invalid platform: ${platform}`);
   }
   if (!VALID_SOURCES.has(source)) {
@@ -146,7 +171,7 @@ export async function resolveArtistMapping(params: {
   }
 
   // Verify artist exists
-  const artist = await db.query.artists.findFirst({
+  const artist = await database.query.artists.findFirst({
     where: eq(artists.id, artistId),
     columns: { id: true },
   });
@@ -155,58 +180,125 @@ export async function resolveArtistMapping(params: {
   }
 
   // Check for existing mapping on this artist+platform
-  const existing = await db.query.artistIdMappings.findFirst({
+  let existing = await database.query.artistIdMappings.findFirst({
     where: and(eq(artistIdMappings.artistId, artistId), eq(artistIdMappings.platform, platform)),
   });
 
-  if (existing) {
-    const existingPriority = CONFIDENCE_PRIORITY[existing.confidence] ?? 0;
-    const newPriority = CONFIDENCE_PRIORITY[confidence] ?? 0;
-
-    // Equal confidence overwrites intentionally — latest submission wins at the same tier
-    if (newPriority < existingPriority) {
-      return {
-        created: false,
-        updated: false,
-        skipped: true,
-        previousMapping: { platformId: existing.platformId, confidence: existing.confidence },
-      };
-    }
-
+  if (!existing) {
     try {
-      await db.execute(sql`
-        UPDATE artist_id_mappings
-        SET platform_id = ${platformId},
-            confidence = ${confidence}::confidence_level,
-            source = ${source},
-            reasoning = ${reasoning ?? null},
-            api_key_hash = ${apiKeyHash ?? null},
-            resolved_at = now(),
-            updated_at = now()
-        WHERE artist_id = ${artistId} AND platform = ${platform}
+      const inserted = await database.execute<{ id: string }>(sql`
+        INSERT INTO artist_id_mappings (
+          artist_id, platform, platform_id, confidence, source, reasoning, api_key_hash
+        )
+        VALUES (
+          ${artistId}, ${platform}, ${platformId}, ${confidence}::confidence_level,
+          ${source}, ${reasoning ?? null}, ${apiKeyHash ?? null}
+        )
+        ON CONFLICT (artist_id, platform) DO NOTHING
+        RETURNING id
       `);
+      if (inserted.length > 0) {
+        return { created: true, updated: false, skipped: false };
+      }
     } catch (err: unknown) {
       handleUniqueViolation(err, platform, platformId);
     }
 
+    // Another writer inserted this artist+platform after our initial read.
+    // Re-read and arbitrate by confidence instead of surfacing a race error.
+    existing = await database.query.artistIdMappings.findFirst({
+      where: and(
+        eq(artistIdMappings.artistId, artistId),
+        eq(artistIdMappings.platform, platform),
+      ),
+    });
+    if (!existing) {
+      throw new MappingConcurrentWriteError(
+        `A mapping for ${platform} changed concurrently; retry the operation`,
+      );
+    }
+  }
+
+  const existingPriority = CONFIDENCE_PRIORITY[existing.confidence] ?? 0;
+  const newPriority = CONFIDENCE_PRIORITY[confidence] ?? 0;
+  const previousMapping = {
+    platformId: existing.platformId,
+    confidence: existing.confidence,
+  };
+
+  // Equal confidence overwrites intentionally — latest committed submission
+  // wins at the same tier.
+  if (newPriority < existingPriority) {
     return {
       created: false,
-      updated: true,
-      skipped: false,
-      previousMapping: { platformId: existing.platformId, confidence: existing.confidence },
+      updated: false,
+      skipped: true,
+      previousMapping,
     };
   }
 
+  let updated: { id: string }[];
   try {
-    await db.execute(sql`
-      INSERT INTO artist_id_mappings (artist_id, platform, platform_id, confidence, source, reasoning, api_key_hash)
-      VALUES (${artistId}, ${platform}, ${platformId}, ${confidence}::confidence_level, ${source}, ${reasoning ?? null}, ${apiKeyHash ?? null})
+    updated = await database.execute<{ id: string }>(sql`
+      UPDATE artist_id_mappings
+      SET platform_id = ${platformId},
+          confidence = ${confidence}::confidence_level,
+          source = ${source},
+          reasoning = ${reasoning ?? null},
+          api_key_hash = ${apiKeyHash ?? null},
+          resolved_at = now(),
+          updated_at = now()
+      WHERE artist_id = ${artistId}
+        AND platform = ${platform}
+        AND ${newPriority} >= CASE confidence
+          WHEN 'manual'::confidence_level THEN 4
+          WHEN 'high'::confidence_level THEN 3
+          WHEN 'medium'::confidence_level THEN 2
+          WHEN 'low'::confidence_level THEN 1
+          ELSE 0
+        END
+      RETURNING id
     `);
   } catch (err: unknown) {
     handleUniqueViolation(err, platform, platformId);
   }
 
-  return { created: true, updated: false, skipped: false };
+  if (updated.length > 0) {
+    return {
+      created: false,
+      updated: true,
+      skipped: false,
+      previousMapping,
+    };
+  }
+
+  // A stronger mapping committed after our read. Report the actual winner.
+  const winner = await database.query.artistIdMappings.findFirst({
+    where: and(
+      eq(artistIdMappings.artistId, artistId),
+      eq(artistIdMappings.platform, platform),
+    ),
+  });
+  if (!winner) {
+    throw new MappingConcurrentWriteError(
+      `A mapping for ${platform} changed concurrently; retry the operation`,
+    );
+  }
+  return {
+    created: false,
+    updated: false,
+    skipped: true,
+    previousMapping: {
+      platformId: winner.platformId,
+      confidence: winner.confidence,
+    },
+  };
+}
+
+export async function resolveArtistMapping(
+  params: ResolveArtistMappingParams,
+): Promise<ResolveArtistMappingResult> {
+  return resolveArtistMappingWithExecutor(db, params);
 }
 
 export async function getMappingStats(): Promise<{


### PR DESCRIPTION
## Summary

- extract a reusable artist-research core for Deezer verification, Wikidata lookup, MusicBrainz relationship parsing, normalization, and platform URL handling
- add transactional application of research findings with Spotify mirroring, confidence precedence, concurrency protection, partial success, and structured conflict results
- reuse the shared resolver code from the existing manual ID-mapping script while preserving its legacy output behavior
- add Spotify as a supported reverse-mapping target without exposing social handles or websites through the public ID-mapping mutation surface
- add focused coverage for resolver behavior, ambiguity handling, mapping conflicts, and safe artist-column writes

## Why

The add-artist flow became Deezer-primary, so newly created artists stopped receiving a Spotify artist ID even though `/findArtistBySpotifyID` is still in use. This establishes the reusable deterministic research and persistence layer needed to restore that identifier asynchronously in the next phase.

## Behavior and safeguards

- research fills empty artist fields and does not overwrite curated values
- an exact older research mirror can be replaced only by strictly stronger evidence
- ambiguous or conflicting IDs are surfaced for human review rather than chosen arbitrarily
- each platform finding is applied independently so one conflict does not discard unrelated valid findings
- website candidates are represented by the research contract but are not forced into the globally unique ID-mapping table; the research-run findings store will own them in the job/status phase

## Phase boundary

This PR is the Phase 1 foundation. It does not yet enqueue research from add-artist, expose progress on the artist page, deploy the autonomous VPS worker, add the Claude fallback, or run the historical Deezer-only backfill.

## Validation

- `npm test -- --runInBand --silent` — 117 suites passed; 1,168 tests passed and 6 skipped
- `npm run type-check`
- `npm run lint` — passes with the repository's existing warnings
- `npm run build`
- `git diff --check`
