### PR TITLE
docs: add Pete + ChatGPT weekly Music Nerd handoff

### DIFF
--- a/docs/weekly-handoffs/2026-08-19-pete-chatgpt.md
+++ b/docs/weekly-handoffs/2026-08-19-pete-chatgpt.md
@@ -1,281 +1,298 @@
-# Music Nerd Weekly Handoff — Pete + ChatGPT
+# Music Nerd — ChatGPT Context Export
 
-**Period:** August 13, 2026 (after the Music Nerd R&D meeting) through August 19, 2026  
-**Perspective:** Pete + ChatGPT exploration only  
-**Purpose:** Give Claude / Claude Code a clean record of what Pete explored in ChatGPT this week so Claude can add its own work, reconcile repo state, and synthesize a weekly status report + team email.
+**Period:** After the August 13, 2026 Music Nerd meeting through August 19, 2026  
+**Source:** Pete's Music Nerd-related ChatGPT conversations only  
+**Purpose:** Preserve what Pete explored in ChatGPT so Claude can use it as an additional input later.
 
-> **Important source boundary:** This file does **not** replace or modify `MEMORY.md`, `CLAUDE.md`, or Claude Code's own project state. Those remain Claude's perspective / implementation record. Anything below labeled as an observed repo snapshot is read-only context, not a claim that ChatGPT designed or implemented it.
+> **Boundary:** This is not a Music Nerd status report. It does not inspect or summarize Claude's work, `MEMORY.md`, repository implementation, commits, PRs, or project state. It does not tell Claude what to conclude or write. It is only a record of the Music Nerd thinking that happened with ChatGPT during this period.
 
-## 1. Baseline from the August 13 Music Nerd meeting
+## Product / vision exploration
 
-The August 13 meeting established several points that shaped the work explored afterward:
+A recurring question this week was what Music Nerd should become beyond its current role as a database that aggregates artist social profiles and support links.
 
-- **Music Nerd Web is the primary aggregation/database layer** for the Music Nerd ecosystem.
-- **Music Nerd TV is a reference implementation** for turning that underlying data into a listener-facing experience.
-- Artist profile language was moving from a generic bio/summary framing toward **"About."**
-- The team wanted a **source-first approach** to artist information rather than having AI freely author artist identity.
-- A low-pressure **story-gathering tool** was discussed: prompts delivered in a way that lets artists contribute context without requiring constant public content creation or performance.
-- Workflow ideas included weekly retrospectives/demos, information radiators, persistent repository memory files, and a weekly team summary email.
-- Pete's immediate work included clarifying bio/About data sourcing, the Web → TV pipeline, onboarding/claiming, empty states/contribution CTAs, and how experiments should be presented.
+The strongest direction explored was that Music Nerd should help artists and scenes **surface, preserve, organize, and control the context around their work**, rather than simply adding more information to artist pages.
 
-This handoff focuses on what Pete + ChatGPT explored after that meeting, not on re-documenting the meeting itself.
+Important distinctions that came up:
 
----
+- The information around music is often **fragmented**, but fragmentation is not the whole problem. Some of the most meaningful artist stories are latent, informal, undocumented, or poorly represented in the first place.
+- Music discovery has become very good at similarity and recommendation, but much weaker at helping a listener follow the **human connective tissue** around a song: collaborators, scenes, places, relationships, influences, moments, and stories.
+- Music Nerd could provide **frameworks, protocols, and tools** that help artists notice and capture those stories without forcing them into a traditional bio, EPK, press campaign, or constant social-content treadmill.
+- The project should not assume that Music Nerd itself has to become the publication or narrator of every artist's story. A more durable role may be infrastructure and facilitation.
+- The exact product form is still open. The same underlying idea could eventually appear as profile features, artist tools, conversation protocols, discovery experiences, editorial experiments, workshops, or other formats.
 
-## 2. Core product thesis that became clearer this week
+### Artist agency and the record
 
-A narrower problem statement started to emerge beneath the many possible forms Music Nerd could take:
+The product thinking repeatedly returned to the idea that an artist should have meaningful control over how they are represented.
 
-**Artists and scenes need better ways to notice, capture, preserve, connect, and share the stories forming around their work on their own terms.**
+Ideas explored included:
 
-Music Nerd has been discussed as a database, profile, archive, publication, discovery engine, TV experience, research system, and storytelling toolkit. The exploration this week increasingly treated those as possible *forms* rather than the definition of the product.
+- artists being able to add, correct, approve, contextualize, withhold, or revise information;
+- preserving visible sources and provenance rather than presenting every statement as equally authoritative;
+- treating the artist record as **living and revisable**, not a permanent canonical definition of a person;
+- distinguishing an artist's own voice from sourced factual information and from community/contributor context;
+- allowing multiple perspectives without flattening disagreement or uncertainty into one polished answer.
 
-The more durable direction is that Music Nerd can provide **infrastructure, frameworks, and protocols for context** rather than trying to become a centralized editorial voice that tells every artist's story itself.
+A working layered model that came up was roughly:
 
-### Implications
+1. **Artist voice** — first-person or artist-approved context.
+2. **Sourced record** — attributable facts, credits, references, and external evidence.
+3. **Community / scene context** — contributions from collaborators, listeners, peers, writers, venues, or other witnesses.
 
-- The database/record is necessary, but **a better database alone is not the product thesis**.
-- Storytelling should not require an artist to become a full-time content creator.
-- Music Nerd can help surface stories that are already latent across conversations, scenes, collaborators, releases, posts, credits, archives, and memories.
-- The platform should make those connections navigable without flattening them into a single polished AI summary.
-- The exact product form can remain somewhat unresolved while the core problem is tested with artists.
+This layering was explored as a useful mental model, not treated as a finalized interface or data model.
 
----
+### AI's role
 
-## 3. Major tensions explored
+A fairly consistent boundary emerged in the ChatGPT discussions:
 
-These tensions kept resurfacing and appear more useful than prematurely locking a feature set.
+AI can be useful for:
 
-### Access vs. control
-Artists technically have more direct access to audiences than ever, but access to a microphone is not the same as control over how their story is represented, remembered, or connected.
+- transcription;
+- organization;
+- search and navigation;
+- connecting related material;
+- surfacing gaps or questions;
+- restructuring information for review;
+- helping a person work through a large archive.
 
-### Story vs. content production
-There is meaningful context around artists that may never become a post, campaign, interview, press release, or piece of content. Music Nerd should not make artists perform their identity on a publishing treadmill just to have that context preserved.
+AI should not become the unquestioned author of an artist's identity or fabricate completeness where reliable information does not exist.
 
-### Frameworks vs. formulas
-A useful Music Nerd framework should help an artist notice and articulate what matters without becoming another EPK questionnaire, branding exercise, content template, or rigid storytelling formula.
+The larger idea was: **AI can help navigate and organize the record without becoming the authority that defines the artist.**
 
