### PR TITLE
chore(about): fold in #1163 review polish (no-op regen signal, dead code, stale docs)

### DIFF
--- a/src/server/utils/__tests__/artistLinkService.test.ts
+++ b/src/server/utils/__tests__/artistLinkService.test.ts
@@ -17,8 +17,8 @@ describe("artistLinkService", () => {
     // Mock artist existence check - return a found artist by default
     (db as any).query.artists.findFirst = jest.fn().mockResolvedValue({ id: "artist-123", name: "Test Artist" });
     const { regenerateArtistBio } = await import("@/server/utils/queries/artistBioQuery");
-    const { setArtistLink, clearArtistLink, sanitizeColumnName, BIO_RELEVANT_COLUMNS } = await import("../artistLinkService");
-    return { db, setArtistLink, clearArtistLink, sanitizeColumnName, BIO_RELEVANT_COLUMNS, regenerateArtistBio };
+    const { setArtistLink, clearArtistLink, sanitizeColumnName } = await import("../artistLinkService");
+    return { db, setArtistLink, clearArtistLink, sanitizeColumnName, regenerateArtistBio };
   }
 
   // 1. sanitizeColumnName strips non-alphanumeric/underscore

--- a/src/server/utils/artistLinkService.ts
+++ b/src/server/utils/artistLinkService.ts
@@ -6,8 +6,6 @@ import { db } from "@/server/db/drizzle";
 import { eq, sql } from "drizzle-orm";
 import { artists } from "@/server/db/schema";
 
-export const BIO_RELEVANT_COLUMNS = ["spotify", "deezer", "instagram", "x", "soundcloud", "youtube", "youtubechannel"];
-
 // Whitelist of platform columns that can be written via link helpers.
 // Derived from the artists table schema — only platform/social columns.
 // System columns (id, name, bio, etc.) are excluded by omission.

--- a/src/server/utils/queries/__tests__/updateArtistBio.test.ts
+++ b/src/server/utils/queries/__tests__/updateArtistBio.test.ts
@@ -14,8 +14,11 @@ describe("updateArtistBio — regenerate degradation signal", () => {
   });
 
   async function setup() {
+    const { db } = await import("@/server/db/drizzle");
+    // updateArtistBio now snapshots the prior bio via getArtistById → db.query.artists.findFirst.
+    (db as any).query.artists.findFirst = jest.fn().mockResolvedValue(null);
     const { updateArtistBio } = await import("../artistQueries");
-    return { updateArtistBio };
+    return { updateArtistBio, db };
   }
 
   it("reports a distinct message when regenerate degrades to the claim-nudge", async () => {
@@ -38,6 +41,18 @@ describe("updateArtistBio — regenerate degradation signal", () => {
     expect(res.status).toBe("success");
     expect(res.message).toBe("Bio regenerated");
     expect(res.data).toBe("A real synthesized About.");
+  });
+
+  it("reports 'unchanged' when discovery finds nothing and the existing bio is preserved (no-op)", async () => {
+    const { updateArtistBio, db } = await setup();
+    (db as any).query.artists.findFirst = jest.fn().mockResolvedValue({ bio: "An existing, unchanged About." });
+    mockRegenerate.mockResolvedValue("An existing, unchanged About."); // clobber-guard preserved the same bio
+
+    const res = await updateArtistBio("a1", "", true);
+
+    expect(res.status).toBe("success");
+    expect(res.message).toMatch(/unchanged/i); // not the plain "Bio regenerated"
+    expect(res.data).toBe("An existing, unchanged About.");
   });
 
   it("reports error when regenerate returns nothing", async () => {

--- a/src/server/utils/queries/artistBioQuery.ts
+++ b/src/server/utils/queries/artistBioQuery.ts
@@ -102,7 +102,7 @@ export async function generateArtistBio(artistId: string): Promise<NextResponse>
     return NextResponse.json({ error: "Artist not found" }, { status: 404 });
   }
 
-  // Run every independent I/O concurrently so they overlap inside the route's 45s budget
+  // Run every independent I/O concurrently so they overlap inside the route's 57s budget
   // instead of summing. Platform stats (Deezer primary, Spotify fallback), verified-ID
   // grounding, the real catalog, and source-gathering all fire at once; each is bounded.
   const spotifyId = artist.spotify;
@@ -288,8 +288,8 @@ You have NO web access for this task. Write the About using ONLY the curated sou
 }
 
 /**
- * Simplified wrapper that returns just the bio string.
- * Used by artistLinkService for background bio regeneration.
+ * Simplified wrapper around generateArtistBio that returns just the bio string
+ * (or null on failure). Used by updateArtistBio for admin-triggered regeneration.
  */
 export async function regenerateArtistBio(artistId: string): Promise<string | null> {
   try {

--- a/src/server/utils/queries/artistQueries.ts
+++ b/src/server/utils/queries/artistQueries.ts
@@ -655,16 +655,22 @@ export async function removeArtistData(artistId: string, siteName: string): Prom
 export async function updateArtistBio(artistId: string, bio: string, regenerate: boolean = false): Promise<RemoveArtistDataResp> {
     try {
         if (regenerate) {
-            // Generate new bio using Gemini
+            // Snapshot the current About so we can tell a real regeneration apart from a
+            // no-op (discovery is flaky; when it finds nothing new the clobber-guard in
+            // generateArtistBio preserves the existing bio unchanged).
+            const priorBio = (await getArtistById(artistId))?.bio ?? null;
             const generatedBio = await regenerateArtistBio(artistId);
             if (!generatedBio) {
                 return { status: "error", message: "Failed to generate bio" };
             }
-            // Discovery is flaky and can find nothing verifiable — in which case the About
-            // degrades to the claim-nudge. Surface that distinctly so an admin regenerate
-            // doesn't look like a normal success when it effectively found no sources.
+            // Discovery found nothing verifiable — the About degraded to the claim-nudge.
+            // Surface that distinctly so an admin regenerate doesn't look like a normal success.
             if (isAboutEmptyState(generatedBio)) {
                 return { status: "success", message: "No verified sources found — showing the claim prompt", data: generatedBio };
+            }
+            // Discovery found nothing new — the existing About was preserved, not regenerated.
+            if (priorBio !== null && generatedBio === priorBio) {
+                return { status: "success", message: "No new sources found — About unchanged", data: generatedBio };
             }
             return { status: "success", message: "Bio regenerated", data: generatedBio };
         } else {

--- a/src/server/utils/queries/vaultWebSearch.ts
+++ b/src/server/utils/queries/vaultWebSearch.ts
@@ -154,7 +154,7 @@ If you cannot find any results specifically about this artist, return an empty a
         // Resolve vertexaisearch redirect URLs to their real destinations in PARALLEL.
         // Each redirect fetch can take several seconds and there can be up to 8; doing
         // them sequentially could blow the request budget now that discovery runs inside
-        // About generation (bounded by the route's 45s race).
+        // About generation (bounded by the route's 57s race).
         const validResults = results.filter((r) => r.url && r.title);
         await Promise.all(
             validResults.map(async (r) => { r.url = await resolveRedirectUrl(r.url); })


### PR DESCRIPTION
Non-blocking polish from the #1163 release review, folded in before the staging→main promotion so `main` gets it too.

- **No-op regenerate signal** (`artistQueries.ts`): an admin "Regenerate" that finds nothing new — where the clobber-guard correctly *preserves* the existing bio — now reports **"No new sources found — About unchanged"** instead of a misleading "Bio regenerated". Detected by snapshotting the prior bio and comparing. Added an `updateArtistBio` test.
- **Removed dead `BIO_RELEVANT_COLUMNS`** (`artistLinkService.ts`) — unused since auto-regen-on-link-change was removed.
- **Stale docs**: two leftover "45s" comments → 57s; fixed the `regenerateArtistBio` docstring.

### Verification
- Suite green (**1151**), type-check + build clean.
- **End-to-end** (real Gemini + Dev DB): Toro y Moi regenerate → accurate rich bio, 35s, app healthy — no regression.

Follow-ups tracked in MEMORY.md: `waitUntil()`, concurrent first-view dedup, async polling state.

https://claude.ai/code/session_01SxgsJLvpQ8mPqhSftgx9wz
