### PR TITLE
copy(about): rewrite empty-state / claim-nudge (action + value framed)

### DIFF
--- a/src/lib/bioConstants.ts
+++ b/src/lib/bioConstants.ts
@@ -9,7 +9,7 @@ export const MAX_BIO_LENGTH = 10_000;
  * (e.g. so the nudge is never fed back in as an "existing bio").
  */
 export const ABOUT_EMPTY_STATE =
-  "We couldn't find enough verified information about this artist yet — and Music Nerd won't guess. If this is you, claim your profile and add a few sources, and your About will fill in within seconds.";
+  "We don't have enough verified information about this artist yet. If this is you, claim your profile and add a few sources to generate your About — or write your own. What you add helps Music Nerd tell your story to fans.";
 
 /** True when `bio` IS the claim-nudge empty-state (trimmed, tolerant of stray whitespace). */
 export function isAboutEmptyState(bio: string | null | undefined): boolean {


### PR DESCRIPTION
Reworks the `ABOUT_EMPTY_STATE` copy per product feedback — drops the defensive "Music Nerd won't guess" and the stacked "and, and, and", leads with the ask, and closes on the *why*.

**New copy:**
> We don't have enough verified information about this artist yet. If this is you, claim your profile and add a few sources to generate your About — or write your own. What you add helps Music Nerd tell your story to fans.

- Two clear paths: add sources → auto-generate, or write your own.
- States the value: verified context powers the experiences that carry the artist's story to fans.
- All readers use the shared constant, so no literals to update.

**Verified:** suite green (1154), build clean; E2E — the empty-state artist now renders the new copy.

Small copy change; folds into release PR #1163.

https://claude.ai/code/session_01SxgsJLvpQ8mPqhSftgx9wz