-### Artist agency vs. many voices
-An artist's own voice matters, but scenes are made of collaborators, listeners, producers, engineers, friends, venues, writers, releases, and other witnesses. Music Nerd needs a way to hold multiple perspectives without implying that every contribution has equal authority.
+## Substack / vision article exploration
 
-### Preservation vs. privacy
-Preserving context is valuable, but not everything should become public or permanent. Any long-term story/archive system needs consent, provenance, visibility controls, uncertainty, and a meaningful right to withhold.
+The actual article writing is intentionally excluded from this file. The article was used as a way to pressure-test and clarify the Music Nerd thesis.
 
-### Living person vs. frozen record
-A persistent artist record can easily become a static definition of a person. The system should preserve history without pretending the current summary is the final truth of who someone is.
+### Themes explored
 
-### Scale vs. intimacy
-The most meaningful artist conversations often depend on trust and good facilitation. Automating that intimacy would likely destroy what makes it valuable. The scaling question is therefore: **can Music Nerd scale the framework for good conversations rather than automate the human relationship itself?**
+- **Access vs. control:** artists have unprecedented direct access to audiences, but having a microphone is not the same as having durable control over how a story is represented, discovered, remembered, or interpreted.
+- **Story vs. content:** meaningful context about artists often exists outside of posts, campaigns, press releases, formal interviews, and promotional content.
+- **Fragmented information vs. missing stories:** some information already exists but is scattered; other important context was never captured in the first place.
+- **Framework vs. formula:** Music Nerd could give artists structures that help them think about and capture their story without turning storytelling into another branding worksheet or rigid template.
+- **Database vs. connection:** aggregating more data is not enough. The value is in helping a listener understand why a person, place, collaborator, release, or moment connects to something they already care about.
+- **Product certainty vs. experimentation:** the public vision can be clear about the problem and values without pretending the final product form has already been solved.
 
-### Infrastructure vs. editorial authority
-Music Nerd can have a strong point of view about how stories should be sourced, preserved, connected, and treated without insisting that Music Nerd itself must be the publication or narrator of every story.
+### Pete's intended structure for the article
 
-### AI assistance vs. AI authorship
-A working boundary emerged:
+Pete clarified that the piece should roughly move through:
 
-- AI can help **transcribe, organize, search, connect, identify gaps, structure material, and produce drafts for review**.
-- AI should not become the unquestioned author of an artist's identity.
-- Human contributions, artist review/control, visible sources, provenance, and uncertainty should remain more authoritative than a complete-sounding answer.
+1. what Music Nerd has been;
+2. the problem Pete has run into;
+3. who Pete is and why his relationship to the problem matters;
+4. what Pete thinks Music Nerd could become.
 
-### Platform utility vs. platform dependency
-There is a DIY/punk instinct behind giving artists tools to document themselves without waiting for traditional media coverage. But Music Nerd could reproduce the same dependency problem if the history only exists inside Music Nerd. Portability and protocols that remain useful outside the interface are therefore important.
+Pete's introduction was not meant to be a résumé section. It was supposed to explain why his experience as a producer, artist-development person, listener, builder, and someone who spends time around artists gives him a particular relationship to the problem.
 
----
+### Writing/process feedback Pete repeatedly gave
 
-## 4. Substack / public writing exploration
+The article iterations also surfaced useful product-communication constraints:
 
-**No article prose is included in this handoff.** Only the themes and strategic function of the writing are recorded.
+- do not over-explain the platform;
+- get to the point faster;
+- avoid generic or overly polished AI-sounding prose;
+- avoid formal, corporate, stale, or "corny" language;
+- introduce Pete naturally and early enough that the reader understands who is speaking;
+- do not insert biography in a way that interrupts the logic of the argument;
+- make paragraphs actually transition into each other rather than stacking disconnected ideas;
+- do not use a boring thesis-first opening simply because it is structurally neat;
+- when Pete says something like "here's what I'm thinking," treat that as context for tone and perspective, not necessarily literal copy to place in the article;
+- do not mention C.Y. in the article just because he was part of the internal exploration;
+- preserve some roughness and personality rather than sanding the writing into generic thought-leadership language.
 
-The article work was used to pressure-test the Music Nerd thesis rather than simply announce product features.
+## Anthony Bourdain as a facilitation model
 
-Themes explored:
+C.Y. shared a reference about Anthony Bourdain and described it as a goal for the kind of conversation Music Nerd should be able to evoke from artists. Pete then explored that idea further in ChatGPT on August 16 and again on August 18.
 
-- Artists can distribute and speak directly to audiences more easily than in previous eras, but this does not automatically give them durable control of their story.
-- Music discovery is strong at similarity/recommendation but weaker at helping listeners follow the **human and cultural connective tissue** around music.
-- The problem is not necessarily that the information is missing; much of it is fragmented across many places and formats.
-- Music Nerd could provide **tools/frameworks/protocols** that help artists and scenes capture, organize, review, and preserve meaningful context.
-- Pete's role should be framed through his way of working — listening, producing, artist development, building systems, and shortening the distance between artist feedback and product decisions — rather than as a résumé or a grand claim of authority.
-- The project should communicate conviction about its values without pretending the final product form is already known.
-- Testing with a small group of artists should determine whether the useful outputs become platform features, protocols, workshops, editorial formats, or some combination.
+The useful part was not copying Bourdain's aesthetic or making "Bourdain for musicians." The focus was on the deeper method behind his work.
 
-A recurring writing/product lesson: **do not over-explain Music Nerd.** The platform and the public writing both become weaker when every possible function is explained at once.
+Principles discussed:
 
----
+- do not ask someone to constantly explain why they matter;
+- follow concrete details, people, places, memories, habits, objects, and relationships;
+- let meaning emerge through what a person notices and cares about;
+- create a situation where conversation can happen naturally rather than conducting a rigid formal interview;
+- remain curious instead of arriving with a predetermined story to extract;
+- allow the person and their world to carry the meaning instead of having the interviewer repeatedly explain it to the audience;
+- use conversation to make a world more legible, not simply to collect quotable answers.
 
-## 5. Anthony Bourdain / facilitation exploration
+A concise principle that came out of the exploration was that Music Nerd should not necessarily **extract a story** from an artist. It should create conditions where the artist's world can become visible and navigable.
 
-A Bourdain-focused conversation became a useful model for how Music Nerd might approach artist storytelling.
+### Product ideas that came out of the Bourdain exploration
 
-The important principle was not "make Music Nerd journalism like Bourdain." It was the method:
+These were exploratory, not roadmap commitments:
 
