### PR TITLE
feat: add reciprocal Spotify and Deezer artist IDs

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -237,6 +237,7 @@ jest.mock('@/server/utils/musicPlatform', () => ({
         getArtistImages: jest.fn().mockResolvedValue(new Map()),
         getActivePlatform: jest.fn().mockReturnValue(null),
     },
+    findReciprocalArtistIdentity: jest.fn().mockResolvedValue(null),
     SpotifyProvider: jest.fn(),
     DeezerProvider: jest.fn(),
     ArtistMusicPlatformDataProvider: jest.fn(),
@@ -252,4 +253,4 @@ jest.mock('@/app/actions/serverActions', () => ({
     removeFromWhitelistAction: jest.fn(),
     addUsersToAdminAction: jest.fn(),
     removeFromAdminAction: jest.fn(),
-})); 
+}));

--- a/src/__tests__/components/AddArtistContent.test.tsx
+++ b/src/__tests__/components/AddArtistContent.test.tsx
@@ -93,6 +93,20 @@ describe('AddArtistContent duplicate choice', () => {
         expect(second).not.toHaveAccessibleName(/another-candidate-id/);
     });
 
+    it('does not offer force creation when the platform IDs are verified as the same artist', async () => {
+        mockAddArtist.mockResolvedValueOnce({
+            ...possibleDuplicate,
+            canCreateSeparate: false,
+            message: 'Wikidata links these profiles to the same artist.',
+        });
+        render(<AddArtistContent initialArtist={initialArtist} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Add Artist' }));
+
+        expect(await screen.findByText('Wikidata links these profiles to the same artist.')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /Add link to existing artist: Same Name/ })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Create separate artist' })).not.toBeInTheDocument();
+    });
+
     it('force-creates only after the user confirms this is a separate artist', async () => {
         await submitWithDuplicate();
         mockAddArtist.mockResolvedValueOnce({

--- a/src/app/_components/DuplicateArtistChoice.tsx
+++ b/src/app/_components/DuplicateArtistChoice.tsx
@@ -20,6 +20,7 @@ type DuplicateArtistChoiceProps = {
     platformId: string;
     message?: string;
     isCreatingSeparate: boolean;
+    canCreateSeparate?: boolean;
     onCreateSeparate: () => void | Promise<void>;
     onChooseExisting?: () => void;
 };
@@ -36,6 +37,7 @@ export default function DuplicateArtistChoice({
     platformId,
     message,
     isCreatingSeparate,
+    canCreateSeparate = true,
     onCreateSeparate,
     onChooseExisting,
 }: DuplicateArtistChoiceProps) {
@@ -103,19 +105,21 @@ export default function DuplicateArtistChoice({
                 })}
             </ul>
 
-            <div className="mt-4 border-t border-amber-200 pt-4">
-                <p className="mb-2 text-xs text-amber-900">
-                    Only create a separate artist if this is a different person or group with the same name.
-                </p>
-                <Button
-                    type="button"
-                    variant="outline"
-                    disabled={isCreatingSeparate}
-                    onClick={onCreateSeparate}
-                >
-                    {isCreatingSeparate ? "Creating..." : "Create separate artist"}
-                </Button>
-            </div>
+            {canCreateSeparate && (
+                <div className="mt-4 border-t border-amber-200 pt-4">
+                    <p className="mb-2 text-xs text-amber-900">
+                        Only create a separate artist if this is a different person or group with the same name.
+                    </p>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isCreatingSeparate}
+                        onClick={onCreateSeparate}
+                    >
+                        {isCreatingSeparate ? "Creating..." : "Create separate artist"}
+                    </Button>
+                </div>
+            )}
         </section>
     );
 }

--- a/src/app/_components/nav/components/AddArtist.tsx
+++ b/src/app/_components/nav/components/AddArtist.tsx
@@ -91,7 +91,11 @@ export default function AddArtist() {
     }
 
     async function handleCreateSeparate() {
-        if (addArtistStatus?.status !== "possible_duplicate" || requestInFlightRef.current) return;
+        if (
+            addArtistStatus?.status !== "possible_duplicate"
+            || addArtistStatus.canCreateSeparate === false
+            || requestInFlightRef.current
+        ) return;
 
         const requestGeneration = ++requestGenerationRef.current;
         requestInFlightRef.current = true;
@@ -248,6 +252,7 @@ export default function AddArtist() {
                                                 platformId={addArtistStatus.platformId}
                                                 message={addArtistStatus.message}
                                                 isCreatingSeparate={isCreatingSeparate}
+                                                canCreateSeparate={addArtistStatus.canCreateSeparate}
                                                 onCreateSeparate={handleCreateSeparate}
                                                 onChooseExisting={() => closeModal(false)}
                                             />

--- a/src/app/_components/nav/components/SearchBar.tsx
+++ b/src/app/_components/nav/components/SearchBar.tsx
@@ -47,6 +47,7 @@ type PossibleDuplicateResponse = {
     platform: MusicPlatform;
     platformId: string;
     message?: string;
+    canCreateSeparate?: boolean;
 };
 
 function SearchBarInner({ isTopSide = false }: SearchBarProps) {
@@ -115,7 +116,11 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
     }, [router, toast]);
 
     const handleCreateSeparate = useCallback(async () => {
-        if (!duplicateChoice || addRequestInFlightRef.current) return;
+        if (
+            !duplicateChoice
+            || duplicateChoice.canCreateSeparate === false
+            || addRequestInFlightRef.current
+        ) return;
 
         const response = duplicateChoice;
         const requestGeneration = ++addRequestGenerationRef.current;
@@ -323,6 +328,7 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
                         platformId={duplicateChoice.platformId}
                         message={duplicateChoice.message}
                         isCreatingSeparate={isCreatingSeparate}
+                        canCreateSeparate={duplicateChoice.canCreateSeparate}
                         onCreateSeparate={handleCreateSeparate}
                         onChooseExisting={() => {
                             invalidateAddRequest();

--- a/src/app/add-artist/_components/AddArtistContent.tsx
+++ b/src/app/add-artist/_components/AddArtistContent.tsx
@@ -14,6 +14,7 @@ type PossibleDuplicateResponse = {
     platform: MusicPlatform;
     platformId: string;
     message?: string;
+    canCreateSeparate?: boolean;
 };
 
 export default function AddArtistContent({ initialArtist }: { initialArtist: MusicPlatformArtist }) {
@@ -78,7 +79,11 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
     }
 
     async function handleCreateSeparate() {
-        if (!duplicateChoice || isCreatingSeparate) return;
+        if (
+            !duplicateChoice
+            || duplicateChoice.canCreateSeparate === false
+            || isCreatingSeparate
+        ) return;
 
         setIsCreatingSeparate(true);
         setError(null);
@@ -171,6 +176,7 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
                         platformId={duplicateChoice.platformId}
                         message={duplicateChoice.message}
                         isCreatingSeparate={isCreatingSeparate}
+                        canCreateSeparate={duplicateChoice.canCreateSeparate}
                         onCreateSeparate={handleCreateSeparate}
                     />
                 )}

--- a/src/server/utils/musicPlatform/__tests__/crossPlatformArtistResolver.test.ts
+++ b/src/server/utils/musicPlatform/__tests__/crossPlatformArtistResolver.test.ts
@@ -1,0 +1,206 @@
+// @ts-nocheck
+import { jest } from '@jest/globals';
+
+const mockDeezerGetArtist = jest.fn();
+const mockSpotifyGetArtist = jest.fn();
+
+jest.mock('../deezerProvider', () => ({
+    deezerProvider: { getArtist: mockDeezerGetArtist },
+}));
+
+jest.mock('../spotifyProvider', () => ({
+    spotifyProvider: { getArtist: mockSpotifyGetArtist },
+}));
+
+function wikidataResponse(rows: Array<{ entity: string; targetId: string }>) {
+    return {
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue({
+            results: {
+                bindings: rows.map(({ entity, targetId }) => ({
+                    item: { value: `http://www.wikidata.org/entity/${entity}` },
+                    targetId: { value: targetId },
+                })),
+            },
+        }),
+    };
+}
+
+describe('findReciprocalArtistIdentity', () => {
+    let findReciprocalArtistIdentity: typeof import('../crossPlatformArtistResolver').findReciprocalArtistIdentity;
+    let mockFetch: jest.Mock;
+
+    beforeEach(async () => {
+        jest.resetModules();
+        jest.clearAllMocks();
+        mockFetch = global.fetch as jest.Mock;
+        mockFetch.mockResolvedValue(wikidataResponse([]));
+        mockDeezerGetArtist.mockResolvedValue(null);
+        mockSpotifyGetArtist.mockResolvedValue(null);
+        ({ findReciprocalArtistIdentity } = await import('../crossPlatformArtistResolver'));
+    });
+
+    it('resolves a Deezer artist to Spotify through one Wikidata entity and verifies its name', async () => {
+        mockFetch.mockResolvedValue(wikidataResponse([{
+            entity: 'Q36153',
+            targetId: '6vWDO969PvNqNYHIOW5v0m',
+        }]));
+        mockSpotifyGetArtist.mockResolvedValue({
+            platform: 'spotify',
+            platformId: '6vWDO969PvNqNYHIOW5v0m',
+            name: 'Beyoncé',
+        });
+
+        await expect(findReciprocalArtistIdentity({
+            platform: 'deezer',
+            platformId: '145',
+            name: 'Beyonce',
+        })).resolves.toEqual({
+            platform: 'spotify',
+            platformId: '6vWDO969PvNqNYHIOW5v0m',
+            source: 'wikidata',
+            wikidataId: 'Q36153',
+        });
+        expect(mockSpotifyGetArtist).toHaveBeenCalledWith('6vWDO969PvNqNYHIOW5v0m');
+        expect(mockDeezerGetArtist).not.toHaveBeenCalled();
+        expect(mockFetch).toHaveBeenCalledWith(
+            'https://query.wikidata.org/sparql',
+            expect.objectContaining({
+                method: 'POST',
+                body: expect.stringContaining('query='),
+            }),
+        );
+        const requestBody = mockFetch.mock.calls[0][1].body as string;
+        expect(decodeURIComponent(requestBody)).toContain('wdt:P2722 "145"');
+        expect(decodeURIComponent(requestBody)).toContain('wdt:P1902 ?targetId');
+    });
+
+    it('resolves a Spotify artist to Deezer and verifies the target profile', async () => {
+        mockFetch.mockResolvedValue(wikidataResponse([{
+            entity: 'Q36153',
+            targetId: '145',
+        }]));
+        mockDeezerGetArtist.mockResolvedValue({
+            platform: 'deezer',
+            platformId: '145',
+            name: 'Beyoncé',
+        });
+
+        await expect(findReciprocalArtistIdentity({
+            platform: 'spotify',
+            platformId: '6vWDO969PvNqNYHIOW5v0m',
+            name: 'Beyonce',
+        })).resolves.toEqual({
+            platform: 'deezer',
+            platformId: '145',
+            source: 'wikidata',
+            wikidataId: 'Q36153',
+        });
+        expect(mockDeezerGetArtist).toHaveBeenCalledWith('145');
+        const requestBody = mockFetch.mock.calls[0][1].body as string;
+        expect(decodeURIComponent(requestBody)).toContain('wdt:P1902 "6vWDO969PvNqNYHIOW5v0m"');
+        expect(decodeURIComponent(requestBody)).toContain('wdt:P2722 ?targetId');
+    });
+
+    it('rejects malformed source IDs before querying Wikidata', async () => {
+        await expect(findReciprocalArtistIdentity({
+            platform: 'spotify',
+            platformId: 'bad-id-with-punctuation',
+            name: 'Artist',
+        })).resolves.toBeNull();
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(mockDeezerGetArtist).not.toHaveBeenCalled();
+    });
+
+    it('returns null when a source ID is attached to multiple Wikidata entities', async () => {
+        mockFetch.mockResolvedValue(wikidataResponse([
+            { entity: 'Q1', targetId: '123' },
+            { entity: 'Q2', targetId: '123' },
+        ]));
+
+        await expect(findReciprocalArtistIdentity({
+            platform: 'spotify',
+            platformId: 'spotify123',
+            name: 'Artist',
+        })).resolves.toBeNull();
+        expect(mockDeezerGetArtist).not.toHaveBeenCalled();
+    });
+
+    it('returns null when Wikidata has multiple target IDs for one entity', async () => {
+        mockFetch.mockResolvedValue(wikidataResponse([
+            { entity: 'Q1', targetId: '123' },
+            { entity: 'Q1', targetId: '456' },
+        ]));
+
+        await expect(findReciprocalArtistIdentity({
+            platform: 'spotify',
+            platformId: 'spotify123',
+            name: 'Artist',
+        })).resolves.toBeNull();
+        expect(mockDeezerGetArtist).not.toHaveBeenCalled();
+    });
+
+    it('rejects a Wikidata counterpart whose target-platform name does not match', async () => {
+        mockFetch.mockResolvedValue(wikidataResponse([{
+            entity: 'Q1',
+            targetId: '123',
+        }]));
+        mockDeezerGetArtist.mockResolvedValue({
+            platform: 'deezer',
+            platformId: '123',
+            name: 'Different Artist',
+        });
+
+        await expect(findReciprocalArtistIdentity({
+            platform: 'spotify',
+            platformId: 'spotify123',
+            name: 'Artist',
+        })).resolves.toBeNull();
+    });
+
+    it('logs Wikidata failures and returns null', async () => {
+        const error = new Error('Wikidata unavailable');
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        mockFetch.mockRejectedValue(error);
+
+        try {
+            await expect(findReciprocalArtistIdentity({
+                platform: 'deezer',
+                platformId: '145',
+                name: 'Artist',
+            })).resolves.toBeNull();
+            expect(consoleError).toHaveBeenCalledWith(
+                '[CrossPlatformArtistResolver] Failed to resolve deezer:145:',
+                error,
+            );
+        } finally {
+            consoleError.mockRestore();
+        }
+    });
+
+    it('bounds target-provider verification time and falls back to no counterpart', async () => {
+        jest.useFakeTimers();
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        mockFetch.mockResolvedValue(wikidataResponse([{
+            entity: 'Q1',
+            targetId: '123',
+        }]));
+        mockDeezerGetArtist.mockReturnValue(new Promise(() => undefined));
+
+        try {
+            const result = findReciprocalArtistIdentity({
+                platform: 'spotify',
+                platformId: 'spotify123',
+                name: 'Artist',
+            });
+            await Promise.resolve();
+            await Promise.resolve();
+            await jest.advanceTimersByTimeAsync(5000);
+            await expect(result).resolves.toBeNull();
+        } finally {
+            consoleError.mockRestore();
+            jest.useRealTimers();
+        }
+    });
+});

--- a/src/server/utils/musicPlatform/crossPlatformArtistResolver.ts
+++ b/src/server/utils/musicPlatform/crossPlatformArtistResolver.ts
@@ -1,0 +1,167 @@
+import { deezerProvider } from './deezerProvider';
+import { spotifyProvider } from './spotifyProvider';
+import type { MusicPlatform, MusicPlatformArtist } from './types';
+
+export type ReciprocalArtistIdentity = {
+    platform: MusicPlatform;
+    platformId: string;
+    source: 'wikidata';
+    wikidataId: string;
+};
+
+const WIKIDATA_ENDPOINT = 'https://query.wikidata.org/sparql';
+const WIKIDATA_TIMEOUT_MS = 4000;
+const PROVIDER_VERIFICATION_TIMEOUT_MS = 5000;
+const USER_AGENT = 'MusicNerdWeb/1.0 (https://musicnerd.xyz; contact@musicnerd.xyz)';
+
+const WIKIDATA_PLATFORM_PROPERTY: Record<MusicPlatform, string> = {
+    spotify: 'P1902',
+    deezer: 'P2722',
+};
+
+type WikidataBinding = {
+    item?: { value?: string };
+    targetId?: { value?: string };
+};
+
+function normalizeArtistName(name: string): string {
+    return name
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .replace(/^the\s+/, '')
+        .replace(/\s+(?:feat|ft|featuring)\s+.*/, '')
+        .trim();
+}
+
+function isValidPlatformId(platform: MusicPlatform, platformId: string): boolean {
+    return platform === 'deezer'
+        ? /^\d+$/.test(platformId)
+        : /^[A-Za-z0-9]+$/.test(platformId);
+}
+
+async function withTimeout<T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+    label: string,
+): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+            () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+            timeoutMs,
+        );
+    });
+
+    try {
+        return await Promise.race([promise, timeout]);
+    } finally {
+        if (timeoutId) clearTimeout(timeoutId);
+    }
+}
+
+async function findWikidataCounterpart(
+    sourcePlatform: MusicPlatform,
+    sourcePlatformId: string,
+    targetPlatform: MusicPlatform,
+): Promise<{ platformId: string; wikidataId: string } | null> {
+    if (!isValidPlatformId(sourcePlatform, sourcePlatformId)) return null;
+
+    const sourceProperty = WIKIDATA_PLATFORM_PROPERTY[sourcePlatform];
+    const targetProperty = WIKIDATA_PLATFORM_PROPERTY[targetPlatform];
+    const sparql = `
+SELECT ?item ?targetId WHERE {
+  ?item wdt:${sourceProperty} "${sourcePlatformId}" .
+  ?item wdt:${targetProperty} ?targetId .
+}
+LIMIT 10`;
+    const response = await fetch(WIKIDATA_ENDPOINT, {
+        method: 'POST',
+        headers: {
+            Accept: 'application/sparql-results+json',
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'User-Agent': USER_AGENT,
+        },
+        body: `query=${encodeURIComponent(sparql)}`,
+        signal: AbortSignal.timeout(WIKIDATA_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+        throw new Error(`Wikidata SPARQL returned ${response.status}`);
+    }
+
+    const data = await response.json() as {
+        results?: { bindings?: WikidataBinding[] };
+    };
+    const entityIds = new Set<string>();
+    const targetIds = new Set<string>();
+
+    for (const binding of data.results?.bindings ?? []) {
+        const entityId = binding.item?.value?.split('/').pop()?.trim();
+        const targetId = binding.targetId?.value?.trim();
+        if (
+            !entityId
+            || !/^Q\d+$/.test(entityId)
+            || !targetId
+            || !isValidPlatformId(targetPlatform, targetId)
+        ) {
+            continue;
+        }
+        entityIds.add(entityId);
+        targetIds.add(targetId);
+    }
+
+    if (entityIds.size !== 1 || targetIds.size !== 1) return null;
+
+    return {
+        platformId: targetIds.values().next().value!,
+        wikidataId: entityIds.values().next().value!,
+    };
+}
+
+export async function findReciprocalArtistIdentity(
+    artist: Pick<MusicPlatformArtist, 'platform' | 'platformId' | 'name'>,
+): Promise<ReciprocalArtistIdentity | null> {
+    const normalizedName = normalizeArtistName(artist.name);
+    if (!normalizedName) return null;
+
+    const targetPlatform: MusicPlatform = artist.platform === 'deezer' ? 'spotify' : 'deezer';
+    const targetProvider = targetPlatform === 'spotify' ? spotifyProvider : deezerProvider;
+
+    try {
+        const counterpart = await findWikidataCounterpart(
+            artist.platform,
+            artist.platformId,
+            targetPlatform,
+        );
+        if (!counterpart) return null;
+
+        const verifiedArtist = await withTimeout(
+            targetProvider.getArtist(counterpart.platformId),
+            PROVIDER_VERIFICATION_TIMEOUT_MS,
+            `${targetPlatform} artist verification`,
+        );
+        if (
+            !verifiedArtist
+            || normalizeArtistName(verifiedArtist.name) !== normalizedName
+        ) {
+            return null;
+        }
+
+        return {
+            platform: targetPlatform,
+            platformId: counterpart.platformId,
+            source: 'wikidata',
+            wikidataId: counterpart.wikidataId,
+        };
+    } catch (error) {
+        console.error(
+            `[CrossPlatformArtistResolver] Failed to resolve ${artist.platform}:${artist.platformId}:`,
+            error,
+        );
+        return null;
+    }
+}

--- a/src/server/utils/musicPlatform/index.ts
+++ b/src/server/utils/musicPlatform/index.ts
@@ -2,6 +2,8 @@ export type { MusicPlatform, MusicPlatformArtist, MusicPlatformProvider } from '
 export { SpotifyProvider, spotifyProvider } from './spotifyProvider';
 export { DeezerProvider, deezerProvider } from './deezerProvider';
 export { ArtistMusicPlatformDataProvider } from './artistMusicPlatformDataProvider';
+export { findReciprocalArtistIdentity } from './crossPlatformArtistResolver';
+export type { ReciprocalArtistIdentity } from './crossPlatformArtistResolver';
 
 import { deezerProvider } from './deezerProvider';
 import { spotifyProvider } from './spotifyProvider';

--- a/src/server/utils/queries/__tests__/addArtistIdentity.test.ts
+++ b/src/server/utils/queries/__tests__/addArtistIdentity.test.ts
@@ -3,11 +3,23 @@ import { jest } from "@jest/globals";
 
 const mockSpotifyGetArtist = jest.fn();
 const mockDeezerGetArtist = jest.fn();
+const mockFindReciprocalArtistIdentity = jest.fn();
+const mockAcquirePlatformIdentityLock = jest.fn();
+const mockAcquireArtistNameLock = jest.fn();
 
 jest.mock("@/server/auth", () => ({ getServerAuthSession: jest.fn() }));
 jest.mock("@/server/utils/musicPlatform", () => ({
-    spotifyProvider: { getArtist: mockSpotifyGetArtist },
-    deezerProvider: { getArtist: mockDeezerGetArtist },
+    spotifyProvider: {
+        getArtist: mockSpotifyGetArtist,
+    },
+    deezerProvider: {
+        getArtist: mockDeezerGetArtist,
+    },
+    findReciprocalArtistIdentity: mockFindReciprocalArtistIdentity,
+}));
+jest.mock("@/server/utils/artistIdentityLocks", () => ({
+    acquirePlatformIdentityLock: mockAcquirePlatformIdentityLock,
+    acquireArtistNameLock: mockAcquireArtistNameLock,
 }));
 jest.mock("@/server/utils/queries/userQueries", () => ({
     getUserById: jest.fn(),
@@ -33,6 +45,15 @@ function artist(overrides: Record<string, unknown> = {}) {
         spotify: null,
         deezer: null,
         ...overrides,
+    };
+}
+
+function reciprocalIdentity(platform: "spotify" | "deezer", platformId: string) {
+    return {
+        platform,
+        platformId,
+        source: "wikidata",
+        wikidataId: "Q123",
     };
 }
 
@@ -75,6 +96,9 @@ describe("addArtist identity resolution", () => {
         mockSendDiscordMessage.mockResolvedValue(undefined);
         mockSpotifyGetArtist.mockResolvedValue({ name: "Jonathan Pape" });
         mockDeezerGetArtist.mockResolvedValue({ name: "Jonathan Pape" });
+        mockFindReciprocalArtistIdentity.mockResolvedValue(null);
+        mockAcquirePlatformIdentityLock.mockResolvedValue(undefined);
+        mockAcquireArtistNameLock.mockResolvedValue(undefined);
         mockDb.query.artists.findFirst.mockResolvedValue(null);
         mockDb.query.artists.findMany.mockResolvedValue([]);
         mockDb.query.artistIdMappings.findFirst.mockResolvedValue(null);
@@ -208,6 +232,195 @@ describe("addArtist identity resolution", () => {
         expect(insert.onConflictDoNothing).toHaveBeenCalledWith();
     });
 
+    it.each([
+        {
+            submittedPlatform: "spotify",
+            submittedId: "spotify-123",
+            reciprocalPlatform: "deezer",
+            reciprocalId: "815939",
+        },
+        {
+            submittedPlatform: "deezer",
+            submittedId: "815939",
+            reciprocalPlatform: "spotify",
+            reciprocalId: "spotify-123",
+        },
+    ])(
+        "adds the $reciprocalPlatform ID when creating an artist from $submittedPlatform",
+        async ({ submittedPlatform, submittedId, reciprocalPlatform, reciprocalId }) => {
+            const { addArtist, mockDb } = await setup();
+            mockFindReciprocalArtistIdentity.mockResolvedValue(
+                reciprocalIdentity(reciprocalPlatform, reciprocalId),
+            );
+            const inserted = artist({
+                id: "new-artist",
+                spotify: "spotify-123",
+                deezer: "815939",
+            });
+            const insert = mockInsertReturning(mockDb, [inserted]);
+
+            const result = await addArtist(
+                submittedId,
+                submittedPlatform,
+                { forceCreate: true },
+            );
+
+            expect(result).toEqual(expect.objectContaining({
+                status: "success",
+                artistId: "new-artist",
+            }));
+            expect(mockFindReciprocalArtistIdentity).toHaveBeenCalledWith({
+                platform: submittedPlatform,
+                platformId: submittedId,
+                name: "Jonathan Pape",
+            });
+            expect(insert.values).toHaveBeenCalledWith(expect.objectContaining({
+                spotify: "spotify-123",
+                deezer: "815939",
+            }));
+            expect(mockDb.execute).toHaveBeenCalledTimes(1);
+            expect(mockAcquirePlatformIdentityLock.mock.calls.map(([, lockedPlatform, lockedId]) => (
+                [lockedPlatform, lockedId]
+            ))).toEqual([
+                ["deezer", "815939"],
+                ["spotify", "spotify-123"],
+            ]);
+        },
+    );
+
+    it("creates with only the submitted ID when no reciprocal identity is resolved", async () => {
+        const { addArtist, mockDb } = await setup();
+        const insert = mockInsertReturning(mockDb, [
+            artist({ id: "new-artist", spotify: "spotify-123" }),
+        ]);
+
+        const result = await addArtist("spotify-123", "spotify", { forceCreate: true });
+
+        expect(result.status).toBe("success");
+        expect(insert.values).toHaveBeenCalledWith(expect.objectContaining({
+            spotify: "spotify-123",
+        }));
+        expect(insert.values).not.toHaveBeenCalledWith(expect.objectContaining({
+            deezer: expect.anything(),
+        }));
+        expect(mockAcquirePlatformIdentityLock).toHaveBeenCalledTimes(1);
+    });
+
+    it("offers the owner of a discovered reciprocal ID instead of creating a duplicate", async () => {
+        const { addArtist, mockDb } = await setup();
+        const reciprocalOwner = artist({
+            id: "deezer-owner",
+            spotify: null,
+            deezer: "815939",
+        });
+        mockFindReciprocalArtistIdentity.mockResolvedValue(
+            reciprocalIdentity("deezer", "815939"),
+        );
+        mockDb.query.artists.findFirst
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(reciprocalOwner);
+
+        const result = await addArtist("spotify-123", "spotify");
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "possible_duplicate",
+            candidates: [reciprocalOwner],
+            platform: "spotify",
+            platformId: "spotify-123",
+            canCreateSeparate: false,
+        }));
+        expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("recognizes a reciprocal ID owner recorded only in the mapping table", async () => {
+        const { addArtist, mockDb } = await setup();
+        const reciprocalOwner = artist({
+            id: "mapped-owner",
+            spotify: null,
+            deezer: null,
+        });
+        mockFindReciprocalArtistIdentity.mockResolvedValue(
+            reciprocalIdentity("deezer", "815939"),
+        );
+        mockDb.query.artists.findFirst
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(reciprocalOwner);
+        mockDb.query.artistIdMappings.findFirst
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({ artistId: "mapped-owner" });
+
+        const result = await addArtist("spotify-123", "spotify");
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "possible_duplicate",
+            candidates: [reciprocalOwner],
+        }));
+        expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("returns a conflict when submitted and reciprocal IDs have different owners", async () => {
+        const { addArtist, mockDb } = await setup();
+        const spotifyOwner = artist({ id: "spotify-owner", spotify: "spotify-123" });
+        const deezerOwner = artist({ id: "deezer-owner", deezer: "815939" });
+        mockFindReciprocalArtistIdentity.mockResolvedValue(
+            reciprocalIdentity("deezer", "815939"),
+        );
+        mockDb.query.artists.findFirst
+            .mockResolvedValueOnce(spotifyOwner)
+            .mockResolvedValueOnce(deezerOwner);
+
+        const result = await addArtist("spotify-123", "spotify");
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "conflict",
+            candidates: [spotifyOwner, deezerOwner],
+        }));
+        expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("returns the existing artist when both platform IDs have the same owner", async () => {
+        const { addArtist, mockDb } = await setup();
+        const existing = artist({
+            id: "existing-owner",
+            spotify: "spotify-123",
+            deezer: "815939",
+        });
+        mockFindReciprocalArtistIdentity.mockResolvedValue(
+            reciprocalIdentity("deezer", "815939"),
+        );
+        mockDb.query.artists.findFirst
+            .mockResolvedValueOnce(existing)
+            .mockResolvedValueOnce(existing);
+
+        const result = await addArtist("spotify-123", "spotify");
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "exists",
+            artistId: "existing-owner",
+        }));
+        expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("does not let forceCreate bypass reciprocal platform ownership", async () => {
+        const { addArtist, mockDb } = await setup();
+        const reciprocalOwner = artist({ id: "deezer-owner", deezer: "815939" });
+        mockFindReciprocalArtistIdentity.mockResolvedValue(
+            reciprocalIdentity("deezer", "815939"),
+        );
+        mockDb.query.artists.findFirst
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(reciprocalOwner);
+
+        const result = await addArtist("spotify-123", "spotify", { forceCreate: true });
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "conflict",
+            candidates: [reciprocalOwner],
+        }));
+        expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
     it("returns the race winner when a conflict-safe insert creates no row", async () => {
         const { addArtist, mockDb } = await setup();
         const raceWinner = artist({ id: "race-winner", spotify: "spotify-123" });
@@ -225,6 +438,35 @@ describe("addArtist identity resolution", () => {
             status: "exists",
             artistId: "race-winner",
             artistName: "Jonathan Pape",
+        }));
+    });
+
+    it("re-resolves the reciprocal ID when a dual-ID insert loses a race", async () => {
+        const { addArtist, mockDb } = await setup();
+        const reciprocalRaceWinner = artist({
+            id: "reciprocal-race-winner",
+            deezer: "815939",
+        });
+        mockFindReciprocalArtistIdentity.mockResolvedValue(
+            reciprocalIdentity("deezer", "815939"),
+        );
+        mockInsertReturning(mockDb, []);
+        mockDb.query.artists.findFirst
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(reciprocalRaceWinner);
+        mockDb.query.artistIdMappings.findFirst
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(null);
+
+        const result = await addArtist("spotify-123", "spotify");
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "possible_duplicate",
+            candidates: [reciprocalRaceWinner],
         }));
     });
 

