### PR TITLE
fix(about): gate forced bio regeneration to editors (close unauth GET ?regenerate=true)

### DIFF
--- a/src/app/api/artistBio/[id]/__tests__/route.test.ts
+++ b/src/app/api/artistBio/[id]/__tests__/route.test.ts
@@ -46,6 +46,11 @@ const createGetRequest = () =>
     method: 'GET',
   });
 
+const createGetRegenerateRequest = () =>
+  new Request('http://localhost/api/artistBio/artist-123?regenerate=true', {
+    method: 'GET',
+  });
+
 const adminSession = {
   user: { id: 'admin-uuid', email: 'admin@test.com' },
   expires: '2025-12-31',
@@ -258,6 +263,31 @@ describe('/api/artistBio/[id]', () => {
       const data = await response.json();
       expect(mockGenerateArtistBio).toHaveBeenCalledWith('artist-123'); // regenerated from sources
       expect(data.bio).toBe('Synthesized from the pending sources');
+    });
+
+    it('rejects unauthenticated GET ?regenerate=true (gates the expensive forced regen)', async () => {
+      const { GET, mockGetSession, mockGenerateArtistBio } = await setup();
+      mockGetSession.mockResolvedValue(null); // unauthenticated
+
+      const response = await GET(createGetRegenerateRequest(), { params: paramsPromise });
+
+      expect(response.status).toBe(401);
+      expect(mockGenerateArtistBio).not.toHaveBeenCalled(); // never reaches discovery/Gemini
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBeTruthy(); // CORS on the 403/401
+    });
+
+    it('allows GET ?regenerate=true for an admin/editor', async () => {
+      const { GET, mockGetSession, mockGetUserById, mockGetArtistById, mockGenerateArtistBio } = await setup();
+      mockGetSession.mockResolvedValue(adminSession);
+      mockGetUserById.mockResolvedValue({ id: 'admin-uuid', isAdmin: true });
+      mockGetArtistById.mockResolvedValue({ id: 'artist-123', bio: null, spotify: 'sp1' });
+      mockGenerateArtistBio.mockResolvedValue(Response.json({ bio: 'Regenerated bio' }));
+
+      const response = await GET(createGetRegenerateRequest(), { params: paramsPromise });
+
+      expect(mockGenerateArtistBio).toHaveBeenCalledWith('artist-123'); // auth passed → generation ran
+      const data = await response.json();
+      expect(data.bio).toBe('Regenerated bio');
     });
 
     it('returns 404 when artist not found', async () => {

--- a/src/app/api/artistBio/[id]/__tests__/route.test.ts
+++ b/src/app/api/artistBio/[id]/__tests__/route.test.ts
@@ -276,6 +276,18 @@ describe('/api/artistBio/[id]', () => {
       expect(response.headers.get('Access-Control-Allow-Origin')).toBeTruthy(); // CORS on the 403/401
     });
 
+    it('returns 403 (with CORS) for an authenticated non-editor on GET ?regenerate=true', async () => {
+      const { GET, mockGetSession, mockGetUserById, mockGenerateArtistBio } = await setup();
+      mockGetSession.mockResolvedValue(regularSession);
+      mockGetUserById.mockResolvedValue({ id: 'regular-uuid', isAdmin: false }); // no claim, not admin
+
+      const response = await GET(createGetRegenerateRequest(), { params: paramsPromise });
+
+      expect(response.status).toBe(403);
+      expect(mockGenerateArtistBio).not.toHaveBeenCalled();
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBeTruthy();
+    });
+
     it('allows GET ?regenerate=true for an admin/editor', async () => {
       const { GET, mockGetSession, mockGetUserById, mockGetArtistById, mockGenerateArtistBio } = await setup();
       mockGetSession.mockResolvedValue(adminSession);

--- a/src/app/api/artistBio/[id]/route.ts
+++ b/src/app/api/artistBio/[id]/route.ts
@@ -38,6 +38,21 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
   const url = new URL(request.url);
   const forceRegenerate = url.searchParams.get("regenerate") === "true";
 
+  // Forced regeneration bypasses the cache and triggers the expensive discovery + Gemini
+  // path, so gate it to admins / the artist who claimed the profile (same guard as PUT).
+  // Normal cached reads stay public. Re-wrap the auth response with CORS headers so it
+  // matches every other response this cross-origin-enabled route returns.
+  if (forceRegenerate) {
+    const auth = await requireArtistEditor(id);
+    if (!auth.authenticated) {
+      const body = await auth.response.text();
+      return new Response(body, {
+        status: auth.response.status,
+        headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
+      });
+    }
+  }
+
   // Set a timeout for the entire operation to prevent Vercel timeouts
   const timeoutPromise = new Promise<NextResponse>((_, reject) =>
     setTimeout(() => reject(new Error('Bio generation timeout')), 57000) // 57s: fits inline discovery (~38s) + synthesis under the 60s maxDuration ceiling

--- a/src/app/api/artistBio/[id]/route.ts
+++ b/src/app/api/artistBio/[id]/route.ts
@@ -31,6 +31,15 @@ export async function OPTIONS() {
   return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
 }
 
+// Re-wrap an auth failure (from requireArtistEditor) with this route's CORS headers so it
+// matches every other response the route returns. Shared by GET (forced regen) and PUT.
+async function corsAuthFailure(auth: { response: Response }): Promise<NextResponse> {
+  return NextResponse.json(await auth.response.json(), {
+    status: auth.response.status,
+    headers: CORS_HEADERS,
+  });
+}
+
 
 
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -38,27 +47,21 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
   const url = new URL(request.url);
   const forceRegenerate = url.searchParams.get("regenerate") === "true";
 
-  // Forced regeneration bypasses the cache and triggers the expensive discovery + Gemini
-  // path, so gate it to admins / the artist who claimed the profile (same guard as PUT).
-  // Normal cached reads stay public. Re-wrap the auth response with CORS headers so it
-  // matches every other response this cross-origin-enabled route returns.
-  if (forceRegenerate) {
-    const auth = await requireArtistEditor(id);
-    if (!auth.authenticated) {
-      const body = await auth.response.text();
-      return new Response(body, {
-        status: auth.response.status,
-        headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
-      });
-    }
-  }
-
   // Set a timeout for the entire operation to prevent Vercel timeouts
   const timeoutPromise = new Promise<NextResponse>((_, reject) =>
     setTimeout(() => reject(new Error('Bio generation timeout')), 57000) // 57s: fits inline discovery (~38s) + synthesis under the 60s maxDuration ceiling
   );
 
   const bioOperation = async (): Promise<NextResponse> => {
+    // Forced regeneration bypasses the cache and triggers the expensive discovery + Gemini
+    // path, so gate it to admins / the artist who claimed the profile (same guard as PUT).
+    // Normal cached reads stay public. Runs INSIDE the try/timeout race so a thrown or slow
+    // auth check gets the same graceful (CORS'd, timed) handling as the rest of the route.
+    if (forceRegenerate) {
+      const auth = await requireArtistEditor(id);
+      if (!auth.authenticated) return corsAuthFailure(auth);
+    }
+
     // Fetch artist row/object
     const artist = await getArtistById(id);
     if (!artist) {
@@ -131,14 +134,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
     const { id } = await params;
     const auth = await requireArtistEditor(id);
     if (!auth.authenticated) {
-      const body = await auth.response.text();
-      return new Response(body, {
-        status: auth.response.status,
-        headers: {
-          'Content-Type': 'application/json',
-          ...CORS_HEADERS,
-        },
-      });
+      return corsAuthFailure(auth);
     }
     const body = await request.json();
     const bio: string = body?.bio;

--- a/src/app/artist/[id]/_components/BlurbSection.tsx
+++ b/src/app/artist/[id]/_components/BlurbSection.tsx
@@ -123,7 +123,8 @@ export default function BlurbSection({ artistName, artistId, initialBio }: Blurb
         refetch(); // Update the hook's displayed bio
         toast({ title: "Bio regenerated" });
       } else {
-        // PUT failed (not admin) — use GET with force-regenerate param
+        // PUT failed — retry via GET force-regenerate. Both paths are editor-gated now,
+        // so this only helps an authorized editor whose PUT hit a transient (non-auth) error.
         const getResp = await fetch(`/api/artistBio/${artistId}?regenerate=true`);
         const getData = await getResp.json();
         if (getResp.ok && getData.bio) {


### PR DESCRIPTION
Follow-up **#4** from the About-flow review: close the unauthenticated forced-regeneration hole.

### The hole
`GET /api/artistBio/[id]?regenerate=true` had **no auth** — anyone could hit it directly (curl/script) to force the expensive discovery + Gemini path and bypass the cache. (BlurbSection used it as a non-admin fallback; PUT was already gated.)

### The fix
Forced regeneration on GET now requires `requireArtistEditor` (admin or the artist who claimed the profile), matching PUT. **Normal cached reads stay public.** The 401/403 is re-wrapped with CORS headers so it matches every other response this cross-origin-enabled route returns. Updated the now-inaccurate BlurbSection fallback comment (no frontend refactor).

### Verification
- **Unit:** rejects unauthenticated `GET ?regenerate=true` (never calls `generateArtistBio`; CORS header present); allows it for an admin/editor. Suite green (**1153**), type-check + build clean.
- **End-to-end (dev, real):** unauthenticated `?regenerate=true` → **401** with `access-control-allow-origin` present; normal public GET → **200**. *(The authed-editor path is covered by the unit test with mocked auth — exercising it via curl needs a real session, so it's not claimed as E2E.)*

Scope kept to this one fix per plan. Deferred (documented in MEMORY.md): `waitUntil()` (can't verify serverless freeze locally, so not shipping it unverified), PUT outer-timeout race (low value, internally bounded), concurrent-first-view dedup, async polling state.

https://claude.ai/code/session_01SxgsJLvpQ8mPqhSftgx9wz