-- enter with curiosity rather than a predetermined thesis;
-- listen closely;
-- create conditions where people reveal what matters through their own details and relationships;
-- avoid repeatedly telling the audience why something is important;
-- do not over-insert the interviewer or institution into the story;
-- let context generate curiosity and care.
+- **conversation-based onboarding** instead of a generic artist-profile form;
+- a system that follows interesting threads from one answer into another instead of running every artist through the same questionnaire;
+- an ongoing artist "conversation room" that could accept voice, text, links, images, references, or other material over time;
+- artist profiles that feel more like an explorable oral history, archive, or map than a single definitive biography;
+- treating small details as portals into deeper context: a collaborator, venue, object, lyric, neighborhood, memory, studio, influence, or release could open another path;
+- adaptive conversation paths rather than identical prompts for every artist;
+- allowing the same underlying captured material to produce different listener experiences depending on what someone is curious about;
+- a loop of **conversation → artifact/context → discovery → curiosity → more conversation**.
 
-### Product implication
+### Scaling the approach
 
-Music Nerd could behave less like an automated profile writer and more like a **facilitator of context**.
+A central tension was that the conversations people care about often work because a real person is listening closely. Automating that intimacy could destroy the value.
 
-Possible direction explored:
+The more interesting scaling question became whether Music Nerd can **scale the framework for better conversations without trying to automate the human relationship itself**.
 
-1. Give artists/scenes thoughtful prompts or conversational frameworks.
-2. Capture raw conversation, memories, references, relationships, artifacts, and sources.
-3. Organize that material without pretending to replace the people who contributed it.
-4. Allow artists to review, approve, correct, hide, or expand it.
-5. Let listener experiences surface the relevant pieces at the right moment instead of publishing one giant definitive narrative.
+One possible direction was a protocol or set of tools that artists, collaborators, scenes, interviewers, or other music nerds could use themselves. Music Nerd could provide the structure, preservation, sourcing, and connective layer while people remain the actual participants.
 
-### Scaling implication
+## Music Nerd Web prototype / UX exploration
 
-The most interesting possibility may be a **protocol that artists/scenes can run themselves** rather than Music Nerd having to personally conduct every interview. Music Nerd supplies the structure, preservation, provenance, and connective layer; humans remain the actual participants.
+Pete was strongly dissatisfied with prototype directions that tried to explain the whole Music Nerd thesis through the interface.
 
-This also suggests a useful separation between **platform** and **editorial work**. Music Nerd can support or host editorial experiments without requiring the underlying infrastructure to become a centralized publication.
+The clearest feedback:
 
----
+- the prototype felt **too busy**;
+- there was **too much explanatory copy**;
+- the polished/curated presentation made the product feel too much like a **publication**;
+- a proposed "web of knowledge" presentation did not justify the additional complexity;
+- Pete wanted a much more **minimal and focused** experience;
+- the home should remain relatively close to the clarity and function of the current `musicnerd.xyz` home while applying the newer branding/visual system;
+- the product should be understandable through use rather than repeatedly explaining itself in copy;
+- "one screen / one job" was a useful constraint for continued prototyping.
 
-## 6. Product / UX direction reinforced this week
+Pete also asked for repeated simulated use of the prototype from both **artist** and **music-nerd/listener** perspectives, with iteration based on where those journeys became confusing or overbuilt.
 
-Several prior interface instincts were reinforced by the storytelling discussion:
+Areas that continued to matter in those simulations and discussions:
 
-- Music Nerd should feel **minimal, focused, and curiosity-led**, not like a publication homepage or a wall of explanatory copy.
-- The home experience should stay relatively close to the clarity of the current MusicNerd.xyz page rather than trying to explain the entire thesis in UI copy.
-- Avoid designing the product as "Wikipedia, but AI" or as a giant static artist dossier.
-- Listener discovery should reveal connections progressively: a person, place, collaborator, release, quote, source, scene, artifact, or relationship can become an entry point.
-- The system should not require a listener to connect Spotify before it can be interesting.
-- More data is not automatically more compelling. The useful unit is **context that creates a reason to become curious**.
-- "One screen / one job" remains a useful design constraint when prototyping.
+- artist profile claiming;
+- onboarding;
+- the artist About experience;
+- empty states when little reliable artist information exists;
+- contribution paths;
+- discovery and rabbit-hole behavior;
+- preserving the usefulness of the existing Music Nerd home instead of replacing it with an editorial landing page;
+- revealing connections progressively rather than dumping an entire knowledge graph or thesis on the user at once.
 
-### Open product-form question
+The repeated UX lesson was that **more information on the screen does not automatically create more curiosity**.
 
-The platform still has multiple layers that should not be collapsed prematurely:
+## Artist "About" and story-capture exploration
 
-- trusted artist record / sources;
-- artist-controlled first-person context;
-- community/contributor context;
-- low-pressure story capture;
-- listener discovery / connection paths;
-- Music Nerd TV as an experiential surface;
-- experimental tools/protocols that may or may not belong directly inside the main Music Nerd interface.
+Pete continued thinking through what the artist "About" layer should actually be and separately started thinking through a product approach for artist stories.
 
-The work this week moved toward understanding how these layers relate instead of trying to make them all one screen or one feature.
+### About direction
 
----
+Ideas discussed in ChatGPT included:
 
-## 7. About / artist identity direction from Pete + ChatGPT's perspective
+- use **About** rather than treating the section as a traditional fixed bio;
+- start from reliable/sourceable information rather than asking an LLM to invent a complete-sounding biography;
+- prefer original or primary sources where possible before leaning on generated synthesis;
+- an honest lack of information can be better than hallucinated completeness;
+- missing information can become an invitation for the artist to claim the page or for someone to contribute a source;
+- artist-authored or artist-approved information should have visibly different authority from automated research or outside contributions;
+- a factual/sourced About record and richer story material may be related but do not necessarily need to be the same layer.
 
-The "About" discussion increasingly aligned with a source-and-control model:
+### Story capture
 
-- "About" should not be treated as permission for an LLM to improvise an artist biography.
-- A sourced factual record is a better floor than an eloquent but uncertain summary.
-- When information is missing, an honest gap plus a contribution/claim path is better than hallucinated completeness.
-- Artist-authored or artist-approved information should carry different authority from community or automated research.
-- Story capture may deserve to be a distinct layer from the factual About record rather than forcing every rich story into the profile summary.
+The story discussion moved away from the assumption that the platform simply needs "better bios."
 
-This is directly connected to the broader thesis: **AI can help navigate the archive; it should not become the archive's unquestioned narrator.**
+The more interesting problem was how to capture things such as:
 
----
+- anecdotes;
+- influences;
+- relationships;
+- creative decisions;
+- places;
+- memories;
+- scenes;
+- collaborators;
+- references;
+- unfinished or evolving context that does not naturally fit a bio.
 
-## 8. Workflow / shared-context exploration
+The product question became how Music Nerd could help those stories surface without forcing artists into a performative content process.
 