--- a/src/server/utils/queries/artistQueries.ts
+++ b/src/server/utils/queries/artistQueries.ts
@@ -1,6 +1,10 @@
 import { db } from "@/server/db/drizzle";
 import { getSpotifyHeaders, getSpotifyArtist } from "@/server/utils/queries/externalApiQueries";
-import { deezerProvider, spotifyProvider } from "@/server/utils/musicPlatform";
+import {
+    deezerProvider,
+    findReciprocalArtistIdentity,
+    spotifyProvider,
+} from "@/server/utils/musicPlatform";
 import type { MusicPlatform } from "@/server/utils/musicPlatform";
 import { eq, sql, inArray, and, arrayContains, asc } from "drizzle-orm";
 import { artists, artistIdMappings, ugcresearch } from "@/server/db/schema";
@@ -79,6 +83,7 @@ export type AddArtistResp =
         candidates: AddArtistCandidate[];
         platform: MusicPlatform;
         platformId: string;
+        canCreateSeparate?: boolean;
     })
     | (AddArtistRespCommon & {
         status: "conflict";
@@ -361,6 +366,11 @@ type ArtistCreationExecutor = Pick<typeof db, "query" | "execute" | "insert">;
 
 const ADD_ARTIST_CANDIDATE_LIMIT = 10;
 
+type ArtistPlatformIdentity = {
+    platform: MusicPlatform;
+    platformId: string;
+};
+
 function toAddArtistCandidate(artist: Pick<Artist, "id" | "name" | "spotify" | "deezer">): AddArtistCandidate {
     return {
         id: artist.id,
@@ -427,6 +437,104 @@ async function resolvePlatformIdOwner(
     return { status: "owner", owner: mappedCandidate };
 }
 
+function sortArtistPlatformIdentities(
+    identities: ArtistPlatformIdentity[],
+): ArtistPlatformIdentity[] {
+    return [...identities].sort((left, right) => {
+        const platformOrder = left.platform.localeCompare(right.platform);
+        return platformOrder !== 0
+            ? platformOrder
+            : left.platformId.localeCompare(right.platformId);
+    });
+}
+
+function dedupeAddArtistCandidates(
+    candidates: AddArtistCandidate[],
+): AddArtistCandidate[] {
+    return [...new Map(candidates.map((candidate) => [candidate.id, candidate])).values()];
+}
+
+function getIdentityOwnershipResponse(params: {
+    submittedIdentity: ArtistPlatformIdentity;
+    submittedOwnership: PlatformIdOwnerResolution;
+    reciprocalIdentity: ArtistPlatformIdentity | null;
+    reciprocalOwnership: PlatformIdOwnerResolution;
+    forceCreate: boolean;
+}): AddArtistResp | null {
+    const {
+        submittedIdentity,
+        submittedOwnership,
+        reciprocalIdentity,
+        reciprocalOwnership,
+        forceCreate,
+    } = params;
+    const ownershipConflicts = [submittedOwnership, reciprocalOwnership]
+        .filter((ownership): ownership is Extract<PlatformIdOwnerResolution, { status: "conflict" }> => (
+            ownership.status === "conflict"
+        ));
+
+    if (ownershipConflicts.length > 0) {
+        return {
+            status: "conflict",
+            candidates: dedupeAddArtistCandidates(
+                ownershipConflicts.flatMap((ownership) => ownership.candidates),
+            ),
+            platform: submittedIdentity.platform,
+            platformId: submittedIdentity.platformId,
+            message: "Those platform profiles are assigned to conflicting artist records",
+        };
+    }
+
+    const submittedOwner = submittedOwnership.status === "owner"
+        ? submittedOwnership.owner
+        : null;
+    const reciprocalOwner = reciprocalOwnership.status === "owner"
+        ? reciprocalOwnership.owner
+        : null;
+
+    if (submittedOwner && reciprocalOwner && submittedOwner.id !== reciprocalOwner.id) {
+        return {
+            status: "conflict",
+            candidates: dedupeAddArtistCandidates([submittedOwner, reciprocalOwner]),
+            platform: submittedIdentity.platform,
+            platformId: submittedIdentity.platformId,
+            message: "The matching Spotify and Deezer profiles belong to different artist records",
+        };
+    }
+
+    if (submittedOwner) {
+        return {
+            status: "exists",
+            artistId: submittedOwner.id,
+            artistName: submittedOwner.name ?? "",
+            message: "That artist is already in our database",
+        };
+    }
+
+    if (reciprocalOwner && reciprocalIdentity) {
+        if (forceCreate) {
+            return {
+                status: "conflict",
+                candidates: [reciprocalOwner],
+                platform: submittedIdentity.platform,
+                platformId: submittedIdentity.platformId,
+                message: `The matching ${reciprocalIdentity.platform} profile already belongs to another artist`,
+            };
+        }
+
+        return {
+            status: "possible_duplicate",
+            candidates: [reciprocalOwner],
+            platform: submittedIdentity.platform,
+            platformId: submittedIdentity.platformId,
+            canCreateSeparate: false,
+            message: `Wikidata links this profile to an existing artist's ${reciprocalIdentity.platform} profile. Add the submitted link to that artist.`,
+        };
+    }
+
+    return null;
+}
+
 export async function addArtist(
     platformId: string,
     platform: MusicPlatform = 'spotify',
@@ -463,35 +571,60 @@ export async function addArtist(
             return { status: "error", message: `Could not find artist on ${platform}` };
         }
 
+        const reciprocalIdentity = await findReciprocalArtistIdentity({
+            platform,
+            platformId,
+            name: platformArtist.name,
+        });
+        const submittedIdentity = { platform, platformId } satisfies ArtistPlatformIdentity;
+        const identities = sortArtistPlatformIdentities([
+            submittedIdentity,
+            ...(reciprocalIdentity ? [reciprocalIdentity] : []),
+        ]);
         const normalisedName = normaliseText(platformArtist.name);
         let notificationCreatedAt: string | null | undefined;
         const result = await db.transaction(async (transaction): Promise<AddArtistResp> => {
             const database = transaction as ArtistCreationExecutor;
-            await acquirePlatformIdentityLock(database, platform, platformId);
+            for (const identity of identities) {
+                await acquirePlatformIdentityLock(
+                    database,
+                    identity.platform,
+                    identity.platformId,
+                );
+            }
             if (!options?.forceCreate) {
                 await acquireArtistNameLock(database, normalisedName);
             }
 
+            const readIdentityOwnership = async () => {
+                const [submittedOwnership, reciprocalOwnership] = await Promise.all([
+                    resolvePlatformIdOwner(
+                        database,
+                        submittedIdentity.platform,
+                        submittedIdentity.platformId,
+                    ),
+                    reciprocalIdentity
+                        ? resolvePlatformIdOwner(
+                            database,
+                            reciprocalIdentity.platform,
+                            reciprocalIdentity.platformId,
+                        )
+                        : Promise.resolve<PlatformIdOwnerResolution>({ status: "none" }),
+                ]);
+
+                return { submittedOwnership, reciprocalOwnership };
+            };
+
             console.debug("[Server] Checking platform ID ownership...");
-            const ownership = await resolvePlatformIdOwner(database, platform, platformId);
-            if (ownership.status === "conflict") {
-                console.error("[Server] Conflicting platform ID owners:", ownership.candidates);
-                return {
-                    status: "conflict",
-                    candidates: ownership.candidates,
-                    platform,
-                    platformId,
-                    message: "That platform profile is assigned to conflicting artist records",
-                };
-            }
-            if (ownership.status === "owner") {
-                console.debug("[Server] Artist already exists:", ownership.owner);
-                return {
-                    status: "exists",
-                    artistId: ownership.owner.id,
-                    artistName: ownership.owner.name ?? "",
-                    message: "That artist is already in our database",
-                };
+            const initialOwnership = await readIdentityOwnership();
+            const ownershipResponse = getIdentityOwnershipResponse({
+                submittedIdentity,
+                ...initialOwnership,
+                reciprocalIdentity,
+                forceCreate: options?.forceCreate === true,
+            });
+            if (ownershipResponse) {
+                return ownershipResponse;
             }
 
             if (!options?.forceCreate) {
@@ -513,8 +646,14 @@ export async function addArtist(
             }
 
             console.debug("[Server] Inserting new artist into database...");
+            const platformIds: Partial<Record<MusicPlatform, string>> = {
+                [submittedIdentity.platform]: submittedIdentity.platformId,
+            };
+            if (reciprocalIdentity) {
+                platformIds[reciprocalIdentity.platform] = reciprocalIdentity.platformId;
+            }
             const artistData = {
-                [platform]: platformId,
+                ...platformIds,
                 lcname: normalisedName,
                 name: platformArtist.name,
                 addedBy: session.user?.id || undefined,
@@ -527,28 +666,42 @@ export async function addArtist(
                 .returning();
 
             if (!newArtist) {
-                const raceWinner = await resolvePlatformIdOwner(database, platform, platformId);
-                if (raceWinner.status === "conflict") {
-                    return {
-                        status: "conflict",
-                        candidates: raceWinner.candidates,
-                        platform,
-                        platformId,
-                        message: "That platform profile is assigned to conflicting artist records",
-                    };
-                }
-                if (raceWinner.status === "owner") {
-                    return {
-                        status: "exists",
-                        artistId: raceWinner.owner.id,
-                        artistName: raceWinner.owner.name ?? "",
-                        message: "That artist is already in our database",
-                    };
+                const raceOwnership = await readIdentityOwnership();
+                const raceResponse = getIdentityOwnershipResponse({
+                    submittedIdentity,
+                    ...raceOwnership,
+                    reciprocalIdentity,
+                    forceCreate: options?.forceCreate === true,
+                });
+                if (raceResponse) {
+                    return raceResponse;
                 }
                 return {
                     status: "error",
                     message: "The artist could not be created because another record changed at the same time. Please try again.",
                 };
+            }
+
+            const mappedDeezerId = platformIds.deezer;
+            if (reciprocalIdentity && mappedDeezerId) {
+                const reasoning = `Wikidata ${reciprocalIdentity.wikidataId} links Spotify and Deezer for ${platformArtist.name}`;
+                await database.execute(sql`
+                    INSERT INTO artist_id_mappings (
+                        artist_id,
+                        platform,
+                        platform_id,
+                        confidence,
+                        source,
+                        reasoning
+                    ) VALUES (
+                        ${newArtist.id},
+                        'deezer',
+                        ${mappedDeezerId},
+                        'high'::confidence_level,
+                        ${reciprocalIdentity.source},
+                        ${reasoning}
+                    )
+                `);
             }
             console.debug("[Server] New artist created:", newArtist);
             notificationCreatedAt = newArtist.createdAt;


### PR DESCRIPTION
## Summary

- Resolve reciprocal Spotify and Deezer IDs through a unique Wikidata crosswalk
- Verify the destination platform profile before persisting the match
- Save both first-class IDs atomically with deterministic locks and fail-closed ownership checks
- Record Deezer mapping provenance and prevent unsafe force creation for verified matches
- Fall back to the submitted platform ID when reciprocal lookup is unavailable or ambiguous

No database migration is required.

## Validation

- npm run type-check
- npm run lint
- npm test -- --runInBand — 121 suites passed; 1,256 tests passed; 6 skipped
- npm run build