### PR TITLE
fix(about): guard Spotify ID before SPARQL interpolation + tidy docblocks

### DIFF
--- a/src/lib/bioConstants.ts
+++ b/src/lib/bioConstants.ts
@@ -11,16 +11,16 @@ export const MAX_BIO_LENGTH = 10_000;
 export const ABOUT_EMPTY_STATE =
   "We couldn't find enough verified information about this artist yet — and Music Nerd won't guess. If this is you, claim your profile and add a few sources, and your About will fill in within seconds.";
 
-/**
- * True when `bio` is a real, synthesized About — non-empty and not the claim-nudge
- * empty-state. Use this everywhere the nudge must not be treated as a bio (fed back
- * into the chat/MCP as context, or clobbered/overwritten as if it were real content).
- */
 /** True when `bio` IS the claim-nudge empty-state (trimmed, tolerant of stray whitespace). */
 export function isAboutEmptyState(bio: string | null | undefined): boolean {
   return bio?.trim() === ABOUT_EMPTY_STATE;
 }
 
+/**
+ * True when `bio` is a real, synthesized About — non-empty and not the claim-nudge
+ * empty-state. Use this everywhere the nudge must not be treated as a bio (fed back
+ * into the chat/MCP as context, or clobbered/overwritten as if it were real content).
+ */
 export function isRealBio(bio: string | null | undefined): boolean {
   return !!bio && bio.trim().length > 0 && !isAboutEmptyState(bio);
 }

--- a/src/server/utils/__tests__/verifiedGrounding.test.ts
+++ b/src/server/utils/__tests__/verifiedGrounding.test.ts
@@ -34,6 +34,15 @@ describe("resolveVerifiedGrounding", () => {
     expect(fn).not.toHaveBeenCalled();
   });
 
+  it("rejects a non-base62 spotifyId without building/sending the SPARQL query (injection guard)", async () => {
+    const fn = mockFetchSequence([]);
+    // A value that tries to break out of the SPARQL string literal.
+    expect(await resolveVerifiedGrounding('abc" } UNION { ?item wdt:P1 ?x . #')).toBeNull();
+    expect(await resolveVerifiedGrounding("has spaces")).toBeNull();
+    expect(await resolveVerifiedGrounding("under_score")).toBeNull();
+    expect(fn).not.toHaveBeenCalled(); // guarded before any network call
+  });
+
   it("returns null when a Wikidata item exists but has no English Wikipedia article", async () => {
     mockFetchSequence([{ json: { results: { bindings: [{ item: { value: "http://www.wikidata.org/entity/Q9" } }] } } }]);
     expect(await resolveVerifiedGrounding("abc")).toBeNull();

--- a/src/server/utils/verifiedGrounding.ts
+++ b/src/server/utils/verifiedGrounding.ts
@@ -17,6 +17,11 @@ export async function resolveVerifiedGrounding(
   spotifyId: string | null | undefined
 ): Promise<VerifiedGrounding | null> {
   if (!spotifyId) return null;
+  // Spotify artist IDs are base62 (letters + digits). Reject anything else before splicing
+  // into the SPARQL string — defense-in-depth so a malformed/hostile value (e.g. one written
+  // via UGC/MCP that slipped a quote through) can't break out of the literal and inject a
+  // query against Wikidata's public endpoint. A rejected ID simply yields no grounding.
+  if (!/^[A-Za-z0-9]+$/.test(spotifyId)) return null;
   try {
     const sparql =
       `SELECT ?item ?sitelink WHERE { ?item wdt:P1902 "${spotifyId}". ` +


### PR DESCRIPTION
Post-merge review polish from the #1163 release review (both non-blocking, low-severity — folding them in before the staging→main promotion so `main` gets them too).

### #1 — SPARQL injection guard (`verifiedGrounding.ts`)
`resolveVerifiedGrounding` spliced `spotifyId` straight into the Wikidata SPARQL string. Now it rejects any non-base62 ID (`^[A-Za-z0-9]+$`) before building the query — defense-in-depth so a malformed/hostile value (e.g. one that slipped a `"` through UGC/MCP) can't break out of the string literal and inject a query against Wikidata's public endpoint. A rejected ID simply yields no grounding (returns null). Added an injection-guard test.

### #4 — docblock ordering (`bioConstants.ts`)
`isRealBio`'s docblock had ended up above `isAboutEmptyState`; swapped back. Cosmetic.

### Verification
- Suite green (**1150**), type-check + build clean.
- **End-to-end** (real Gemini + Dev DB): Grimes regenerate stays fully grounded — *Claire Elise Boucher, Canadian musician* (those facts come from the Wikipedia grounding, which requires the valid base62 ID to pass the new guard), 13.9s. So the guard rejects hostile IDs without breaking valid ones.

https://claude.ai/code/session_01SxgsJLvpQ8mPqhSftgx9wz