-Pete also explored the practical problem that Music Nerd context is fragmented across ChatGPT, Claude/Claude Code, Google Workspace meeting transcripts, GitHub, and Obsidian.
+## Listener discovery / connective tissue
 
-The desired operating model is moving toward:
+A related direction was that Music Nerd should help a listener move from a song or artist into the surrounding world through **connections**, not just recommendations.
 
-- meeting transcripts / notes becoming durable shared inputs;
-- GitHub holding implementation state and project-adjacent Markdown context;
-- Obsidian holding structured knowledge / people / concepts where useful;
-- ChatGPT and Claude each contributing their own perspective without silently overwriting the other's record;
-- a weekly reconciliation layer that turns those separate perspectives into one status report for the team.
+Examples of possible connection points discussed across the week's exploration included:
 
-A small related step was cleaning up structured context about Music Nerd people/relationships for use in the knowledge base, rather than relying on every AI workspace to reconstruct the same context from scratch.
+- collaborators;
+- producers;
+- scenes;
+- venues;
+- places;
+- influences;
+- releases;
+- credits;
+- quotes;
+- artifacts;
+- shared history;
+- other people referenced inside a story.
 
-### New workflow created August 19
+The point was not to expose a giant graph for its own sake. The interface should reveal the next useful connection when it creates a reason to care or keep digging.
 
-This file is the first explicit **Pete + ChatGPT weekly handoff** for that system.
+This was one reason the "publication" feeling in the prototype was a problem: Music Nerd should feel like something a person can **use to follow curiosity**, not primarily something they sit down to read front-to-back.
 
-A recurring ChatGPT task is scheduled for **Thursdays at 6:00 AM Eastern** to:
+## Shared-context / workflow exploration
 
-1. collect Pete + ChatGPT's Music Nerd exploration since the previous meeting;
-2. inspect relevant repo activity as read-only context;
-3. create a new dated Markdown handoff under `docs/weekly-handoffs/`;
-4. never edit or overwrite `MEMORY.md`;
-5. give Pete a prompt for Claude to add Claude's own perspective and synthesize the weekly report/email.
+Pete also spent time in ChatGPT working through a Music Nerd operating problem: project context is spread across ChatGPT, Claude, Google Workspace, GitHub, and an Obsidian vault.
 
----
+Current workflow problem described by Pete:
 
-## 9. Observed repository implementation snapshot — FOR RECONCILIATION ONLY
+- meetings are recorded/transcribed into Google Workspace;
+- Pete then repeatedly has to move or restate the same context into ChatGPT, Claude, and Obsidian;
+- each workspace develops a different partial understanding of Music Nerd;
+- coworkers need a way to understand the latest state without depending on one person's AI conversation history.
 
-This section is **not ChatGPT's authored project memory**. It is a read-only observation of recent `xdjs/MusicNerdWeb` commits / Claude-maintained state so Claude can reconcile this handoff against its own authoritative implementation record.
+The explored direction was toward a shared information layer where:
 
-Recent repository activity on August 16–17 appears to have materially advanced the "About" direction discussed above:
+- meeting transcripts become durable inputs rather than one-off attachments;
+- GitHub can hold project-adjacent context close to implementation;
+- Obsidian can hold structured people/concept/project knowledge;
+- ChatGPT and Claude can both read shared source material while still keeping their own reasoning/context separate;
+- useful information produced in one environment can be exported into a format another environment can ingest.
 
-- same-name artist conflation protections and catalog/verified-identity grounding;
-- retry behavior around source discovery;
-- movement toward the **vault as the source system** for About generation;
-- About synthesis from curated vault sources with model web search turned off;
-- claim/contribution empty-state behavior instead of fabricating a hollow bio;
-- forced regeneration gated to authorized editors;
-- additional review/polish around the About flow and empty-state copy.
+Pete also used ChatGPT to prepare cleaner structured context about Music Nerd people such as **C.Y. Lee and Carl** for his Obsidian workflow, so those relationships and roles would not have to be reconstructed from scratch by every AI workspace.
 
-Relevant recent work includes PR/commit lines around **#1162, #1164, #1165, #1166, #1167, #1168**, followed by the staging → main release.
+This weekly ChatGPT-to-GitHub export is itself an experiment in solving that context-fragmentation problem. Its scope is intentionally narrow: ChatGPT contributes only what happened in ChatGPT, and another system can decide what to do with that information later.
 
-**Claude should replace/expand this section with its own precise implementation notes. Do not use this summary as a substitute for `MEMORY.md`, PR history, or Claude Code session context.**
+## Chronology of notable ChatGPT exploration
 
----
+### August 14
 
-## 10. Where the thinking appears to be now
+- Strong critique of an overbuilt Music Nerd prototype.
+- Pete rejected the busy "web of knowledge" direction, excessive explanatory copy, and publication-like feel.
+- Direction moved toward a much more minimal, focused product experience.
 
-### Increasingly clear
+### August 16
 
-- Music Nerd should help preserve and navigate the connective tissue around music, not merely aggregate links.
-- Artist agency, provenance, sourcing, and uncertainty are core product constraints, not compliance details to bolt on later.
-- AI is useful as infrastructure for capture/navigation/organization, but should not be the final authority on identity.
-- The strongest opportunity may be creating **frameworks and protocols that enable better human storytelling at scale**.
-- The listener experience should create curiosity through connections rather than explain everything upfront.
-- Music Nerd Web can remain the underlying record/data layer while Music Nerd TV and future experiments test different ways of experiencing that context.
+- Bourdain reference became a model for artist interviewing/facilitation.
+- Explored how Music Nerd could create conditions for artists to reveal context rather than forcing formal story extraction.
+- Pete also worked through cross-tool context fragmentation and structured Music Nerd knowledge for use outside ChatGPT.
 
-### Still unresolved
+### August 17
 
-- What is the smallest product that proves the storytelling/context thesis?
-- Is the low-pressure artist story tool email, SMS, an in-app conversation, a scheduled prompt, an interview kit, or a protocol that can use several channels?
-- What belongs in the factual About record versus a richer story/archive layer?
-- How should artist voice, sourced facts, and community contributions coexist in the interface and data model?
-- What is private by default, what is publishable, and how does an artist withdraw or revise context later?
-- How much editorial shaping should Music Nerd itself do?
-- How do we preserve contradiction and uncertainty without making the experience feel unusable?
-- What should flow from Music Nerd Web into TV, and at what level: sources, facts, story fragments, relationships, generated listener context, or all of the above?
-- Where do Music Nerd experiments live? Inside the primary product, as a separate lab surface, or both?
-- How do we test whether these tools actually reduce burden for artists rather than creating another form to maintain?
-- What are the first artists/scenes to test with, and what evidence would count as success?
+- Continued refinement of the Substack/vision article as a tool for clarifying the product thesis.
+- Pete clarified the desired article structure: what Music Nerd has been → problem → Pete's relationship to the problem → what Music Nerd could become.
+- Reaffirmed that the Music Nerd home should stay close to the current site's simplicity while using the newer visual identity.
+- Prototype feedback remained centered on removing explanatory copy and publication-like presentation.
 
----
+### August 18
 
-## 11. Suggested synthesis frame for Claude
+- Pete used ChatGPT to think through the Music Nerd About experience and a broader product approach for artist stories.
+- Returned to the Bourdain idea and explored how the spirit of those conversations could translate into Music Nerd without copying the surface format.
+- Conversation-based onboarding, thread-following, persistent conversation spaces, explorable artist archives, and human-led facilitation frameworks were among the ideas explored.
 
-When combining this with Claude's own notes, repo work, and meeting context, the useful weekly report should distinguish:
+### August 19
 
-1. **What we learned / clarified** — product and philosophical progress.
-2. **What actually shipped or changed** — repo / implementation facts.
-3. **What we tested** — user scenarios, technical experiments, prototypes, or conversations.
-4. **What remains unresolved** — real decisions still requiring evidence or discussion.
-5. **What should happen next** — the smallest concrete experiments or implementation tasks for the coming week.
+- Continued work on the Music Nerd vision/Substack themes.
+- Pete noted continued work on the Bourdain GPT / Bourdain-inspired exploration.
+- Pete formalized the need for ChatGPT to export its weekly Music Nerd context into GitHub so Claude can independently use that context later.
 
-Avoid presenting every explored idea as a commitment. A major part of this week's work was narrowing the problem and identifying tensions, not declaring all possible Music Nerd concepts to be roadmap items.
+## Repeated constraints Pete emphasized this week
 
----
+Across the different Music Nerd conversations, Pete repeatedly pushed toward the following constraints:
 
-## 12. Claude handoff instructions
-
-Claude / Claude Code should now:
-
-- read this file as **Pete + ChatGPT's weekly perspective**;
-- read `MEMORY.md`, recent commits/PRs, and relevant Claude conversations as Claude's separate perspective;
-- add any major Claude-side exploration or implementation work that is missing;
-- correct any repo implementation details that this file only observed at a high level;
-- reconcile duplicate or contradictory notes explicitly rather than silently overwriting one source;
-- produce a concise **Music Nerd Weekly Report / Status of Play**;
-- then synthesize a team email focused on what changed, what was learned, what is currently in motion, and what the team should discuss or do next.
-
-Do **not** reproduce draft Substack/article prose in the report. It is enough to say that the article was used to clarify the product thesis and list the themes/tensions explored.
+- minimal over explanatory;
+- product over publication;
+- curiosity over information density;
+- artist agency over automated authority;
+- sourced context over plausible-sounding synthesis;
+- human conversation over automated intimacy;
+- frameworks/protocols over rigid storytelling formulas;
+- living context over a frozen definitive bio;
+- progressive discovery over giant knowledge dumps;
+- preserve the clarity of the existing Music Nerd experience while testing new ideas;
+- use AI to help organize and connect human material, not to replace the people whose stories are being represented.

--- a/docs/weekly-handoffs/2026-08-19-pete-chatgpt.md
+++ b/docs/weekly-handoffs/2026-08-19-pete-chatgpt.md
@@ -1,0 +1,281 @@
+# Music Nerd Weekly Handoff — Pete + ChatGPT
+
+**Period:** August 13, 2026 (after the Music Nerd R&D meeting) through August 19, 2026  
+**Perspective:** Pete + ChatGPT exploration only  
+**Purpose:** Give Claude / Claude Code a clean record of what Pete explored in ChatGPT this week so Claude can add its own work, reconcile repo state, and synthesize a weekly status report + team email.
+
+> **Important source boundary:** This file does **not** replace or modify `MEMORY.md`, `CLAUDE.md`, or Claude Code's own project state. Those remain Claude's perspective / implementation record. Anything below labeled as an observed repo snapshot is read-only context, not a claim that ChatGPT designed or implemented it.
+
+## 1. Baseline from the August 13 Music Nerd meeting
+
+The August 13 meeting established several points that shaped the work explored afterward:
+
+- **Music Nerd Web is the primary aggregation/database layer** for the Music Nerd ecosystem.
+- **Music Nerd TV is a reference implementation** for turning that underlying data into a listener-facing experience.
+- Artist profile language was moving from a generic bio/summary framing toward **"About."**
+- The team wanted a **source-first approach** to artist information rather than having AI freely author artist identity.
+- A low-pressure **story-gathering tool** was discussed: prompts delivered in a way that lets artists contribute context without requiring constant public content creation or performance.
+- Workflow ideas included weekly retrospectives/demos, information radiators, persistent repository memory files, and a weekly team summary email.
+- Pete's immediate work included clarifying bio/About data sourcing, the Web → TV pipeline, onboarding/claiming, empty states/contribution CTAs, and how experiments should be presented.
+
+This handoff focuses on what Pete + ChatGPT explored after that meeting, not on re-documenting the meeting itself.
+
+---
+
+## 2. Core product thesis that became clearer this week
+
+A narrower problem statement started to emerge beneath the many possible forms Music Nerd could take:
+
+**Artists and scenes need better ways to notice, capture, preserve, connect, and share the stories forming around their work on their own terms.**
+
+Music Nerd has been discussed as a database, profile, archive, publication, discovery engine, TV experience, research system, and storytelling toolkit. The exploration this week increasingly treated those as possible *forms* rather than the definition of the product.
+
+The more durable direction is that Music Nerd can provide **infrastructure, frameworks, and protocols for context** rather than trying to become a centralized editorial voice that tells every artist's story itself.
+
+### Implications
+
+- The database/record is necessary, but **a better database alone is not the product thesis**.
+- Storytelling should not require an artist to become a full-time content creator.
+- Music Nerd can help surface stories that are already latent across conversations, scenes, collaborators, releases, posts, credits, archives, and memories.
+- The platform should make those connections navigable without flattening them into a single polished AI summary.
+- The exact product form can remain somewhat unresolved while the core problem is tested with artists.
+
+---
+
+## 3. Major tensions explored
+
+These tensions kept resurfacing and appear more useful than prematurely locking a feature set.
+
+### Access vs. control
+Artists technically have more direct access to audiences than ever, but access to a microphone is not the same as control over how their story is represented, remembered, or connected.
+
+### Story vs. content production
+There is meaningful context around artists that may never become a post, campaign, interview, press release, or piece of content. Music Nerd should not make artists perform their identity on a publishing treadmill just to have that context preserved.
+
+### Frameworks vs. formulas
+A useful Music Nerd framework should help an artist notice and articulate what matters without becoming another EPK questionnaire, branding exercise, content template, or rigid storytelling formula.
+
+### Artist agency vs. many voices
+An artist's own voice matters, but scenes are made of collaborators, listeners, producers, engineers, friends, venues, writers, releases, and other witnesses. Music Nerd needs a way to hold multiple perspectives without implying that every contribution has equal authority.
+
+### Preservation vs. privacy
+Preserving context is valuable, but not everything should become public or permanent. Any long-term story/archive system needs consent, provenance, visibility controls, uncertainty, and a meaningful right to withhold.
+
+### Living person vs. frozen record
+A persistent artist record can easily become a static definition of a person. The system should preserve history without pretending the current summary is the final truth of who someone is.
+
+### Scale vs. intimacy
+The most meaningful artist conversations often depend on trust and good facilitation. Automating that intimacy would likely destroy what makes it valuable. The scaling question is therefore: **can Music Nerd scale the framework for good conversations rather than automate the human relationship itself?**
+
+### Infrastructure vs. editorial authority
+Music Nerd can have a strong point of view about how stories should be sourced, preserved, connected, and treated without insisting that Music Nerd itself must be the publication or narrator of every story.
+
+### AI assistance vs. AI authorship
+A working boundary emerged:
+
+- AI can help **transcribe, organize, search, connect, identify gaps, structure material, and produce drafts for review**.
+- AI should not become the unquestioned author of an artist's identity.
+- Human contributions, artist review/control, visible sources, provenance, and uncertainty should remain more authoritative than a complete-sounding answer.
+
+### Platform utility vs. platform dependency
+There is a DIY/punk instinct behind giving artists tools to document themselves without waiting for traditional media coverage. But Music Nerd could reproduce the same dependency problem if the history only exists inside Music Nerd. Portability and protocols that remain useful outside the interface are therefore important.
+
+---
+
+## 4. Substack / public writing exploration
+
+**No article prose is included in this handoff.** Only the themes and strategic function of the writing are recorded.
+
+The article work was used to pressure-test the Music Nerd thesis rather than simply announce product features.
+
+Themes explored:
+
+- Artists can distribute and speak directly to audiences more easily than in previous eras, but this does not automatically give them durable control of their story.
+- Music discovery is strong at similarity/recommendation but weaker at helping listeners follow the **human and cultural connective tissue** around music.
+- The problem is not necessarily that the information is missing; much of it is fragmented across many places and formats.
+- Music Nerd could provide **tools/frameworks/protocols** that help artists and scenes capture, organize, review, and preserve meaningful context.
+- Pete's role should be framed through his way of working — listening, producing, artist development, building systems, and shortening the distance between artist feedback and product decisions — rather than as a résumé or a grand claim of authority.
+- The project should communicate conviction about its values without pretending the final product form is already known.
+- Testing with a small group of artists should determine whether the useful outputs become platform features, protocols, workshops, editorial formats, or some combination.
+
+A recurring writing/product lesson: **do not over-explain Music Nerd.** The platform and the public writing both become weaker when every possible function is explained at once.
+
+---
+
+## 5. Anthony Bourdain / facilitation exploration
+
+A Bourdain-focused conversation became a useful model for how Music Nerd might approach artist storytelling.
+
+The important principle was not "make Music Nerd journalism like Bourdain." It was the method:
+
+- enter with curiosity rather than a predetermined thesis;
+- listen closely;
+- create conditions where people reveal what matters through their own details and relationships;
+- avoid repeatedly telling the audience why something is important;
+- do not over-insert the interviewer or institution into the story;
+- let context generate curiosity and care.
+
+### Product implication
+
+Music Nerd could behave less like an automated profile writer and more like a **facilitator of context**.
+
+Possible direction explored:
+
+1. Give artists/scenes thoughtful prompts or conversational frameworks.
+2. Capture raw conversation, memories, references, relationships, artifacts, and sources.
+3. Organize that material without pretending to replace the people who contributed it.
+4. Allow artists to review, approve, correct, hide, or expand it.
+5. Let listener experiences surface the relevant pieces at the right moment instead of publishing one giant definitive narrative.
+
+### Scaling implication
+
+The most interesting possibility may be a **protocol that artists/scenes can run themselves** rather than Music Nerd having to personally conduct every interview. Music Nerd supplies the structure, preservation, provenance, and connective layer; humans remain the actual participants.
+
+This also suggests a useful separation between **platform** and **editorial work**. Music Nerd can support or host editorial experiments without requiring the underlying infrastructure to become a centralized publication.
+
+---
+
+## 6. Product / UX direction reinforced this week
+
+Several prior interface instincts were reinforced by the storytelling discussion:
+
+- Music Nerd should feel **minimal, focused, and curiosity-led**, not like a publication homepage or a wall of explanatory copy.
+- The home experience should stay relatively close to the clarity of the current MusicNerd.xyz page rather than trying to explain the entire thesis in UI copy.
+- Avoid designing the product as "Wikipedia, but AI" or as a giant static artist dossier.
+- Listener discovery should reveal connections progressively: a person, place, collaborator, release, quote, source, scene, artifact, or relationship can become an entry point.
+- The system should not require a listener to connect Spotify before it can be interesting.
+- More data is not automatically more compelling. The useful unit is **context that creates a reason to become curious**.
+- "One screen / one job" remains a useful design constraint when prototyping.
+
+### Open product-form question
+
+The platform still has multiple layers that should not be collapsed prematurely:
+
+- trusted artist record / sources;
+- artist-controlled first-person context;
+- community/contributor context;
+- low-pressure story capture;
+- listener discovery / connection paths;
+- Music Nerd TV as an experiential surface;
+- experimental tools/protocols that may or may not belong directly inside the main Music Nerd interface.
+
+The work this week moved toward understanding how these layers relate instead of trying to make them all one screen or one feature.
+
+---
+
+## 7. About / artist identity direction from Pete + ChatGPT's perspective
+
+The "About" discussion increasingly aligned with a source-and-control model:
+
+- "About" should not be treated as permission for an LLM to improvise an artist biography.
+- A sourced factual record is a better floor than an eloquent but uncertain summary.
+- When information is missing, an honest gap plus a contribution/claim path is better than hallucinated completeness.
+- Artist-authored or artist-approved information should carry different authority from community or automated research.
+- Story capture may deserve to be a distinct layer from the factual About record rather than forcing every rich story into the profile summary.
+
+This is directly connected to the broader thesis: **AI can help navigate the archive; it should not become the archive's unquestioned narrator.**
+
+---
+
+## 8. Workflow / shared-context exploration
+
+Pete also explored the practical problem that Music Nerd context is fragmented across ChatGPT, Claude/Claude Code, Google Workspace meeting transcripts, GitHub, and Obsidian.
+
+The desired operating model is moving toward:
+
+- meeting transcripts / notes becoming durable shared inputs;
+- GitHub holding implementation state and project-adjacent Markdown context;
+- Obsidian holding structured knowledge / people / concepts where useful;
+- ChatGPT and Claude each contributing their own perspective without silently overwriting the other's record;
+- a weekly reconciliation layer that turns those separate perspectives into one status report for the team.
+
+A small related step was cleaning up structured context about Music Nerd people/relationships for use in the knowledge base, rather than relying on every AI workspace to reconstruct the same context from scratch.
+
+### New workflow created August 19
+
+This file is the first explicit **Pete + ChatGPT weekly handoff** for that system.
+
+A recurring ChatGPT task is scheduled for **Thursdays at 6:00 AM Eastern** to:
+
+1. collect Pete + ChatGPT's Music Nerd exploration since the previous meeting;
+2. inspect relevant repo activity as read-only context;
+3. create a new dated Markdown handoff under `docs/weekly-handoffs/`;
+4. never edit or overwrite `MEMORY.md`;
+5. give Pete a prompt for Claude to add Claude's own perspective and synthesize the weekly report/email.
+
+---
+
+## 9. Observed repository implementation snapshot — FOR RECONCILIATION ONLY
+
+This section is **not ChatGPT's authored project memory**. It is a read-only observation of recent `xdjs/MusicNerdWeb` commits / Claude-maintained state so Claude can reconcile this handoff against its own authoritative implementation record.
+
+Recent repository activity on August 16–17 appears to have materially advanced the "About" direction discussed above:
+
+- same-name artist conflation protections and catalog/verified-identity grounding;
+- retry behavior around source discovery;
+- movement toward the **vault as the source system** for About generation;
+- About synthesis from curated vault sources with model web search turned off;
+- claim/contribution empty-state behavior instead of fabricating a hollow bio;
+- forced regeneration gated to authorized editors;
+- additional review/polish around the About flow and empty-state copy.
+
+Relevant recent work includes PR/commit lines around **#1162, #1164, #1165, #1166, #1167, #1168**, followed by the staging → main release.
+
+**Claude should replace/expand this section with its own precise implementation notes. Do not use this summary as a substitute for `MEMORY.md`, PR history, or Claude Code session context.**
+
+---
+
+## 10. Where the thinking appears to be now
+
+### Increasingly clear
+
+- Music Nerd should help preserve and navigate the connective tissue around music, not merely aggregate links.
+- Artist agency, provenance, sourcing, and uncertainty are core product constraints, not compliance details to bolt on later.
+- AI is useful as infrastructure for capture/navigation/organization, but should not be the final authority on identity.
+- The strongest opportunity may be creating **frameworks and protocols that enable better human storytelling at scale**.
+- The listener experience should create curiosity through connections rather than explain everything upfront.
+- Music Nerd Web can remain the underlying record/data layer while Music Nerd TV and future experiments test different ways of experiencing that context.
+
+### Still unresolved
+
+- What is the smallest product that proves the storytelling/context thesis?
+- Is the low-pressure artist story tool email, SMS, an in-app conversation, a scheduled prompt, an interview kit, or a protocol that can use several channels?
+- What belongs in the factual About record versus a richer story/archive layer?
+- How should artist voice, sourced facts, and community contributions coexist in the interface and data model?
+- What is private by default, what is publishable, and how does an artist withdraw or revise context later?
+- How much editorial shaping should Music Nerd itself do?
+- How do we preserve contradiction and uncertainty without making the experience feel unusable?
+- What should flow from Music Nerd Web into TV, and at what level: sources, facts, story fragments, relationships, generated listener context, or all of the above?
+- Where do Music Nerd experiments live? Inside the primary product, as a separate lab surface, or both?
+- How do we test whether these tools actually reduce burden for artists rather than creating another form to maintain?
+- What are the first artists/scenes to test with, and what evidence would count as success?
+
+---
+
+## 11. Suggested synthesis frame for Claude
+
+When combining this with Claude's own notes, repo work, and meeting context, the useful weekly report should distinguish:
+
+1. **What we learned / clarified** — product and philosophical progress.
+2. **What actually shipped or changed** — repo / implementation facts.
+3. **What we tested** — user scenarios, technical experiments, prototypes, or conversations.
+4. **What remains unresolved** — real decisions still requiring evidence or discussion.
+5. **What should happen next** — the smallest concrete experiments or implementation tasks for the coming week.
+
+Avoid presenting every explored idea as a commitment. A major part of this week's work was narrowing the problem and identifying tensions, not declaring all possible Music Nerd concepts to be roadmap items.
+
+---
+
+## 12. Claude handoff instructions
+
+Claude / Claude Code should now:
+
+- read this file as **Pete + ChatGPT's weekly perspective**;
+- read `MEMORY.md`, recent commits/PRs, and relevant Claude conversations as Claude's separate perspective;
+- add any major Claude-side exploration or implementation work that is missing;
+- correct any repo implementation details that this file only observed at a high level;
+- reconcile duplicate or contradictory notes explicitly rather than silently overwriting one source;
+- produce a concise **Music Nerd Weekly Report / Status of Play**;
+- then synthesize a team email focused on what changed, what was learned, what is currently in motion, and what the team should discuss or do next.
+
+Do **not** reproduce draft Substack/article prose in the report. It is enough to say that the article was used to clarify the product thesis and list the themes/tensions explored.

--- a/docs/weekly-handoffs/2026-08-20-chatgpt-export.md
+++ b/docs/weekly-handoffs/2026-08-20-chatgpt-export.md
@@ -1,0 +1,85 @@
+# Music Nerd ChatGPT Export — August 20, 2026
+
+Source window: August 13–20, 2026. ChatGPT context only. This file is for Claude to consume later. It does not summarize Claude work or repository status.
+
+## Product vision
+
+Pete continued framing Music Nerd as more than a database or publication. Artist information is abundant but fragmented across social posts, interviews, profiles, collaborators, platforms, and fan communities. Direct publishing access does not necessarily give artists coherent control over their story.
+
+The direction explored is infrastructure, frameworks, prompts, or protocols that help artists surface, structure, preserve, and control stories that are otherwise latent or scattered. Music discovery should become better at connection rather than only similarity.
+
+The recurring conceptual layers were Voice (first-person artist perspective), Record (sourced/verified context), and Chorus (community or scene context). Pete pushed against treating these as merely content modules. The deeper question is how Music Nerd helps artists think about and capture their own stories over time.
+
+## Substack/article themes
+
+The article continued functioning as a pressure test for the product thesis. Actual article prose is intentionally excluded.
+
+Themes explored included the difference between artists having direct access to audiences and actually controlling their story; fragmentation of artist narratives across platforms; algorithmic pressure on how artists present themselves; Music Nerd as a provider of frameworks rather than a service that tells artists' stories for them; preserving the distinction between artist voice, sourced truth, and surrounding context; and the fact that writing the article kept exposing unresolved product tensions.
+
+Pete repeatedly rejected generic AI-sounding framing, unnecessary explanation, inflated claims, and overly polished language. He wanted contradictions and unresolved tensions to remain visible rather than being flattened into a clean thesis too early. He also wanted his own perspective and why he is positioned to work on the problem introduced naturally, without turning the piece into a formal founder narrative.
+
+## Bourdain as a facilitation model
+
+C.Y. shared a video about Anthony Bourdain's interviewing/facilitation style as a model for what Music Nerd could evoke from artist conversations. Pete explored this as platform behavior rather than just editorial tone.
+
+The useful principle was that the facilitator should create conditions where artists, places, scenes, collaborators, objects, memories, and relationships reveal why they matter instead of constantly explaining significance to the audience.
+
+Possible product implications explored: conversational story capture rather than CMS-style form filling; prompts built around concrete memories, relationships, places, influences, artifacts, and contradictions; preserving first-person voice; knowing when the system should get out of the way; and presenting listener-facing connections without excessive explanatory UI copy.
+
+## Product and UI corrections
+
+Pete continued pushing the prototype away from a publication or generic SaaS product. He said the interface had too much explanatory copy and should be more minimal and focused. Music Nerd should not repeatedly explain every section or explain the platform to the user. The home should remain close to the current MusicNerd.xyz structure while incorporating the newer branding and product direction. The product should work one screen at a time and should not feel like a publication.
+
+Pete repeatedly rejected generic UI patterns and verbose AI-generated interface language. He also wanted artist and listener use simulated during iteration rather than judging screens only as static design. The design tension is how to make Music Nerd deeper and more connective without making it denser or more explanatory.
+
+## Research/writer agent
+
+Pete explored a persistent Music Nerd research/writer agent that researches music, rising artists, scenes, social activity, and web sources, potentially using Apify to scrape social platforms and other sites.
+
+The desired value is not commodity music news. The agent should identify scenes forming before they become obvious, identify the artists and relationships inside those scenes, explain why a scene appears to be developing, notice patterns across disconnected signals, and turn research into curiosity and potential support. It should also help Pete reason about where music culture may be going and what Music Nerd might build.
+
+Pete described the desired sensibility as Hacker News / Y Combinator-style signal discovery for music nerds, while explicitly saying he does not want a news product. He wants real stories, patterns, developing scenes, overlooked connections, and signals useful for thinking about the future of music.
+
+## Two recurring Music Nerd reports
+
+Pete developed two distinct report concepts.
+
+The first is a high-signal Music Nerd/future briefing that surfaces developing scenes, artists inside them, why those scenes are forming, overlooked connections, cultural and technological patterns, implications for the future of music, implications for what Music Nerd might build, and opportunities to move from passive listening toward engaged curiosity/support. Pete emphasized that this should not become a daily music-news digest.
+
+The second is a separate editorial report with a sensibility closer to Pitchfork, Complex, and 2DopeBoyz mixed with music technology. Pete also explored including a small section of Google Trends terms related to music technology and culture as a lightweight signal layer.
+
+## Interactive music and streaming
+
+Pete brought in a TechRadar interview about the idea that a future major music platform should give people something to do with music, plus a Pigeons & Planes essay about alternative futures for music streaming.
+
+These references connected to an existing Music Nerd line of inquiry: streaming has optimized access and passive playback, while future music products may create more meaningful participation around music. This aligns with Pete's interest in moving listeners from passive consumption toward exploration, connection, participation, and artist support.
+
+## Patronage concept
+
+Pete explored an app where a listener sets aside a monthly music-support budget. Signals from listening behavior, potentially Spotify or Apple Music, combined with social interaction signals, could determine which artists the listener meaningfully engaged with that month.
+
+Ideas included ranking or tiering artists based on actual interaction, allocating the monthly support budget across one or more artists, and generating a radio-show-like monthly recap from songs collected during the month. The broader goal is making patronage feel connected to lived listening behavior rather than a generic donation flow.
+
+## Provenance / proof-of-life exploration
+
+Pete continued exploring provenance for music creation through the temporary concept name LinerOS and a proof-bearing media concept. The starting point was a trail showing when a song was created and metadata recording human contribution and authorship. Pete connected this to a more expansive proof-of-life idea involving identity/presence data and imagining a new proof-bearing file or container rather than relying only on conventional audio files.
+
+Questions explored included technical feasibility, what information should be attached, how human contribution could be demonstrated, whether provenance belongs inside a new format or alongside an existing media file, and how identity, authorship, AI contribution, session events, and proof-of-presence signals could relate. This connects to earlier Fizzy thinking around session provenance, contributor records, AI disclosure, splits, and sealed session receipts.
+
+## Shared-context workflow
+
+Pete explored fragmentation across ChatGPT, Claude, Google Workspace, GitHub, and Obsidian. Music Nerd meeting recordings land in Google Docs, but context then has to be moved manually between systems. Each workspace develops a fragmented understanding of the project.
+
+Questions included how these systems could access shared project context, how meeting transcripts could flow into that context without manual copy/paste, how coworkers could access the latest understanding, and how ChatGPT and Claude could contribute separate exploration histories without overwriting each other's perspective.
+
+This led to the current handoff boundary: ChatGPT exports only its own Music Nerd exploration into a dated Markdown file in GitHub. Claude handles its own context and any later synthesis. Pete explicitly corrected ChatGPT when it tried to include repository/project-state reconciliation and Claude synthesis instructions. He also explicitly required that ChatGPT not overwrite or reinterpret MEMORY.md because it is maintained by Claude Code and can contain context ChatGPT does not know.
+
+## Meeting workflow discussed
+
+A 60-minute weekly meeting structure discussed in ChatGPT was: vibe check; Pete runs the agenda; Pete leads planning for the next week; C.Y. or Carl leads keep/fix/try retrospective; C.Y. leads AMA. Jade was expected to receive the agenda but not attend that meeting.
+
+A related idea was for AI to assemble what happened during the week from relevant context before the meeting, while preserving the boundary between ChatGPT's context and Claude's context.
+
+## Through-lines
+
+Across the period, Pete repeatedly returned to these ideas: Music Nerd should not become another publication, database, or generic AI music product; artist stories need structures for capture and preservation without losing artist voice; the platform can facilitate reflection rather than merely generate biographies; listener discovery should create curiosity, participation, connection, and support; research should surface scenes, patterns, and relationships before they become obvious rather than summarize news; music technology matters when it changes how people create, understand, authenticate, participate in, or support music; and separate AI systems should contribute their own perspectives to shared project context without silently overwriting one another.


### PR DESCRIPTION
Adds the dated Pete + ChatGPT exploration handoff for Aug. 13–19, 2026 under `docs/weekly-handoffs/`.

Important boundary: this does not modify `MEMORY.md` or Claude Code's project state. The file is explicitly labeled as Pete + ChatGPT perspective and includes repo implementation only as read-only reconciliation context.