### PR TITLE
Release: cross-platform artist identity hardening (#1170 + #1171)

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -237,6 +237,7 @@ jest.mock('@/server/utils/musicPlatform', () => ({
         getArtistImages: jest.fn().mockResolvedValue(new Map()),
         getActivePlatform: jest.fn().mockReturnValue(null),
     },
+    findReciprocalArtistIdentity: jest.fn().mockResolvedValue(null),
     SpotifyProvider: jest.fn(),
     DeezerProvider: jest.fn(),
     ArtistMusicPlatformDataProvider: jest.fn(),
@@ -252,4 +253,4 @@ jest.mock('@/app/actions/serverActions', () => ({
     removeFromWhitelistAction: jest.fn(),
     addUsersToAdminAction: jest.fn(),
     removeFromAdminAction: jest.fn(),
-})); 
+}));

--- a/src/__tests__/ArtistPage.test.tsx
+++ b/src/__tests__/ArtistPage.test.tsx
@@ -39,8 +39,16 @@ jest.mock('@/app/_components/EditModeContext', () => ({
 jest.mock('@/app/_components/EditModeToggle', () => function EditModeToggle() { return <button data-testid="edit-mode-toggle">Edit</button>; });
 jest.mock('@/app/_components/AutoRefresh', () => function AutoRefresh() { return null; });
 jest.mock('@/app/artist/[id]/_components/BlurbSection', () => function BlurbSection() { return <div data-testid="blurb-section" />; });
-jest.mock('@/app/artist/[id]/_components/AddArtistData', () => function AddArtistData({ directEdit = false, autoApprove = false }: { directEdit?: boolean, autoApprove?: boolean }) {
-    return <div data-testid="add-artist-data" data-direct-edit={String(directEdit)} data-auto-approve={String(autoApprove)} />;
+jest.mock('@/app/artist/[id]/_components/AddArtistData', () => function AddArtistData({ directEdit = false, autoApprove = false, isOpenOnLoad = false, prefillUrl }: { directEdit?: boolean, autoApprove?: boolean, isOpenOnLoad?: boolean, prefillUrl?: string }) {
+    return (
+        <div
+            data-testid="add-artist-data"
+            data-direct-edit={String(directEdit)}
+            data-auto-approve={String(autoApprove)}
+            data-open-on-load={String(isOpenOnLoad)}
+            data-prefill-url={prefillUrl ?? ''}
+        />
+    );
 });
 jest.mock('@/app/artist/[id]/_components/HeroSection', () => function HeroSection({ artistName }: { artistName: string }) { return <div data-testid="hero-section"><img alt={artistName} src="test.jpg" /></div>; });
 jest.mock('@/app/artist/[id]/_components/FunFacts', () => function FunFacts() { return <div data-testid="fun-facts" />; });
@@ -95,8 +103,14 @@ function setupMocks({ session = null, artist = mockArtist } = {}) {
     (getAllLinks as jest.Mock).mockResolvedValue([]);
 }
 
-async function renderArtistPage(id = 'artist-uuid') {
-    const jsx = await ArtistProfile({ params: Promise.resolve({ id }) });
+async function renderArtistPage(
+    id = 'artist-uuid',
+    searchParams?: { addLink?: string | string[] },
+) {
+    const jsx = await ArtistProfile({
+        params: Promise.resolve({ id }),
+        ...(searchParams ? { searchParams: Promise.resolve(searchParams) } : {}),
+    });
     return render(jsx as React.ReactElement);
 }
 
@@ -140,6 +154,45 @@ describe('ArtistProfile page', () => {
         it('does not render edit mode toggle when not authenticated', async () => {
             await renderArtistPage();
             expect(screen.queryByTestId('edit-mode-toggle')).not.toBeInTheDocument();
+        });
+
+        it('opens only the Social Links dialog with a canonical Spotify URL prefilled', async () => {
+            const spotifyUrl = 'https://open.spotify.com/artist/2TNJWBi73MnkSRkZRPBqSW?si=test';
+            const canonicalSpotifyUrl = 'https://open.spotify.com/artist/2TNJWBi73MnkSRkZRPBqSW';
+
+            await renderArtistPage('artist-uuid', { addLink: spotifyUrl });
+
+            const dialogs = screen.getAllByTestId('add-artist-data');
+            expect(dialogs[0]).toHaveAttribute('data-open-on-load', 'true');
+            expect(dialogs[0]).toHaveAttribute('data-prefill-url', canonicalSpotifyUrl);
+            expect(dialogs[1]).toHaveAttribute('data-open-on-load', 'false');
+            expect(dialogs[1]).toHaveAttribute('data-prefill-url', '');
+        });
+
+        it('accepts a regional Deezer artist URL for the Social Links handoff', async () => {
+            const deezerUrl = 'http://deezer.com/us/artist/12345?utm_source=test#tracks';
+
+            await renderArtistPage('artist-uuid', { addLink: deezerUrl });
+
+            const dialogs = screen.getAllByTestId('add-artist-data');
+            expect(dialogs[0]).toHaveAttribute('data-open-on-load', 'true');
+            expect(dialogs[0]).toHaveAttribute('data-prefill-url', 'https://www.deezer.com/artist/12345');
+            expect(dialogs[1]).toHaveAttribute('data-open-on-load', 'false');
+        });
+
+        it.each([
+            ['an unsupported URL', 'https://example.com/artist/123'],
+            ['a deceptive Spotify subdomain', 'https://open.spotify.com.evil.example/artist/abc'],
+            ['a non-artist Spotify URL', 'https://open.spotify.com/track/123'],
+            ['a Deezer URL with an extra path segment', 'https://www.deezer.com/artist/123/tracks'],
+            ['multiple addLink values', ['https://open.spotify.com/artist/abc', 'https://www.deezer.com/artist/123']],
+        ])('ignores %s instead of opening either dialog', async (_label, addLink) => {
+            await renderArtistPage('artist-uuid', { addLink });
+
+            screen.getAllByTestId('add-artist-data').forEach((dialog) => {
+                expect(dialog).toHaveAttribute('data-open-on-load', 'false');
+                expect(dialog).toHaveAttribute('data-prefill-url', '');
+            });
         });
     });
 

--- a/src/__tests__/components/AddArtistContent.test.tsx
+++ b/src/__tests__/components/AddArtistContent.test.tsx
@@ -93,6 +93,20 @@ describe('AddArtistContent duplicate choice', () => {
         expect(second).not.toHaveAccessibleName(/another-candidate-id/);
     });
 
+    it('does not offer force creation when the platform IDs are verified as the same artist', async () => {
+        mockAddArtist.mockResolvedValueOnce({
+            ...possibleDuplicate,
+            canCreateSeparate: false,
+            message: 'Wikidata links these profiles to the same artist.',
+        });
+        render(<AddArtistContent initialArtist={initialArtist} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Add Artist' }));
+
+        expect(await screen.findByText('Wikidata links these profiles to the same artist.')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /Add link to existing artist: Same Name/ })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Create separate artist' })).not.toBeInTheDocument();
+    });
+
     it('force-creates only after the user confirms this is a separate artist', async () => {
         await submitWithDuplicate();
         mockAddArtist.mockResolvedValueOnce({

--- a/src/__tests__/components/AddArtistContent.test.tsx
+++ b/src/__tests__/components/AddArtistContent.test.tsx
@@ -128,6 +128,85 @@ describe('AddArtistContent duplicate choice', () => {
         });
     });
 
+    it('submits the initial add only once when activated twice before state settles', async () => {
+        let resolveAdd!: (value: unknown) => void;
+        mockAddArtist.mockReturnValueOnce(new Promise(resolve => { resolveAdd = resolve; }));
+        const { container } = render(<AddArtistContent initialArtist={initialArtist} />);
+        const addButton = screen.getByRole('button', { name: 'Add Artist' });
+
+        act(() => {
+            addButton.click();
+            addButton.click();
+        });
+
+        expect(mockAddArtist).toHaveBeenCalledTimes(1);
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+        expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+
+        await act(async () => {
+            resolveAdd({ status: 'error', message: 'Try again.' });
+        });
+    });
+
+    it('submits force creation only once when activated twice before state settles', async () => {
+        await submitWithDuplicate();
+        let resolveCreate!: (value: unknown) => void;
+        mockAddArtist.mockReturnValueOnce(new Promise(resolve => { resolveCreate = resolve; }));
+        const createButton = screen.getByRole('button', { name: 'Create separate artist' });
+
+        act(() => {
+            createButton.click();
+            createButton.click();
+        });
+
+        expect(mockAddArtist).toHaveBeenCalledTimes(2);
+
+        await act(async () => {
+            resolveCreate({ status: 'success', artistId: 'new-id', artistName: 'Same Name' });
+        });
+
+        expect(mockPush).toHaveBeenCalledTimes(1);
+        expect(mockPush).toHaveBeenCalledWith('/artist/new-id');
+    });
+
+    it('ignores a pending response when cancellation wins the same render turn', async () => {
+        let resolveAdd!: (value: unknown) => void;
+        mockAddArtist.mockReturnValueOnce(new Promise(resolve => { resolveAdd = resolve; }));
+        render(<AddArtistContent initialArtist={initialArtist} />);
+        const addButton = screen.getByRole('button', { name: 'Add Artist' });
+        const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+
+        act(() => {
+            addButton.click();
+            cancelButton.click();
+        });
+
+        expect(mockBack).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            resolveAdd({ status: 'success', artistId: 'late-id', artistName: 'Same Name' });
+        });
+
+        expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it('ignores a pending add response after navigation unmounts the page', async () => {
+        let resolveAdd!: (value: unknown) => void;
+        mockAddArtist.mockReturnValueOnce(new Promise(resolve => { resolveAdd = resolve; }));
+        const { unmount } = render(<AddArtistContent initialArtist={initialArtist} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add Artist' }));
+
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+        unmount();
+
+        await act(async () => {
+            resolveAdd({ status: 'success', artistId: 'late-id', artistName: 'Same Name' });
+        });
+
+        expect(mockPush).not.toHaveBeenCalled();
+    });
+
     it('blocks candidate navigation and cancellation while force creation is pending', async () => {
         const candidateLink = await submitWithDuplicate();
         let resolveCreate!: (value: unknown) => void;

--- a/src/__tests__/components/AddArtistContent.test.tsx
+++ b/src/__tests__/components/AddArtistContent.test.tsx
@@ -1,0 +1,174 @@
+// @ts-nocheck
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mockPush = jest.fn();
+const mockBack = jest.fn();
+const mockAddArtist = jest.fn();
+
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push: mockPush, back: mockBack }),
+}));
+
+jest.mock('next-auth/react', () => ({
+    useSession: () => ({
+        data: { user: { id: 'user-id' } },
+        status: 'authenticated',
+    }),
+}));
+
+jest.mock('@/app/actions/addArtist', () => ({
+    addArtist: (...args: unknown[]) => mockAddArtist(...args),
+}));
+
+import AddArtistContent from '@/app/add-artist/_components/AddArtistContent';
+
+const initialArtist = {
+    platform: 'spotify',
+    platformId: '2TNJWBi73MnkSRkZRPBqSW',
+    name: 'Same Name',
+    imageUrl: 'https://example.com/artist.jpg',
+    followerCount: 123,
+    albumCount: 2,
+    genres: ['indie'],
+    profileUrl: 'https://open.spotify.com/artist/2TNJWBi73MnkSRkZRPBqSW',
+    topTrackName: 'A Song',
+};
+
+const possibleDuplicate = {
+    status: 'possible_duplicate',
+    message: 'We found a possible match.',
+    platform: 'spotify',
+    platformId: '2TNJWBi73MnkSRkZRPBqSW',
+    candidates: [{
+        id: 'candidate-id',
+        name: 'Same Name',
+        spotify: null,
+        deezer: 'deezer-id',
+    }],
+};
+
+describe('AddArtistContent duplicate choice', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    async function submitWithDuplicate() {
+        mockAddArtist.mockResolvedValueOnce(possibleDuplicate);
+        render(<AddArtistContent initialArtist={initialArtist} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Add Artist' }));
+        return screen.findByRole('link', { name: /Add link to existing artist: Same Name/ });
+    }
+
+    it('links the submitted profile to a selected existing artist', async () => {
+        const link = await submitWithDuplicate();
+
+        expect(mockAddArtist).toHaveBeenCalledWith(initialArtist.platformId, 'spotify');
+        expect(link).toHaveAttribute(
+            'href',
+            `/artist/candidate-id?addLink=${encodeURIComponent(initialArtist.profileUrl)}`,
+        );
+        expect(screen.getByRole('button', { name: 'Create separate artist' })).toBeInTheDocument();
+    });
+
+    it('disambiguates duplicate accessible names by position without exposing UUIDs', async () => {
+        mockAddArtist.mockResolvedValueOnce({
+            ...possibleDuplicate,
+            candidates: [
+                possibleDuplicate.candidates[0],
+                { ...possibleDuplicate.candidates[0], id: 'another-candidate-id' },
+            ],
+        });
+        render(<AddArtistContent initialArtist={initialArtist} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Add Artist' }));
+
+        const first = await screen.findByRole('link', {
+            name: 'Add link to existing artist: Same Name (candidate 1 of 2)',
+        });
+        const second = screen.getByRole('link', {
+            name: 'Add link to existing artist: Same Name (candidate 2 of 2)',
+        });
+
+        expect(first).not.toHaveAccessibleName(/candidate-id/);
+        expect(second).not.toHaveAccessibleName(/another-candidate-id/);
+    });
+
+    it('force-creates only after the user confirms this is a separate artist', async () => {
+        await submitWithDuplicate();
+        mockAddArtist.mockResolvedValueOnce({
+            status: 'success',
+            artistId: 'new-id',
+            artistName: 'Same Name',
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Create separate artist' }));
+
+        await waitFor(() => {
+            expect(mockAddArtist).toHaveBeenNthCalledWith(
+                2,
+                initialArtist.platformId,
+                'spotify',
+                { forceCreate: true },
+            );
+            expect(mockPush).toHaveBeenCalledWith('/artist/new-id');
+        });
+    });
+
+    it('blocks candidate navigation and cancellation while force creation is pending', async () => {
+        const candidateLink = await submitWithDuplicate();
+        let resolveCreate!: (value: unknown) => void;
+        mockAddArtist.mockReturnValueOnce(new Promise(resolve => { resolveCreate = resolve; }));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Create separate artist' }));
+
+        expect(await screen.findByRole('status')).toHaveTextContent('Creating separate artist');
+        expect(candidateLink).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(mockBack).not.toHaveBeenCalled();
+
+        await act(async () => {
+            resolveCreate({ status: 'success', artistId: 'new-id', artistName: 'Same Name' });
+        });
+
+        expect(mockPush).toHaveBeenCalledWith('/artist/new-id');
+    });
+
+    it('opens login when the action reports that an authenticated-looking session expired', async () => {
+        const loginButton = document.createElement('button');
+        loginButton.id = 'login-btn';
+        const loginClick = jest.fn();
+        loginButton.addEventListener('click', loginClick);
+        document.body.appendChild(loginButton);
+        mockAddArtist.mockResolvedValue({
+            status: 'error',
+            code: 'UNAUTHENTICATED',
+            message: 'Your session has expired. Please sign in again.',
+        });
+
+        try {
+            render(<AddArtistContent initialArtist={initialArtist} />);
+            fireEvent.click(screen.getByRole('button', { name: 'Add Artist' }));
+
+            await waitFor(() => expect(loginClick).toHaveBeenCalledTimes(1));
+            expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+            expect(mockPush).not.toHaveBeenCalled();
+        } finally {
+            loginButton.remove();
+        }
+    });
+
+    it('renders a conflict as an error without a bypass action', async () => {
+        mockAddArtist.mockResolvedValue({
+            status: 'conflict',
+            message: 'This Spotify profile already belongs to another artist.',
+        });
+        render(<AddArtistContent initialArtist={initialArtist} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add Artist' }));
+
+        expect(await screen.findByText('This Spotify profile already belongs to another artist.')).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Create separate artist' })).not.toBeInTheDocument();
+        expect(mockPush).not.toHaveBeenCalled();
+    });
+});

--- a/src/__tests__/components/AddArtistData.test.tsx
+++ b/src/__tests__/components/AddArtistData.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import AddArtistData from '@/app/artist/[id]/_components/AddArtistData';
 import { useSession } from 'next-auth/react';
 import { LINK_NOT_SUPPORTED } from '@/lib/linkSubmissionMessages';
+import { addArtistDataAction } from '@/app/actions/serverActions';
 
 jest.mock('next-auth/react', () => ({ useSession: jest.fn() }));
 
@@ -16,7 +17,10 @@ const baseProps = {
 };
 
 describe('AddArtistData "+" trigger', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (addArtistDataAction as jest.Mock).mockReset();
+  });
 
   it('does nothing while the session is still loading', () => {
     (useSession as jest.Mock).mockReturnValue({ data: null, status: 'loading' });
@@ -48,6 +52,101 @@ describe('AddArtistData "+" trigger', () => {
     getByIdSpy.mockRestore();
   });
 
+  it('auth-gates a handed-off URL, then resumes and consumes it after login', async () => {
+    const spotifyUrl = 'https://open.spotify.com/artist/2TNJWBi73MnkSRkZRPBqSW?si=test';
+    let authState = { data: null, status: 'loading' } as {
+      data: { user: { id: string } } | null;
+      status: 'authenticated' | 'loading' | 'unauthenticated';
+    };
+    (useSession as jest.Mock).mockImplementation(() => authState);
+
+    const loginButton = document.createElement('button');
+    loginButton.id = 'login-btn';
+    const loginClick = jest.fn();
+    loginButton.addEventListener('click', loginClick);
+    document.body.appendChild(loginButton);
+    window.history.replaceState(
+      {},
+      '',
+      `/artist/a1?view=links&addLink=${encodeURIComponent(spotifyUrl)}#social-links`,
+    );
+
+    try {
+      const { rerender } = render(
+        <AddArtistData {...baseProps} isOpenOnLoad prefillUrl={spotifyUrl} />,
+      );
+
+      expect(loginClick).not.toHaveBeenCalled();
+      expect(screen.queryByRole('heading', { name: /Suggest a link for Test Artist/i })).not.toBeInTheDocument();
+
+      authState = { data: null, status: 'unauthenticated' };
+      rerender(<AddArtistData {...baseProps} isOpenOnLoad prefillUrl={spotifyUrl} />);
+
+      expect(loginClick).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole('heading', { name: /Suggest a link for Test Artist/i })).not.toBeInTheDocument();
+      expect(window.location.search).toContain('addLink=');
+      expect(addArtistDataAction).not.toHaveBeenCalled();
+
+      // The real Privy flow reloads after login. A session update on the same
+      // mount is enough to verify the pending handoff resumes as well.
+      authState = {
+        data: { user: { id: 'u1' } },
+        status: 'authenticated',
+      };
+      rerender(<AddArtistData {...baseProps} isOpenOnLoad prefillUrl={spotifyUrl} />);
+
+      expect(screen.getByRole('heading', { name: /Suggest a link for Test Artist/i })).toBeInTheDocument();
+      expect(screen.getByPlaceholderText(/Paste a profile link/i)).toHaveValue(spotifyUrl);
+      expect(addArtistDataAction).not.toHaveBeenCalled();
+      await waitFor(() => expect(window.location.search).toBe('?view=links'));
+      expect(window.location.hash).toBe('#social-links');
+    } finally {
+      loginButton.remove();
+      window.history.replaceState({}, '', '/');
+    }
+  });
+
+  it('handles a new handed-off URL when client navigation reuses the component', async () => {
+    (useSession as jest.Mock).mockReturnValue({
+      data: { user: { id: 'u1' } },
+      status: 'authenticated',
+    });
+    const firstUrl = 'https://open.spotify.com/artist/2TNJWBi73MnkSRkZRPBqSW';
+    const secondUrl = 'https://www.deezer.com/artist/815939';
+    window.history.replaceState(
+      {},
+      '',
+      `/artist/a1?addLink=${encodeURIComponent(firstUrl)}`,
+    );
+
+    try {
+      const { rerender } = render(
+        <AddArtistData {...baseProps} isOpenOnLoad prefillUrl={firstUrl} />,
+      );
+      expect(screen.getByPlaceholderText(/Paste a profile link/i)).toHaveValue(firstUrl);
+      await waitFor(() => expect(window.location.search).toBe(''));
+
+      window.history.replaceState(
+        {},
+        '',
+        `/artist/a2?addLink=${encodeURIComponent(secondUrl)}`,
+      );
+      rerender(
+        <AddArtistData
+          {...baseProps}
+          artist={{ ...baseProps.artist, id: 'a2', name: 'Second Artist' }}
+          isOpenOnLoad
+          prefillUrl={secondUrl}
+        />,
+      );
+
+      expect(screen.getByPlaceholderText(/Paste a profile link/i)).toHaveValue(secondUrl);
+      await waitFor(() => expect(window.location.search).toBe(''));
+    } finally {
+      window.history.replaceState({}, '', '/');
+    }
+  });
+
   it('warns in dev and does not open the modal when login button is absent', () => {
     (useSession as jest.Mock).mockReturnValue({ data: null, status: 'unauthenticated' });
     const getByIdSpy = jest.spyOn(document, 'getElementById').mockReturnValue(null);
@@ -67,11 +166,160 @@ describe('AddArtistData "+" trigger', () => {
     (useSession as jest.Mock).mockReturnValue({ data: { user: { id: 'u1' } }, status: 'authenticated' });
 
     render(<AddArtistData {...baseProps} />);
-    fireEvent.click(screen.getByRole('button'));
+    const trigger = screen.getByRole('button', { name: 'Add a link for Test Artist' });
+    expect(trigger).toHaveAttribute('title', 'Add a link for Test Artist');
+    fireEvent.click(trigger);
 
     // UGC users see "Suggest a link for {artist}" header and a Submit button
     expect(screen.getByRole('heading', { name: /Suggest a link for Test Artist/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
+  });
+
+  it('opens with the handed-off URL prefilled, consumes addLink, and does not submit', async () => {
+    (useSession as jest.Mock).mockReturnValue({ data: { user: { id: 'u1' } }, status: 'authenticated' });
+    const spotifyUrl = 'https://open.spotify.com/artist/2TNJWBi73MnkSRkZRPBqSW?si=test';
+    const originalReplaceState = window.history.replaceState;
+    const nativeReplaceState = originalReplaceState.bind(window.history);
+    nativeReplaceState(
+      { __NA: true, __PRIVATE_NEXTJS_INTERNALS_TREE: ['existing-tree'] },
+      '',
+      `/artist/a1?view=links&addLink=${encodeURIComponent(spotifyUrl)}#social-links`,
+    );
+    let nextCanonicalUrl = window.location.href;
+
+    // Simulate Next's patched History API: supplying its internal __NA state
+    // bypasses router synchronization, while a normal state value updates the
+    // canonical URL and preserves Next's state on the history entry.
+    const nextReplaceState = jest.fn((data: unknown, unused: string, url?: string | URL | null) => {
+      if ((data as { __NA?: boolean } | null)?.__NA) {
+        nativeReplaceState(data, unused, url);
+        return;
+      }
+
+      if (url) nextCanonicalUrl = new URL(String(url), window.location.href).href;
+      nativeReplaceState(
+        {
+          ...(data && typeof data === 'object' ? data : {}),
+          __NA: true,
+          __PRIVATE_NEXTJS_INTERNALS_TREE: ['existing-tree'],
+        },
+        unused,
+        url,
+      );
+    });
+    window.history.replaceState = nextReplaceState as typeof window.history.replaceState;
+
+    try {
+      render(<AddArtistData {...baseProps} isOpenOnLoad prefillUrl={spotifyUrl} />);
+
+      expect(screen.getByRole('heading', { name: /Suggest a link for Test Artist/i })).toBeInTheDocument();
+      expect(screen.getByPlaceholderText(/Paste a profile link/i)).toHaveValue(spotifyUrl);
+      expect(addArtistDataAction).not.toHaveBeenCalled();
+
+      await waitFor(() => {
+        expect(nextReplaceState).toHaveBeenCalledWith(
+          null,
+          '',
+          '/artist/a1?view=links#social-links',
+        );
+      });
+      expect(new URL(nextCanonicalUrl).search).toBe('?view=links');
+      expect(window.location.search).toBe('?view=links');
+      expect(window.location.hash).toBe('#social-links');
+      expect(window.history.state).toMatchObject({
+        __NA: true,
+        __PRIVATE_NEXTJS_INTERNALS_TREE: ['existing-tree'],
+      });
+    } finally {
+      window.history.replaceState = originalReplaceState;
+      nativeReplaceState({}, '', '/');
+    }
+  });
+
+  it('resets a consumed prefill before a later manual open', async () => {
+    (useSession as jest.Mock).mockReturnValue({ data: { user: { id: 'u1' } }, status: 'authenticated' });
+    const spotifyUrl = 'https://open.spotify.com/artist/2TNJWBi73MnkSRkZRPBqSW';
+
+    render(<AddArtistData {...baseProps} isOpenOnLoad prefillUrl={spotifyUrl} />);
+    expect(screen.getByPlaceholderText(/Paste a profile link/i)).toHaveValue(spotifyUrl);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { name: /Suggest a link for Test Artist/i })).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByPlaceholderText(/Paste a profile link/i)).toHaveValue('');
+  });
+
+  it('keeps submission disabled while supported-link validation is loading', () => {
+    (useSession as jest.Mock).mockReturnValue({ data: { user: { id: 'u1' } }, status: 'authenticated' });
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn(() => new Promise(() => {})) as unknown as typeof fetch;
+
+    try {
+      render(<AddArtistData {...baseProps} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Add a link for Test Artist' }));
+
+      const submitButton = screen.getByRole('button', { name: 'Submit' });
+      expect(submitButton).toBeDisabled();
+      expect(submitButton).toHaveAttribute('aria-busy', 'true');
+      fireEvent.click(submitButton);
+      expect(addArtistDataAction).not.toHaveBeenCalled();
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  it('lets an unchanged server-validated prefill reach the server if regex loading fails', async () => {
+    (useSession as jest.Mock).mockReturnValue({ data: { user: { id: 'u1' } }, status: 'authenticated' });
+    const spotifyUrl = 'https://open.spotify.com/artist/2TNJWBi73MnkSRkZRPBqSW';
+    const originalFetch = global.fetch;
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    global.fetch = jest.fn().mockRejectedValue(new Error('offline')) as unknown as typeof fetch;
+    (addArtistDataAction as jest.Mock).mockResolvedValue({ status: 'error', message: 'Server rejected link' });
+
+    try {
+      render(<AddArtistData {...baseProps} isOpenOnLoad prefillUrl={spotifyUrl} />);
+
+      const submitButton = screen.getByRole('button', { name: 'Submit' });
+      await waitFor(() => expect(submitButton).toBeEnabled());
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(addArtistDataAction).toHaveBeenCalledWith(spotifyUrl, baseProps.artist);
+      });
+    } finally {
+      global.fetch = originalFetch;
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('does not trust a modified prefill when regex loading fails', async () => {
+    (useSession as jest.Mock).mockReturnValue({ data: { user: { id: 'u1' } }, status: 'authenticated' });
+    const spotifyUrl = 'https://open.spotify.com/artist/2TNJWBi73MnkSRkZRPBqSW';
+    const originalFetch = global.fetch;
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    global.fetch = jest.fn().mockRejectedValue(new Error('offline')) as unknown as typeof fetch;
+
+    try {
+      render(<AddArtistData {...baseProps} isOpenOnLoad prefillUrl={spotifyUrl} />);
+
+      const submitButton = screen.getByRole('button', { name: 'Submit' });
+      await waitFor(() => expect(submitButton).toBeEnabled());
+      fireEvent.change(screen.getByPlaceholderText(/Paste a profile link/i), {
+        target: { value: 'https://open.spotify.com/artist/differentArtist' },
+      });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(LINK_NOT_SUPPORTED)).toBeInTheDocument();
+      });
+      expect(addArtistDataAction).not.toHaveBeenCalled();
+    } finally {
+      global.fetch = originalFetch;
+      errorSpy.mockRestore();
+    }
   });
 
   it('uses "Save Link" submit label for a claim owner using direct edit', () => {
@@ -81,6 +329,7 @@ describe('AddArtistData "+" trigger', () => {
     fireEvent.click(screen.getByRole('button'));
 
     expect(screen.getByRole('heading', { name: /Add a link for Test Artist/i })).toBeInTheDocument();
+    expect(screen.getByText(/saved directly to the artist profile/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Save Link' })).toBeInTheDocument();
   });
 
@@ -110,7 +359,9 @@ describe('AddArtistData "+" trigger', () => {
 
       const input = screen.getByPlaceholderText(/Paste a profile link/i);
       fireEvent.change(input, { target: { value: 'https://example.com/foo' } });
-      fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+      const submitButton = screen.getByRole('button', { name: 'Submit' });
+      await waitFor(() => expect(submitButton).toBeEnabled());
+      fireEvent.click(submitButton);
 
       await waitFor(() => {
         expect(screen.getByText(LINK_NOT_SUPPORTED)).toBeInTheDocument();

--- a/src/__tests__/components/SearchBarAddArtist.test.tsx
+++ b/src/__tests__/components/SearchBarAddArtist.test.tsx
@@ -215,6 +215,127 @@ describe('SearchBar Add Artist Flow', () => {
         });
     });
 
+    it('uses the action identity to build a canonical existing-artist handoff URL', async () => {
+        (useSession as jest.Mock).mockReturnValue({ data: { user: { id: '1' } } });
+        const trackedExternalResult = {
+            ...externalResult,
+            platformId: '123',
+            profileUrl: 'https://deezer.com/en/artist/123?utm_source=search#tracks',
+        };
+        mockAddArtist.mockResolvedValue({
+            status: 'possible_duplicate',
+            platform: 'deezer',
+            platformId: '123',
+            candidates: [{
+                id: 'existing-id',
+                name: 'New Artist',
+                spotify: 'spotify-id',
+                deezer: null,
+            }],
+        });
+
+        await renderAndSearch([trackedExternalResult]);
+        fireEvent.click(screen.getByText('New Artist'));
+
+        const link = await screen.findByRole('link', { name: /Add link to existing artist: New Artist/ });
+        expect(link).toHaveAttribute(
+            'href',
+            `/artist/existing-id?addLink=${encodeURIComponent('https://www.deezer.com/artist/123')}`,
+        );
+        expect(screen.getByRole('button', { name: 'Create separate artist' })).toBeInTheDocument();
+        expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it('force-creates a separate artist after duplicate confirmation', async () => {
+        (useSession as jest.Mock).mockReturnValue({ data: { user: { id: '1' } } });
+        mockAddArtist
+            .mockResolvedValueOnce({
+                status: 'possible_duplicate',
+                platform: 'deezer',
+                platformId: '123',
+                candidates: [{
+                    id: 'existing-id',
+                    name: 'New Artist',
+                    spotify: 'spotify-id',
+                    deezer: null,
+                }],
+            })
+            .mockResolvedValueOnce({
+                status: 'success',
+                artistId: 'separate-id',
+                artistName: 'New Artist',
+            });
+
+        await renderAndSearch([externalResult]);
+        fireEvent.click(screen.getByText('New Artist'));
+        fireEvent.click(await screen.findByRole('button', { name: 'Create separate artist' }));
+
+        await waitFor(() => {
+            expect(mockAddArtist).toHaveBeenNthCalledWith(
+                2,
+                '123',
+                'deezer',
+                { forceCreate: true },
+            );
+            expect(mockPush).toHaveBeenCalledWith('/artist/separate-id');
+        });
+    });
+
+    it('blocks candidate navigation and search edits while force creation is pending', async () => {
+        (useSession as jest.Mock).mockReturnValue({ data: { user: { id: '1' } } });
+        let resolveCreate!: (value: unknown) => void;
+        mockAddArtist
+            .mockResolvedValueOnce({
+                status: 'possible_duplicate',
+                platform: 'deezer',
+                platformId: '123',
+                candidates: [{
+                    id: 'existing-id',
+                    name: 'New Artist',
+                    spotify: 'spotify-id',
+                    deezer: null,
+                }],
+            })
+            .mockReturnValueOnce(new Promise(resolve => { resolveCreate = resolve; }));
+
+        await renderAndSearch([{ ...externalResult, platformId: '123' }]);
+        fireEvent.click(screen.getByText('New Artist'));
+        const candidateLink = await screen.findByRole('link', { name: /Add link to existing artist: New Artist/ });
+        fireEvent.click(screen.getByRole('button', { name: 'Create separate artist' }));
+
+        expect(await screen.findByRole('status')).toHaveTextContent('Creating separate artist');
+        expect(candidateLink).not.toBeInTheDocument();
+        const searchInput = screen.getByPlaceholderText('Search for an artist...');
+        expect(searchInput).toBeDisabled();
+        fireEvent.change(searchInput, { target: { value: 'different artist' } });
+        expect(searchInput).toHaveValue('test');
+
+        await act(async () => {
+            resolveCreate({ status: 'success', artistId: 'separate-id', artistName: 'New Artist' });
+        });
+
+        expect(mockPush).toHaveBeenCalledWith('/artist/separate-id');
+    });
+
+    it('shows a blocking conflict without offering force creation', async () => {
+        (useSession as jest.Mock).mockReturnValue({ data: { user: { id: '1' } } });
+        mockAddArtist.mockResolvedValue({
+            status: 'conflict',
+            message: 'This platform profile is already owned by another artist.',
+        });
+
+        await renderAndSearch([externalResult]);
+        fireEvent.click(screen.getByText('New Artist'));
+
+        await waitFor(() => {
+            expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({
+                variant: 'destructive',
+                description: 'This platform profile is already owned by another artist.',
+            }));
+        });
+        expect(screen.queryByRole('button', { name: 'Create separate artist' })).not.toBeInTheDocument();
+    });
+
     it('shows error toast when addArtist fails and keeps dropdown open', async () => {
         (useSession as jest.Mock).mockReturnValue({ data: { user: { id: '1' } } });
         mockAddArtist.mockResolvedValue({ status: 'error', message: 'Platform API down' });
@@ -257,7 +378,7 @@ describe('SearchBar Add Artist Flow', () => {
         expect(mockAddArtist).not.toHaveBeenCalled();
     });
 
-    it('only disables the specific result being added, not others', async () => {
+    it('disables every search result while an artist add is in flight', async () => {
         (useSession as jest.Mock).mockReturnValue({ data: { user: { id: '1' } } });
         let resolveAdd!: (val: unknown) => void;
         mockAddArtist.mockReturnValue(new Promise(r => { resolveAdd = r; }));
@@ -272,13 +393,43 @@ describe('SearchBar Add Artist Flow', () => {
             expect(addingButton).toBeDisabled();
 
             const otherButton = screen.getByText('Other Artist').closest('button');
-            expect(otherButton).not.toBeDisabled();
+            expect(otherButton).toBeDisabled();
 
             const dbButton = screen.getByText('Existing Artist').closest('button');
-            expect(dbButton).not.toBeDisabled();
+            expect(dbButton).toBeDisabled();
         });
 
-        resolveAdd({ status: 'success', artistId: '99' });
+        fireEvent.click(screen.getByText('Other Artist'));
+        expect(mockAddArtist).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            resolveAdd({ status: 'success', artistId: '99' });
+        });
+    });
+
+    it('ignores an add response after the user changes the search', async () => {
+        (useSession as jest.Mock).mockReturnValue({ data: { user: { id: '1' } } });
+        let resolveAdd!: (val: unknown) => void;
+        mockAddArtist.mockReturnValue(new Promise(r => { resolveAdd = r; }));
+
+        await renderAndSearch([externalResult]);
+        fireEvent.click(screen.getByText('New Artist'));
+        await waitFor(() => expect(screen.getByText('Adding...')).toBeInTheDocument());
+
+        fireEvent.change(screen.getByPlaceholderText('Search for an artist...'), {
+            target: { value: 'different search' },
+        });
+        const staleResult = await screen.findByText('New Artist');
+        expect(staleResult.closest('button')).toBeDisabled();
+        fireEvent.click(staleResult);
+        expect(mockAddArtist).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            resolveAdd({ status: 'success', artistId: 'stale-id', artistName: 'Stale Artist' });
+        });
+
+        expect(mockPush).not.toHaveBeenCalledWith('/artist/stale-id');
+        expect(screen.queryByRole('button', { name: 'Create separate artist' })).not.toBeInTheDocument();
     });
 
     it('closes dropdown only on success, not during add', async () => {

--- a/src/__tests__/components/nav/AddArtist.test.tsx
+++ b/src/__tests__/components/nav/AddArtist.test.tsx
@@ -1,15 +1,16 @@
 // @ts-nocheck
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 
-const mockLogin = jest.fn();
 const mockAddArtist = jest.fn();
 
 let mockSessionData: any = null;
+let mockSessionStatus = 'unauthenticated';
 
 // Capture the submit callback so tests can trigger it directly
 let capturedSubmitFn: ((values: Record<string, string>) => Promise<void>) | null = null;
 const mockReset = jest.fn();
+let capturedDialogOnOpenChange: ((open: boolean) => void) | null = null;
 
 jest.mock('react-hook-form', () => {
     const React = require('react');
@@ -46,11 +47,7 @@ jest.mock('@hookform/resolvers/zod', () => ({
 }));
 
 jest.mock('next-auth/react', () => ({
-    useSession: () => ({ data: mockSessionData }),
-}));
-
-jest.mock('@privy-io/react-auth', () => ({
-    useLogin: () => ({ login: mockLogin }),
+    useSession: () => ({ data: mockSessionData, status: mockSessionStatus }),
 }));
 
 jest.mock('@/app/actions/addArtist', () => ({
@@ -68,8 +65,10 @@ jest.mock('lucide-react', () => ({
 }));
 
 jest.mock('@/components/ui/dialog', () => ({
-    Dialog: ({ open, onOpenChange, children }: any) =>
-        open ? <div data-testid="dialog">{children}</div> : null,
+    Dialog: ({ open, onOpenChange, children }: any) => {
+        capturedDialogOnOpenChange = onOpenChange;
+        return open ? <div data-testid="dialog">{children}</div> : null;
+    },
     DialogContent: ({ children }: any) => <div>{children}</div>,
     DialogHeader: ({ children }: any) => <div>{children}</div>,
     DialogTitle: ({ children }: any) => <h2>{children}</h2>,
@@ -100,9 +99,14 @@ jest.mock('@/components/ui/input', () => ({
 
 jest.mock('@/components/ui/button', () => {
     const React = require('react');
-    const MockButton = React.forwardRef(({ children, onClick, disabled, ...props }: any, ref: any) => (
-        <button ref={ref} onClick={onClick} disabled={disabled} {...props}>{children}</button>
-    ));
+    const MockButton = React.forwardRef(({ children, onClick, disabled, asChild, variant, size, ...props }: any, ref: any) => {
+        void variant;
+        void size;
+        if (asChild && React.isValidElement(children)) {
+            return React.cloneElement(children, { ...props, ref });
+        }
+        return <button ref={ref} onClick={onClick} disabled={disabled} {...props}>{children}</button>;
+    });
     MockButton.displayName = 'MockButton';
     return { Button: MockButton };
 });
@@ -118,7 +122,9 @@ describe('AddArtist', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockSessionData = null;
+        mockSessionStatus = 'unauthenticated';
         capturedSubmitFn = null;
+        capturedDialogOnOpenChange = null;
     });
 
     describe('Button rendering', () => {
@@ -126,18 +132,31 @@ describe('AddArtist', () => {
             render(<AddArtist />);
             expect(screen.getByTestId('plus-icon')).toBeInTheDocument();
         });
+
+        it('labels the global control as adding a new artist', () => {
+            render(<AddArtist />);
+            expect(screen.getByRole('button', { name: 'Add new artist' })).toHaveAttribute('title', 'Add new artist');
+        });
     });
 
     describe('Unauthenticated behavior', () => {
-        it('calls Privy login() when unauthenticated user clicks the button', () => {
+        it('uses the shared login control when an unauthenticated user clicks the button', () => {
+            const loginButton = document.createElement('button');
+            loginButton.id = 'login-btn';
+            const loginClick = jest.fn();
+            loginButton.addEventListener('click', loginClick);
+            document.body.appendChild(loginButton);
+
             render(<AddArtist />);
-            fireEvent.click(screen.getByRole('button'));
-            expect(mockLogin).toHaveBeenCalled();
+            fireEvent.click(screen.getByRole('button', { name: 'Add new artist' }));
+
+            expect(loginClick).toHaveBeenCalled();
+            loginButton.remove();
         });
 
         it('does not open modal when unauthenticated', () => {
             render(<AddArtist />);
-            fireEvent.click(screen.getByRole('button'));
+            fireEvent.click(screen.getByRole('button', { name: 'Add new artist' }));
             expect(screen.queryByTestId('dialog')).not.toBeInTheDocument();
         });
     });
@@ -145,24 +164,40 @@ describe('AddArtist', () => {
     describe('Authenticated behavior', () => {
         beforeEach(() => {
             mockSessionData = { user: { id: 'user-uuid', email: 'test@test.com' } };
+            mockSessionStatus = 'authenticated';
         });
 
         it('opens modal when authenticated user clicks the button', () => {
             render(<AddArtist />);
-            fireEvent.click(screen.getByRole('button'));
+            fireEvent.click(screen.getByRole('button', { name: 'Add new artist' }));
             expect(screen.getByTestId('dialog')).toBeInTheDocument();
         });
 
-        it('does not call login() when authenticated', () => {
+        it('does not click the shared login control when authenticated', () => {
+            const loginButton = document.createElement('button');
+            loginButton.id = 'login-btn';
+            const loginClick = jest.fn();
+            loginButton.addEventListener('click', loginClick);
+            document.body.appendChild(loginButton);
+
             render(<AddArtist />);
-            fireEvent.click(screen.getByRole('button'));
-            expect(mockLogin).not.toHaveBeenCalled();
+            fireEvent.click(screen.getByRole('button', { name: 'Add new artist' }));
+
+            expect(loginClick).not.toHaveBeenCalled();
+            loginButton.remove();
+        });
+
+        it('uses a native form so Enter can submit the URL field', () => {
+            render(<AddArtist />);
+            fireEvent.click(screen.getByRole('button', { name: 'Add new artist' }));
+
+            expect(screen.getByPlaceholderText('Paste a Spotify or Deezer artist URL').closest('form')).not.toBeNull();
         });
 
         describe('Form submission', () => {
             async function openModalAndSubmit(url: string) {
                 render(<AddArtist />);
-                fireEvent.click(screen.getByRole('button'));
+                fireEvent.click(screen.getByRole('button', { name: 'Add new artist' }));
                 // Trigger submit by calling the captured handleSubmit fn directly
                 await waitFor(() => expect(capturedSubmitFn).not.toBeNull());
                 await capturedSubmitFn!({ artistUrl: url });
@@ -222,10 +257,204 @@ describe('AddArtist', () => {
                 });
             });
 
+            it('offers matching artists with a canonical add-link handoff URL', async () => {
+                mockAddArtist.mockResolvedValue({
+                    status: 'possible_duplicate',
+                    message: 'We found a possible match.',
+                    platform: 'spotify',
+                    platformId: VALID_SPOTIFY_ID,
+                    candidates: [{
+                        id: 'candidate-id',
+                        name: 'Radiohead',
+                        spotify: null,
+                        deezer: '12345',
+                    }],
+                });
+
+                await openModalAndSubmit(`${VALID_SPOTIFY_URL}?si=tracking-token#popular`);
+
+                const candidateLink = await screen.findByRole('link', { name: /Add link to existing artist: Radiohead/ });
+                expect(screen.getByText('Radiohead')).toBeInTheDocument();
+                expect(candidateLink).toHaveAttribute(
+                    'href',
+                    `/artist/candidate-id?addLink=${encodeURIComponent(VALID_SPOTIFY_URL)}`,
+                );
+                expect(screen.getByRole('button', { name: 'Create separate artist' })).toBeInTheDocument();
+            });
+
+            it('clears a duplicate choice when the submitted URL changes', async () => {
+                mockAddArtist.mockResolvedValue({
+                    status: 'possible_duplicate',
+                    platform: 'spotify',
+                    platformId: VALID_SPOTIFY_ID,
+                    candidates: [{
+                        id: 'candidate-id',
+                        name: 'Radiohead',
+                        spotify: null,
+                        deezer: '12345',
+                    }],
+                });
+
+                await openModalAndSubmit(VALID_SPOTIFY_URL);
+                expect(await screen.findByRole('button', { name: 'Create separate artist' })).toBeInTheDocument();
+
+                fireEvent.change(screen.getByPlaceholderText('Paste a Spotify or Deezer artist URL'), {
+                    target: { value: VALID_DEEZER_URL },
+                });
+
+                expect(screen.queryByRole('button', { name: 'Create separate artist' })).not.toBeInTheDocument();
+                expect(screen.getByRole('button', { name: 'Add Artist' })).toBeEnabled();
+            });
+
+            it('ignores an add response that finishes after the modal closes', async () => {
+                let resolveAdd!: (value: unknown) => void;
+                mockAddArtist.mockReturnValue(new Promise(resolve => { resolveAdd = resolve; }));
+
+                render(<AddArtist />);
+                fireEvent.click(screen.getByRole('button', { name: 'Add new artist' }));
+                await waitFor(() => expect(capturedSubmitFn).not.toBeNull());
+
+                let submitPromise!: Promise<void>;
+                act(() => {
+                    submitPromise = capturedSubmitFn!({ artistUrl: VALID_SPOTIFY_URL });
+                });
+                await waitFor(() => expect(screen.getByAltText('Adding artist')).toBeInTheDocument());
+
+                act(() => capturedDialogOnOpenChange!(false));
+                resolveAdd({ status: 'success', artistId: 'stale-id', artistName: 'Stale Artist' });
+                await act(async () => { await submitPromise; });
+
+                fireEvent.click(screen.getByRole('button', { name: 'Add new artist' }));
+                expect(screen.queryByText('Check out Stale Artist')).not.toBeInTheDocument();
+                expect(screen.getByRole('button', { name: 'Add Artist' })).toBeEnabled();
+            });
+
+            it('keeps the mutation lock until an invalidated request settles', async () => {
+                let resolveAdd!: (value: unknown) => void;
+                mockAddArtist.mockReturnValue(new Promise(resolve => { resolveAdd = resolve; }));
+
+                render(<AddArtist />);
+                fireEvent.click(screen.getByRole('button', { name: 'Add new artist' }));
+                await waitFor(() => expect(capturedSubmitFn).not.toBeNull());
+
+                let firstSubmit!: Promise<void>;
+                act(() => {
+                    firstSubmit = capturedSubmitFn!({ artistUrl: VALID_SPOTIFY_URL });
+                });
+                await waitFor(() => expect(screen.getByAltText('Adding artist')).toBeInTheDocument());
+
+                fireEvent.change(screen.getByPlaceholderText('Paste a Spotify or Deezer artist URL'), {
+                    target: { value: VALID_DEEZER_URL },
+                });
+                await act(async () => {
+                    await capturedSubmitFn!({ artistUrl: VALID_DEEZER_URL });
+                });
+
+                expect(mockAddArtist).toHaveBeenCalledTimes(1);
+                expect(screen.getByRole('button', { name: 'Adding artist' })).toBeDisabled();
+
+                resolveAdd({ status: 'success', artistId: 'stale-id', artistName: 'Stale Artist' });
+                await act(async () => { await firstSubmit; });
+
+                expect(screen.queryByText('Check out Stale Artist')).not.toBeInTheDocument();
+                expect(screen.getByRole('button', { name: 'Add Artist' })).toBeEnabled();
+            });
+
+            it('force-creates a separate artist only after confirmation', async () => {
+                mockAddArtist
+                    .mockResolvedValueOnce({
+                        status: 'possible_duplicate',
+                        platform: 'spotify',
+                        platformId: VALID_SPOTIFY_ID,
+                        candidates: [{
+                            id: 'candidate-id',
+                            name: 'Radiohead',
+                            spotify: null,
+                            deezer: '12345',
+                        }],
+                    })
+                    .mockResolvedValueOnce({
+                        status: 'success',
+                        artistId: 'separate-id',
+                        artistName: 'Radiohead',
+                        message: 'Artist added!',
+                    });
+
+                await openModalAndSubmit(VALID_SPOTIFY_URL);
+                fireEvent.click(await screen.findByRole('button', { name: 'Create separate artist' }));
+
+                await waitFor(() => {
+                    expect(mockAddArtist).toHaveBeenNthCalledWith(
+                        2,
+                        VALID_SPOTIFY_ID,
+                        'spotify',
+                        { forceCreate: true },
+                    );
+                    expect(screen.getByText('Check out Radiohead')).toBeInTheDocument();
+                });
+            });
+
+            it('replaces the dialog with blocking progress and refuses close while force creation is pending', async () => {
+                let resolveCreate!: (value: unknown) => void;
+                mockAddArtist
+                    .mockResolvedValueOnce({
+                        status: 'possible_duplicate',
+                        platform: 'spotify',
+                        platformId: VALID_SPOTIFY_ID,
+                        candidates: [{
+                            id: 'candidate-id',
+                            name: 'Radiohead',
+                            spotify: null,
+                            deezer: '12345',
+                        }],
+                    })
+                    .mockReturnValueOnce(new Promise(resolve => { resolveCreate = resolve; }));
+
+                await openModalAndSubmit(VALID_SPOTIFY_URL);
+                const candidateLink = await screen.findByRole('link', { name: /Add link to existing artist: Radiohead/ });
+                fireEvent.click(screen.getByRole('button', { name: 'Create separate artist' }));
+
+                expect(await screen.findByRole('status')).toHaveTextContent('Creating separate artist');
+                expect(candidateLink).not.toBeInTheDocument();
+                expect(screen.queryByPlaceholderText('Paste a Spotify or Deezer artist URL')).not.toBeInTheDocument();
+
+                act(() => capturedDialogOnOpenChange!(false));
+                expect(screen.getByTestId('dialog')).toBeInTheDocument();
+                expect(screen.getByRole('status')).toBeInTheDocument();
+
+                await act(async () => {
+                    resolveCreate({
+                        status: 'success',
+                        artistId: 'separate-id',
+                        artistName: 'Radiohead',
+                        message: 'Artist added!',
+                    });
+                });
+
+                expect(screen.getByText('Check out Radiohead')).toBeInTheDocument();
+            });
+
+            it('shows identity conflicts as blocking errors', async () => {
+                mockAddArtist.mockResolvedValue({
+                    status: 'conflict',
+                    message: 'That Spotify profile belongs to another artist.',
+                });
+
+                await openModalAndSubmit(VALID_SPOTIFY_URL);
+
+                expect(await screen.findByText('That Spotify profile belongs to another artist.')).toHaveClass('text-red-500');
+                expect(screen.queryByRole('button', { name: 'Create separate artist' })).not.toBeInTheDocument();
+            });
+
             it('does not call addArtist when URL fails regex extraction', async () => {
                 // The onSubmit function guards with a regex match before calling addArtist;
                 // passing an invalid URL string exercises that null-return path.
                 await openModalAndSubmit('https://notspotify.com/artist/123');
+                expect(mockAddArtist).not.toHaveBeenCalled();
+            });
+
+            it('rejects a Spotify artist URL with an extra path segment', async () => {
+                await openModalAndSubmit(`${VALID_SPOTIFY_URL}/albums`);
                 expect(mockAddArtist).not.toHaveBeenCalled();
             });
         });

--- a/src/app/_components/DuplicateArtistChoice.tsx
+++ b/src/app/_components/DuplicateArtistChoice.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+    buildCanonicalArtistUrl,
+    type SupportedArtistPlatform,
+} from "@/lib/artistProfileUrl";
+
+export type DuplicateArtistCandidate = {
+    id: string;
+    name: string | null;
+    spotify: string | null;
+    deezer: string | null;
+};
+
+type DuplicateArtistChoiceProps = {
+    candidates: DuplicateArtistCandidate[];
+    platform: SupportedArtistPlatform;
+    platformId: string;
+    message?: string;
+    isCreatingSeparate: boolean;
+    onCreateSeparate: () => void | Promise<void>;
+    onChooseExisting?: () => void;
+};
+
+function linkedPlatforms(candidate: DuplicateArtistCandidate) {
+    return [candidate.spotify ? "Spotify" : null, candidate.deezer ? "Deezer" : null]
+        .filter(Boolean)
+        .join(" and ");
+}
+
+export default function DuplicateArtistChoice({
+    candidates,
+    platform,
+    platformId,
+    message,
+    isCreatingSeparate,
+    onCreateSeparate,
+    onChooseExisting,
+}: DuplicateArtistChoiceProps) {
+    if (isCreatingSeparate) {
+        return (
+            <section
+                role="status"
+                aria-live="polite"
+                aria-busy="true"
+                className="mt-4 rounded-lg border border-amber-300 bg-amber-50 p-4 text-amber-950"
+            >
+                <h3 className="font-semibold">Creating separate artist…</h3>
+                <p className="mt-1 text-sm">
+                    Please wait while the artist is created. This action cannot be cancelled.
+                </p>
+            </section>
+        );
+    }
+
+    const submittedUrl = buildCanonicalArtistUrl(platform, platformId);
+
+    if (!submittedUrl) {
+        return (
+            <section
+                aria-label="Possible existing artists"
+                className="mt-4 rounded-lg border border-red-300 bg-red-50 p-4 text-red-950"
+            >
+                <p role="alert">We couldn&apos;t prepare this artist link. Please submit the URL again.</p>
+            </section>
+        );
+    }
+
+    return (
+        <section
+            aria-label="Possible existing artists"
+            aria-live="polite"
+            className="mt-4 rounded-lg border border-amber-300 bg-amber-50 p-4 text-amber-950"
+        >
+            <h3 className="font-semibold">Is this an existing artist?</h3>
+            <p className="mt-1 text-sm">
+                {message ?? "We found an artist with the same name. Choose where this link belongs."}
+            </p>
+
+            <ul className="mt-3 space-y-3">
+                {candidates.map((candidate, index) => {
+                    const platforms = linkedPlatforms(candidate);
+                    const href = `/artist/${candidate.id}?addLink=${encodeURIComponent(submittedUrl)}`;
+
+                    return (
+                        <li key={candidate.id} className="rounded-md border border-amber-200 bg-white p-3">
+                            <p className="font-medium text-gray-950">{candidate.name || "Unnamed artist"}</p>
+                            {platforms && (
+                                <p className="mb-2 text-xs text-gray-600">Already linked on {platforms}</p>
+                            )}
+                            <Link
+                                href={href}
+                                onClick={onChooseExisting}
+                                aria-label={`Add link to existing artist: ${candidate.name || "Unnamed artist"} (candidate ${index + 1} of ${candidates.length})`}
+                                className="inline-flex min-h-9 items-center justify-center rounded-md border border-input bg-background px-3 py-2 text-sm font-medium text-gray-950 shadow-sm hover:bg-accent hover:text-accent-foreground"
+                            >
+                                Add link to existing artist
+                            </Link>
+                        </li>
+                    );
+                })}
+            </ul>
+
+            <div className="mt-4 border-t border-amber-200 pt-4">
+                <p className="mb-2 text-xs text-amber-900">
+                    Only create a separate artist if this is a different person or group with the same name.
+                </p>
+                <Button
+                    type="button"
+                    variant="outline"
+                    disabled={isCreatingSeparate}
+                    onClick={onCreateSeparate}
+                >
+                    {isCreatingSeparate ? "Creating..." : "Create separate artist"}
+                </Button>
+            </div>
+        </section>
+    );
+}

--- a/src/app/_components/DuplicateArtistChoice.tsx
+++ b/src/app/_components/DuplicateArtistChoice.tsx
@@ -20,6 +20,7 @@ type DuplicateArtistChoiceProps = {
     platformId: string;
     message?: string;
     isCreatingSeparate: boolean;
+    canCreateSeparate?: boolean;
     onCreateSeparate: () => void | Promise<void>;
     onChooseExisting?: () => void;
 };
@@ -36,6 +37,7 @@ export default function DuplicateArtistChoice({
     platformId,
     message,
     isCreatingSeparate,
+    canCreateSeparate = true,
     onCreateSeparate,
     onChooseExisting,
 }: DuplicateArtistChoiceProps) {
@@ -103,19 +105,21 @@ export default function DuplicateArtistChoice({
                 })}
             </ul>
 
-            <div className="mt-4 border-t border-amber-200 pt-4">
-                <p className="mb-2 text-xs text-amber-900">
-                    Only create a separate artist if this is a different person or group with the same name.
-                </p>
-                <Button
-                    type="button"
-                    variant="outline"
-                    disabled={isCreatingSeparate}
-                    onClick={onCreateSeparate}
-                >
-                    {isCreatingSeparate ? "Creating..." : "Create separate artist"}
-                </Button>
-            </div>
+            {canCreateSeparate && (
+                <div className="mt-4 border-t border-amber-200 pt-4">
+                    <p className="mb-2 text-xs text-amber-900">
+                        Only create a separate artist if this is a different person or group with the same name.
+                    </p>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isCreatingSeparate}
+                        onClick={onCreateSeparate}
+                    >
+                        {isCreatingSeparate ? "Creating..." : "Create separate artist"}
+                    </Button>
+                </div>
+            )}
         </section>
     );
 }

--- a/src/app/_components/nav/components/AddArtist.tsx
+++ b/src/app/_components/nav/components/AddArtist.tsx
@@ -9,7 +9,7 @@ import {
     DialogTitle,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import Link from "next/link";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
@@ -28,33 +28,25 @@ import type { AddArtistResp } from "@/app/actions/serverActions";
 import { cn } from "@/lib/utils";
 import { Plus } from 'lucide-react';
 import { useSession } from "next-auth/react";
-import { useLogin } from "@privy-io/react-auth";
-
-const spotifyArtistUrlRegex = /https:\/\/open\.spotify\.com\/artist\/([a-zA-Z0-9]+)/;
-const deezerArtistUrlRegex = /https?:\/\/(www\.)?deezer\.com\/([\w-]+\/)?artist\/(\d+)/;
-
-function parseArtistUrl(url: string): { id: string; platform: 'deezer' | 'spotify' } | null {
-    const deezerMatch = url.match(deezerArtistUrlRegex);
-    if (deezerMatch) return { id: deezerMatch[3], platform: 'deezer' };
-    const spotifyMatch = url.match(spotifyArtistUrlRegex);
-    if (spotifyMatch) return { id: spotifyMatch[1], platform: 'spotify' };
-    return null;
-}
+import DuplicateArtistChoice from "@/app/_components/DuplicateArtistChoice";
+import { parseSupportedArtistUrl } from "@/lib/artistProfileUrl";
 
 const formSchema = z.object({
     artistUrl: z.string().refine(
-        (val) => spotifyArtistUrlRegex.test(val) || deezerArtistUrlRegex.test(val),
+        (val) => parseSupportedArtistUrl(val) !== null,
         { message: "Enter a Spotify or Deezer artist URL (e.g. https://open.spotify.com/artist/... or https://www.deezer.com/artist/...)" },
     ),
 })
 
 export default function AddArtist() {
-    const { data: session } = useSession();
+    const { data: session, status: sessionStatus } = useSession();
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
+    const [isCreatingSeparate, setIsCreatingSeparate] = useState(false);
     const [addedArtist, setAddedArtist] = useState<{ artistId: string | undefined, artistName: string | undefined } | null>(null);
     const [addArtistStatus, setAddArtistStatus] = useState<AddArtistResp | null>(null);
-    const { login } = useLogin();
+    const requestGenerationRef = useRef(0);
+    const requestInFlightRef = useRef(false);
 
     const form = useForm<z.infer<typeof formSchema>>({
         resolver: zodResolver(formSchema),
@@ -64,17 +56,78 @@ export default function AddArtist() {
         },
     })
 
-    async function onSubmit(values: z.infer<typeof formSchema>) {
-        const parsed = parseArtistUrl(values.artistUrl);
-        if (!parsed) return null;
-        setIsLoading(true);
-        const resp = await addArtist(parsed.id, parsed.platform);
+    function applyResponse(resp: AddArtistResp) {
         setAddArtistStatus(resp);
-        setIsLoading(false);
-        if (resp.status === "success" || resp.status === "exists") setAddedArtist({ artistId: resp.artistId, artistName: resp.artistName });
+        if (resp.status === "success" || resp.status === "exists") {
+            setAddedArtist({ artistId: resp.artistId, artistName: resp.artistName });
+        } else {
+            setAddedArtist(null);
+        }
+    }
+
+    async function onSubmit(values: z.infer<typeof formSchema>) {
+        const parsed = parseSupportedArtistUrl(values.artistUrl);
+        if (!parsed || requestInFlightRef.current) return null;
+
+        const requestGeneration = ++requestGenerationRef.current;
+        requestInFlightRef.current = true;
+        setIsLoading(true);
+        setAddedArtist(null);
+
+        try {
+            const response = await addArtist(parsed.id, parsed.platform);
+            if (requestGenerationRef.current === requestGeneration) {
+                applyResponse(response);
+            }
+        } catch (error) {
+            console.error("[AddArtist] Error adding artist:", error);
+            if (requestGenerationRef.current === requestGeneration) {
+                applyResponse({ status: "error", message: "Failed to add artist. Please try again." });
+            }
+        } finally {
+            requestInFlightRef.current = false;
+            setIsLoading(false);
+        }
+    }
+
+    async function handleCreateSeparate() {
+        if (addArtistStatus?.status !== "possible_duplicate" || requestInFlightRef.current) return;
+
+        const requestGeneration = ++requestGenerationRef.current;
+        requestInFlightRef.current = true;
+        setIsCreatingSeparate(true);
+        try {
+            const resp = await addArtist(
+                addArtistStatus.platformId,
+                addArtistStatus.platform,
+                { forceCreate: true },
+            );
+            if (requestGenerationRef.current === requestGeneration) {
+                applyResponse(resp);
+            }
+        } catch (error) {
+            console.error("[AddArtist] Error creating separate artist:", error);
+            if (requestGenerationRef.current === requestGeneration) {
+                applyResponse({ status: "error", message: "Failed to create the artist. Please try again." });
+            }
+        } finally {
+            requestInFlightRef.current = false;
+            setIsCreatingSeparate(false);
+        }
+    }
+
+    function clearCurrentResponse() {
+        if (isCreatingSeparate) return;
+
+        requestGenerationRef.current += 1;
+        setAddArtistStatus(null);
+        setAddedArtist(null);
     }
 
     function closeModal(isOpen: boolean) {
+        if (!isOpen && isCreatingSeparate) return;
+
+        requestGenerationRef.current += 1;
         setIsModalOpen(isOpen);
         setAddArtistStatus(null);
         setAddedArtist(null);
@@ -82,10 +135,17 @@ export default function AddArtist() {
     }
 
     function handleAddArtistClick() {
+        if (sessionStatus === "loading") return;
+
         if (session) {
             setIsModalOpen(true);
         } else {
-            login();
+            const loginButton = document.getElementById("login-btn");
+            if (loginButton) {
+                loginButton.click();
+            } else if (process.env.NODE_ENV !== "production") {
+                console.warn("[AddArtist] #login-btn not found — cannot prompt login");
+            }
         }
     }
 
@@ -94,64 +154,125 @@ export default function AddArtist() {
             <Button
                 className="text-black p-3 bg-pastyblue rounded-lg border-none hover:bg-gray-200 transition-colors duration-300 w-10 h-10 sm:w-12 sm:h-12 shrink-0"
                 onClick={handleAddArtistClick}
+                aria-label="Add new artist"
+                title="Add new artist"
+                disabled={sessionStatus === "loading"}
                 size="lg"
             >
-                <Plus color="white" />
+                <Plus color="white" aria-hidden="true" />
             </Button>
 
             <Dialog open={isModalOpen} onOpenChange={closeModal}>
-                <DialogContent className="max-w-sm px-4 sm:max-w-[700px] max-h-screen overflow-auto scrollbar-hide text:black rounded-lg" >
-                    <DialogHeader>
-                        <DialogTitle>Add Artist</DialogTitle>
-                        <DialogDescription>
-                            Add an artist by pasting their Spotify or Deezer URL
-                        </DialogDescription>
-                    </DialogHeader>
-                    <Form {...form}>
-                        <div className="space-y-8">
-                            <FormField
-                                control={form.control}
-                                name="artistUrl"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel>Artist URL</FormLabel>
-                                        <FormControl>
-                                            <Input placeholder="Paste a Spotify or Deezer artist URL" {...field} />
-                                        </FormControl>
-                                        <FormDescription>
-                                            Copy the URL from the artist&apos;s Spotify or Deezer page
-                                        </FormDescription>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
-                            <div>
-                                <Button onClick={form.handleSubmit(onSubmit)} className="w-auto self-start bg-pastypink">
-                                    {isLoading ?
-                                        <img className="max-h-6" src="/spinner.svg" alt="whyyyyy" />
-                                        : <span>Add Artist</span>
-                                    }
-                                </Button>
-                                {addArtistStatus &&
-                                    <p className={cn(addArtistStatus.status === "error" ? "text-red-500" : "text-green-500")}>
-                                        {addArtistStatus.message}
-                                    </p>
-                                }
-                                <div className="flex flex-col gap-2 text-black overflow-auto">
-                                    {addedArtist &&
-                                        <>
-                                            <Link onMouseDown={() => setIsModalOpen(false)} href={`/artist/${addedArtist.artistId}`} key="check-out">
-                                                <Button variant="outline">Check out {addedArtist.artistName}</Button>
-                                            </Link>
-                                            <Link onMouseDown={() => setIsModalOpen(false)} href={`/artist/${addedArtist.artistId}?opADM=1`} key="add-data">
-                                                <Button variant="outline">Add links for {addedArtist.artistName}</Button>
-                                            </Link>
-                                        </>
-                                    }
-                                </div>
-                            </div>
+                <DialogContent
+                    aria-busy={isCreatingSeparate}
+                    onEscapeKeyDown={(event) => {
+                        if (isCreatingSeparate) event.preventDefault();
+                    }}
+                    onPointerDownOutside={(event) => {
+                        if (isCreatingSeparate) event.preventDefault();
+                    }}
+                    className={`max-w-sm px-4 sm:max-w-[700px] max-h-screen overflow-auto scrollbar-hide text:black rounded-lg ${isCreatingSeparate ? "min-h-48" : ""}`}
+                >
+                    {isCreatingSeparate ? (
+                        <div
+                            role="status"
+                            aria-live="polite"
+                            className="absolute inset-0 z-10 flex flex-col items-center justify-center rounded-lg bg-background p-6 text-center"
+                        >
+                            <p className="font-semibold">Creating separate artist…</p>
+                            <p className="mt-1 text-sm text-muted-foreground">
+                                Please wait while the artist is created. This action cannot be cancelled.
+                            </p>
                         </div>
-                    </Form>
+                    ) : (
+                        <>
+                            <DialogHeader>
+                                <DialogTitle>Add new artist</DialogTitle>
+                                <DialogDescription>
+                                    Add an artist by pasting their Spotify or Deezer URL
+                                </DialogDescription>
+                            </DialogHeader>
+                            <Form {...form}>
+                                <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+                                    <FormField
+                                        control={form.control}
+                                        name="artistUrl"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel>Artist URL</FormLabel>
+                                                <FormControl>
+                                                    <Input
+                                                        placeholder="Paste a Spotify or Deezer artist URL"
+                                                        {...field}
+                                                        disabled={isCreatingSeparate}
+                                                        onChange={(event) => {
+                                                            field.onChange(event);
+                                                            clearCurrentResponse();
+                                                        }}
+                                                    />
+                                                </FormControl>
+                                                <FormDescription>
+                                                    Copy the URL from the artist&apos;s Spotify or Deezer page
+                                                </FormDescription>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+                                    <div>
+                                        <Button
+                                            type="submit"
+                                            disabled={isLoading || isCreatingSeparate || addArtistStatus?.status === "possible_duplicate"}
+                                            className="w-auto self-start bg-pastypink"
+                                        >
+                                            {isLoading ?
+                                                <img className="max-h-6" src="/spinner.svg" alt="Adding artist" />
+                                                : <span>Add Artist</span>
+                                            }
+                                        </Button>
+                                        {addArtistStatus && addArtistStatus.status !== "possible_duplicate" &&
+                                            <p
+                                                aria-live="polite"
+                                                className={cn(
+                                                    addArtistStatus.status === "error" || addArtistStatus.status === "conflict"
+                                                        ? "text-red-500"
+                                                        : "text-green-500",
+                                                )}
+                                            >
+                                                {addArtistStatus.message}
+                                            </p>
+                                        }
+                                        {addArtistStatus?.status === "possible_duplicate" && (
+                                            <DuplicateArtistChoice
+                                                candidates={addArtistStatus.candidates}
+                                                platform={addArtistStatus.platform}
+                                                platformId={addArtistStatus.platformId}
+                                                message={addArtistStatus.message}
+                                                isCreatingSeparate={isCreatingSeparate}
+                                                onCreateSeparate={handleCreateSeparate}
+                                                onChooseExisting={() => closeModal(false)}
+                                            />
+                                        )}
+                                        <div className="flex flex-col gap-2 text-black overflow-auto">
+                                            {addedArtist &&
+                                                <>
+                                                    <Button asChild variant="outline" key="check-out">
+                                                        <Link onClick={() => closeModal(false)} href={`/artist/${addedArtist.artistId}`}>
+                                                            Check out {addedArtist.artistName}
+                                                        </Link>
+                                                    </Button>
+                                                    <Button asChild variant="outline" key="add-data">
+                                                        <Link onClick={() => closeModal(false)} href={`/artist/${addedArtist.artistId}?opADM=1`}>
+                                                            Add links for {addedArtist.artistName}
+                                                        </Link>
+                                                    </Button>
+                                                </>
+                                            }
+                                        </div>
+                                    </div>
+                                </form>
+                            </Form>
+                        </>
+                    )}
                 </DialogContent>
             </Dialog>
         </>

--- a/src/app/_components/nav/components/AddArtist.tsx
+++ b/src/app/_components/nav/components/AddArtist.tsx
@@ -91,7 +91,11 @@ export default function AddArtist() {
     }
 
     async function handleCreateSeparate() {
-        if (addArtistStatus?.status !== "possible_duplicate" || requestInFlightRef.current) return;
+        if (
+            addArtistStatus?.status !== "possible_duplicate"
+            || addArtistStatus.canCreateSeparate === false
+            || requestInFlightRef.current
+        ) return;
 
         const requestGeneration = ++requestGenerationRef.current;
         requestInFlightRef.current = true;
@@ -248,6 +252,7 @@ export default function AddArtist() {
                                                 platformId={addArtistStatus.platformId}
                                                 message={addArtistStatus.message}
                                                 isCreatingSeparate={isCreatingSeparate}
+                                                canCreateSeparate={addArtistStatus.canCreateSeparate}
                                                 onCreateSeparate={handleCreateSeparate}
                                                 onChooseExisting={() => closeModal(false)}
                                             />

--- a/src/app/_components/nav/components/SearchBar.tsx
+++ b/src/app/_components/nav/components/SearchBar.tsx
@@ -47,6 +47,7 @@ type PossibleDuplicateResponse = {
     platform: MusicPlatform;
     platformId: string;
     message?: string;
+    canCreateSeparate?: boolean;
 };
 
 function SearchBarInner({ isTopSide = false }: SearchBarProps) {
@@ -115,7 +116,11 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
     }, [router, toast]);
 
     const handleCreateSeparate = useCallback(async () => {
-        if (!duplicateChoice || addRequestInFlightRef.current) return;
+        if (
+            !duplicateChoice
+            || duplicateChoice.canCreateSeparate === false
+            || addRequestInFlightRef.current
+        ) return;
 
         const response = duplicateChoice;
         const requestGeneration = ++addRequestGenerationRef.current;
@@ -323,6 +328,7 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
                         platformId={duplicateChoice.platformId}
                         message={duplicateChoice.message}
                         isCreatingSeparate={isCreatingSeparate}
+                        canCreateSeparate={duplicateChoice.canCreateSeparate}
                         onCreateSeparate={handleCreateSeparate}
                         onChooseExisting={() => {
                             invalidateAddRequest();

--- a/src/app/_components/nav/components/SearchBar.tsx
+++ b/src/app/_components/nav/components/SearchBar.tsx
@@ -11,6 +11,8 @@ import { useToast } from '@/hooks/use-toast';
 import { useSession } from "next-auth/react";
 import { addArtist } from "@/app/actions/addArtist";
 import { isDevMode } from "@/lib/dev-mode";
+import DuplicateArtistChoice, { type DuplicateArtistCandidate } from "@/app/_components/DuplicateArtistChoice";
+import type { MusicPlatform } from "@/server/utils/musicPlatform";
 
 const queryClient = new QueryClient({
     defaultOptions: {
@@ -39,6 +41,14 @@ const PENDING_ADD_PLATFORM_KEY = 'pendingAddArtistPlatform';
 const PENDING_ADD_TS_KEY = 'pendingAddArtistTimestamp';
 const PENDING_ADD_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
+type PossibleDuplicateResponse = {
+    status: 'possible_duplicate';
+    candidates: DuplicateArtistCandidate[];
+    platform: MusicPlatform;
+    platformId: string;
+    message?: string;
+};
+
 function SearchBarInner({ isTopSide = false }: SearchBarProps) {
     const router = useRouter();
     const { toast } = useToast();
@@ -51,34 +61,105 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
     const blurTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
     const { data: session } = useSession();
     const [addingPlatformId, setAddingPlatformId] = useState<string | null>(null);
+    const [isCreatingSeparate, setIsCreatingSeparate] = useState(false);
+    const [duplicateChoice, setDuplicateChoice] = useState<PossibleDuplicateResponse | null>(null);
+    const addRequestGenerationRef = useRef(0);
+    const addRequestInFlightRef = useRef(false);
 
-    const handleAddArtist = useCallback(async (platformId: string, platform: string = 'deezer') => {
+    const invalidateAddRequest = useCallback(() => {
+        addRequestGenerationRef.current += 1;
+    }, []);
+
+    const handleAddArtist = useCallback(async (
+        platformId: string,
+        platform: string = 'deezer',
+    ) => {
+        if (addRequestInFlightRef.current) return;
+
+        const requestGeneration = ++addRequestGenerationRef.current;
+        addRequestInFlightRef.current = true;
         try {
             setAddingPlatformId(platformId);
             const addResult = await addArtist(platformId, platform as 'deezer' | 'spotify');
 
+            if (addRequestGenerationRef.current !== requestGeneration) return;
+
             if ((addResult.status === "success" || addResult.status === "exists") && addResult.artistId) {
+                setDuplicateChoice(null);
                 setShowResults(false);
                 setQuery('');
                 router.push(`/artist/${addResult.artistId}`);
+            } else if (addResult.status === "possible_duplicate") {
+                setDuplicateChoice(addResult);
+                setShowResults(false);
             } else {
                 toast({
                     variant: "destructive",
-                    title: "Error",
+                    title: addResult.status === "conflict" ? "Artist conflict" : "Error",
                     description: addResult.message || "Failed to add artist"
                 });
             }
         } catch (error) {
             console.error("[SearchBar] Error adding artist:", error);
-            toast({
-                variant: "destructive",
-                title: "Error",
-                description: "Failed to add artist - please try again"
-            });
+            if (addRequestGenerationRef.current === requestGeneration) {
+                toast({
+                    variant: "destructive",
+                    title: "Error",
+                    description: "Failed to add artist - please try again"
+                });
+            }
         } finally {
+            addRequestInFlightRef.current = false;
             setAddingPlatformId(null);
         }
     }, [router, toast]);
+
+    const handleCreateSeparate = useCallback(async () => {
+        if (!duplicateChoice || addRequestInFlightRef.current) return;
+
+        const response = duplicateChoice;
+        const requestGeneration = ++addRequestGenerationRef.current;
+        addRequestInFlightRef.current = true;
+        setIsCreatingSeparate(true);
+        try {
+            const addResult = await addArtist(
+                response.platformId,
+                response.platform,
+                { forceCreate: true },
+            );
+
+            if (addRequestGenerationRef.current !== requestGeneration) return;
+
+            if ((addResult.status === "success" || addResult.status === "exists") && addResult.artistId) {
+                setDuplicateChoice(null);
+                setQuery('');
+                router.push(`/artist/${addResult.artistId}`);
+            } else if (addResult.status === "possible_duplicate") {
+                setDuplicateChoice(addResult);
+            } else {
+                if (addResult.status === "conflict") {
+                    setDuplicateChoice(null);
+                }
+                toast({
+                    variant: "destructive",
+                    title: addResult.status === "conflict" ? "Artist conflict" : "Error",
+                    description: addResult.message || "Failed to add artist",
+                });
+            }
+        } catch (error) {
+            console.error("[SearchBar] Error creating separate artist:", error);
+            if (addRequestGenerationRef.current === requestGeneration) {
+                toast({
+                    variant: "destructive",
+                    title: "Error",
+                    description: "Failed to add artist - please try again",
+                });
+            }
+        } finally {
+            addRequestInFlightRef.current = false;
+            setIsCreatingSeparate(false);
+        }
+    }, [duplicateChoice, router, toast]);
 
     // After login + page reload, complete the pending add-artist flow
     useEffect(() => {
@@ -130,8 +211,12 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
     }, [debouncedQuery, results]);
 
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (isCreatingSeparate) return;
+
         const value = e.target.value;
+        invalidateAddRequest();
         setQuery(value);
+        setDuplicateChoice(null);
 
         if (value.trim() === '') {
             setShowResults(false);
@@ -155,6 +240,8 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
 
     useEffect(() => {
         return () => {
+            addRequestGenerationRef.current += 1;
+            addRequestInFlightRef.current = false;
             if (blurTimeoutRef.current) {
                 clearTimeout(blurTimeoutRef.current);
             }
@@ -162,6 +249,8 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
     }, []);
 
     const handleResultClick = async (result: SearchResult) => {
+        if (addRequestInFlightRef.current) return;
+
         if (result.isExternalOnly) {
             if (!result.platformId) return;
 
@@ -178,12 +267,16 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
                 return;
             }
 
-            await handleAddArtist(result.platformId, result.platform || 'deezer');
+            await handleAddArtist(
+                result.platformId,
+                result.platform || 'deezer',
+            );
             return;
         }
 
         setShowResults(false);
         setQuery('');
+        addRequestGenerationRef.current += 1;
 
         if (result.id) {
             router.push(`/artist/${result.id}`);
@@ -195,8 +288,10 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
         return platform.charAt(0).toUpperCase() + platform.slice(1);
     };
 
+    const isAddInFlight = addingPlatformId !== null || isCreatingSeparate;
+
     return (
-        <div className="relative w-full max-w-[400px]">
+        <div aria-busy={isCreatingSeparate} className="relative w-full max-w-[400px]">
             <div className="relative">
                 {/* The Input primitive ships with no border, height or focus ring (a documented
                     deviation from stock shadcn), so the search pill's chrome is added here at the
@@ -208,6 +303,7 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
                     type="text"
                     placeholder="Search for an artist..."
                     value={query}
+                    disabled={isCreatingSeparate}
                     onChange={handleInputChange}
                     onBlur={handleBlur}
                     onFocus={handleFocus}
@@ -219,7 +315,26 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
             </div>
 
-            {showResults && results.length > 0 && (
+            {duplicateChoice && (
+                <div className="absolute z-50 mt-2 max-h-[min(28rem,calc(100vh-6rem))] w-full overflow-y-auto rounded-lg bg-white p-3 shadow-lg dark:bg-gray-800">
+                    <DuplicateArtistChoice
+                        candidates={duplicateChoice.candidates}
+                        platform={duplicateChoice.platform}
+                        platformId={duplicateChoice.platformId}
+                        message={duplicateChoice.message}
+                        isCreatingSeparate={isCreatingSeparate}
+                        onCreateSeparate={handleCreateSeparate}
+                        onChooseExisting={() => {
+                            invalidateAddRequest();
+                            setDuplicateChoice(null);
+                            setShowResults(false);
+                            setQuery('');
+                        }}
+                    />
+                </div>
+            )}
+
+            {!duplicateChoice && showResults && results.length > 0 && (
                 <div
                     ref={resultsContainer}
                     className="absolute w-full mt-2 bg-white dark:bg-gray-800 rounded-lg shadow-lg max-h-96 overflow-y-auto z-50"
@@ -232,7 +347,7 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
                         return (
                             <button
                                 key={result.isExternalOnly ? `ext-${result.platformId}` : result.id}
-                                disabled={isThisAdding}
+                                disabled={isAddInFlight}
                                 onClick={() => handleResultClick(result)}
                                 className={`w-full p-3 flex items-center gap-3 text-left disabled:opacity-50 ${
                                     result.isExternalOnly
@@ -304,7 +419,7 @@ function SearchBarInner({ isTopSide = false }: SearchBarProps) {
                 </div>
             )}
 
-            {isLoading && (
+            {!duplicateChoice && isLoading && (
                 <div className="absolute w-full mt-2 bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 text-center z-50">
                     <div className="text-gray-600 dark:text-gray-400">Searching...</div>
                 </div>

--- a/src/app/actions/__tests__/addArtist.test.ts
+++ b/src/app/actions/__tests__/addArtist.test.ts
@@ -22,10 +22,15 @@ describe('addArtist Server Action', () => {
     jest.clearAllMocks();
   });
 
-  it('should throw when not authenticated', async () => {
+  it('should return an error response when not authenticated', async () => {
     mockGetSession.mockResolvedValue(null);
 
-    await expect(addArtist('test-id')).rejects.toThrow('Not authenticated');
+    await expect(addArtist('test-id')).resolves.toEqual({
+      status: 'error',
+      code: 'UNAUTHENTICATED',
+      message: 'Please log in to add artists',
+    });
+    expect(mockDbAddArtist).not.toHaveBeenCalled();
   });
 
   it('should return success when artist is added via spotify (default)', async () => {
@@ -34,7 +39,7 @@ describe('addArtist Server Action', () => {
 
     const result = await addArtist('test-spotify-id');
 
-    expect(mockDbAddArtist).toHaveBeenCalledWith('test-spotify-id', 'spotify');
+    expect(mockDbAddArtist).toHaveBeenCalledWith('test-spotify-id', 'spotify', undefined);
     expect(result).toEqual({ status: 'success', artistId: '123', artistName: 'Test Artist' });
   });
 
@@ -44,7 +49,20 @@ describe('addArtist Server Action', () => {
 
     const result = await addArtist('12345', 'deezer');
 
-    expect(mockDbAddArtist).toHaveBeenCalledWith('12345', 'deezer');
+    expect(mockDbAddArtist).toHaveBeenCalledWith('12345', 'deezer', undefined);
     expect(result).toEqual({ status: 'success', artistId: '456', artistName: 'Deezer Artist' });
+  });
+
+  it('forwards the force-create confirmation', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'user-1' } });
+    mockDbAddArtist.mockResolvedValue({ status: 'success', artistId: '789', artistName: 'Separate Artist' });
+
+    await addArtist('test-spotify-id', 'spotify', { forceCreate: true });
+
+    expect(mockDbAddArtist).toHaveBeenCalledWith(
+      'test-spotify-id',
+      'spotify',
+      { forceCreate: true },
+    );
   });
 });

--- a/src/app/actions/addArtist.ts
+++ b/src/app/actions/addArtist.ts
@@ -2,24 +2,40 @@
 
 import { getServerAuthSession } from "@/server/auth";
 import { getDevSession } from "@/server/utils/dev-auth";
-import { addArtist as dbAddArtist, type AddArtistResp } from "@/server/utils/queries/artistQueries";
+import {
+    addArtist as dbAddArtist,
+    type AddArtistOptions,
+    type AddArtistResp,
+} from "@/server/utils/queries/artistQueries";
 import type { MusicPlatform } from "@/server/utils/musicPlatform";
 
-export async function addArtist(platformId: string, platform: MusicPlatform = 'spotify'): Promise<AddArtistResp> {
+export async function addArtist(
+    platformId: string,
+    platform: MusicPlatform = 'spotify',
+    options?: AddArtistOptions,
+): Promise<AddArtistResp> {
     const session = await getServerAuthSession() ?? await getDevSession();
 
     if (!session) {
-        throw new Error("Not authenticated");
+        return {
+            status: "error",
+            code: "UNAUTHENTICATED",
+            message: "Please log in to add artists",
+        };
     }
 
     try {
-        const result = await dbAddArtist(platformId, platform);
+        const result = await dbAddArtist(platformId, platform, options);
         return result;
     } catch (e) {
         console.error("[addArtist] Error:", e);
         if (e instanceof Error) {
             if (e.message.includes('auth')) {
-                return { status: "error", message: "Please log in to add artists" };
+                return {
+                    status: "error",
+                    code: "UNAUTHENTICATED",
+                    message: "Please log in to add artists",
+                };
             }
             if (e.message.includes('duplicate')) {
                 return { status: "error", message: "This artist is already in our database" };

--- a/src/app/add-artist/_components/AddArtistContent.tsx
+++ b/src/app/add-artist/_components/AddArtistContent.tsx
@@ -5,13 +5,53 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { addArtist } from "../../actions/addArtist";
 import { useSession } from "next-auth/react";
-import type { MusicPlatformArtist } from "@/server/utils/musicPlatform";
+import type { MusicPlatform, MusicPlatformArtist } from "@/server/utils/musicPlatform";
+import DuplicateArtistChoice, { type DuplicateArtistCandidate } from "@/app/_components/DuplicateArtistChoice";
+
+type PossibleDuplicateResponse = {
+    status: "possible_duplicate";
+    candidates: DuplicateArtistCandidate[];
+    platform: MusicPlatform;
+    platformId: string;
+    message?: string;
+};
 
 export default function AddArtistContent({ initialArtist }: { initialArtist: MusicPlatformArtist }) {
     const router = useRouter();
     const [adding, setAdding] = useState(false);
+    const [isCreatingSeparate, setIsCreatingSeparate] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [duplicateChoice, setDuplicateChoice] = useState<PossibleDuplicateResponse | null>(null);
     const { data: session, status } = useSession();
+
+    function promptLogin() {
+        const loginBtn = document.getElementById("login-btn");
+        if (!loginBtn) return false;
+
+        loginBtn.click();
+        return true;
+    }
+
+    function handleResult(result: Awaited<ReturnType<typeof addArtist>>) {
+        if (result.status === "error" && result.code === "UNAUTHENTICATED") {
+            setDuplicateChoice(null);
+            setError(promptLogin()
+                ? null
+                : result.message ?? "Please log in to add artists");
+            return;
+        }
+
+        if ((result.status === "success" || result.status === "exists") && result.artistId) {
+            setDuplicateChoice(null);
+            router.push(`/artist/${result.artistId}`);
+        } else if (result.status === "possible_duplicate") {
+            setDuplicateChoice(result);
+            setError(null);
+        } else {
+            setDuplicateChoice(null);
+            setError(result.message || "Failed to add artist");
+        }
+    }
 
     async function handleAddArtist() {
         if (status === "loading") {
@@ -19,10 +59,7 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
         }
 
         if (!session) {
-            const loginBtn = document.getElementById("login-btn");
-            if (loginBtn) {
-                loginBtn.click();
-            }
+            promptLogin();
             return;
         }
 
@@ -31,32 +68,41 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
 
         try {
             const result = await addArtist(initialArtist.platformId, initialArtist.platform);
-
-            if (result.status === "success" && result.artistId) {
-                router.push(`/artist/${result.artistId}`);
-            } else if (result.status === "exists" && result.artistId) {
-                router.push(`/artist/${result.artistId}`);
-            } else {
-                setError(result.message || "Failed to add artist");
-            }
+            handleResult(result);
         } catch (err) {
             console.error("Error in handleAddArtist:", err);
-            if (err instanceof Error && err.message.includes('Not authenticated')) {
-                const loginBtn = document.getElementById("login-btn");
-                if (loginBtn) {
-                    loginBtn.click();
-                }
-            } else {
-                setError("Failed to add artist - please try again");
-            }
+            setError("Failed to add artist - please try again");
         } finally {
             setAdding(false);
         }
     }
 
+    async function handleCreateSeparate() {
+        if (!duplicateChoice || isCreatingSeparate) return;
+
+        setIsCreatingSeparate(true);
+        setError(null);
+        try {
+            const result = await addArtist(
+                duplicateChoice.platformId,
+                duplicateChoice.platform,
+                { forceCreate: true },
+            );
+            handleResult(result);
+        } catch (err) {
+            console.error("Error creating separate artist:", err);
+            setError("Failed to add artist - please try again");
+        } finally {
+            setIsCreatingSeparate(false);
+        }
+    }
+
     return (
         <div className="min-h-screen flex items-center justify-center bg-gray-50">
-            <div className="bg-white p-8 rounded-xl shadow-lg max-w-2xl w-full mx-4">
+            <div
+                aria-busy={isCreatingSeparate}
+                className="bg-white p-8 rounded-xl shadow-lg max-w-2xl w-full mx-4"
+            >
                 {status === "loading" ? (
                     <div className="mb-4 p-4 bg-blue-100 text-blue-800 rounded-lg">
                         Loading authentication status...
@@ -67,7 +113,7 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
                     </div>
                 ) : null}
                 {error && (
-                    <div className="mb-4 p-4 bg-red-100 text-red-800 rounded-lg">
+                    <div role="alert" className="mb-4 p-4 bg-red-100 text-red-800 rounded-lg">
                         {error}
                     </div>
                 )}
@@ -103,7 +149,7 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
                         <div className="flex gap-4">
                             <Button
                                 onClick={handleAddArtist}
-                                disabled={adding || status === "loading"}
+                                disabled={adding || status === "loading" || Boolean(duplicateChoice)}
                                 className="bg-green-500 hover:bg-green-600 text-white"
                             >
                                 {adding ? "Adding..." : "Add Artist"}
@@ -111,12 +157,23 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
                             <Button
                                 onClick={() => router.back()}
                                 variant="outline"
+                                disabled={isCreatingSeparate}
                             >
                                 Cancel
                             </Button>
                         </div>
                     </div>
                 </div>
+                {duplicateChoice && (
+                    <DuplicateArtistChoice
+                        candidates={duplicateChoice.candidates}
+                        platform={duplicateChoice.platform}
+                        platformId={duplicateChoice.platformId}
+                        message={duplicateChoice.message}
+                        isCreatingSeparate={isCreatingSeparate}
+                        onCreateSeparate={handleCreateSeparate}
+                    />
+                )}
             </div>
         </div>
     );

--- a/src/app/add-artist/_components/AddArtistContent.tsx
+++ b/src/app/add-artist/_components/AddArtistContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { addArtist } from "../../actions/addArtist";
@@ -24,6 +24,13 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
     const [error, setError] = useState<string | null>(null);
     const [duplicateChoice, setDuplicateChoice] = useState<PossibleDuplicateResponse | null>(null);
     const { data: session, status } = useSession();
+    const requestGenerationRef = useRef(0);
+    const requestInFlightRef = useRef(false);
+
+    useEffect(() => () => {
+        requestGenerationRef.current += 1;
+        requestInFlightRef.current = false;
+    }, []);
 
     function promptLogin() {
         const loginBtn = document.getElementById("login-btn");
@@ -55,7 +62,7 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
     }
 
     async function handleAddArtist() {
-        if (status === "loading") {
+        if (status === "loading" || requestInFlightRef.current) {
             return;
         }
 
@@ -64,17 +71,26 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
             return;
         }
 
+        const requestGeneration = ++requestGenerationRef.current;
+        requestInFlightRef.current = true;
         setAdding(true);
         setError(null);
 
         try {
             const result = await addArtist(initialArtist.platformId, initialArtist.platform);
-            handleResult(result);
+            if (requestGenerationRef.current === requestGeneration) {
+                handleResult(result);
+            }
         } catch (err) {
             console.error("Error in handleAddArtist:", err);
-            setError("Failed to add artist - please try again");
+            if (requestGenerationRef.current === requestGeneration) {
+                setError("Failed to add artist - please try again");
+            }
         } finally {
-            setAdding(false);
+            if (requestGenerationRef.current === requestGeneration) {
+                requestInFlightRef.current = false;
+                setAdding(false);
+            }
         }
     }
 
@@ -82,30 +98,48 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
         if (
             !duplicateChoice
             || duplicateChoice.canCreateSeparate === false
-            || isCreatingSeparate
+            || requestInFlightRef.current
         ) return;
 
+        const response = duplicateChoice;
+        const requestGeneration = ++requestGenerationRef.current;
+        requestInFlightRef.current = true;
         setIsCreatingSeparate(true);
         setError(null);
         try {
             const result = await addArtist(
-                duplicateChoice.platformId,
-                duplicateChoice.platform,
+                response.platformId,
+                response.platform,
                 { forceCreate: true },
             );
-            handleResult(result);
+            if (requestGenerationRef.current === requestGeneration) {
+                handleResult(result);
+            }
         } catch (err) {
             console.error("Error creating separate artist:", err);
-            setError("Failed to add artist - please try again");
+            if (requestGenerationRef.current === requestGeneration) {
+                setError("Failed to add artist - please try again");
+            }
         } finally {
-            setIsCreatingSeparate(false);
+            if (requestGenerationRef.current === requestGeneration) {
+                requestInFlightRef.current = false;
+                setIsCreatingSeparate(false);
+            }
         }
     }
+
+    function handleCancel() {
+        requestGenerationRef.current += 1;
+        requestInFlightRef.current = false;
+        router.back();
+    }
+
+    const isRequestInFlight = adding || isCreatingSeparate;
 
     return (
         <div className="min-h-screen flex items-center justify-center bg-gray-50">
             <div
-                aria-busy={isCreatingSeparate}
+                aria-busy={isRequestInFlight}
                 className="bg-white p-8 rounded-xl shadow-lg max-w-2xl w-full mx-4"
             >
                 {status === "loading" ? (
@@ -160,9 +194,9 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
                                 {adding ? "Adding..." : "Add Artist"}
                             </Button>
                             <Button
-                                onClick={() => router.back()}
+                                onClick={handleCancel}
                                 variant="outline"
-                                disabled={isCreatingSeparate}
+                                disabled={isRequestInFlight}
                             >
                                 Cancel
                             </Button>

--- a/src/app/add-artist/_components/AddArtistContent.tsx
+++ b/src/app/add-artist/_components/AddArtistContent.tsx
@@ -14,6 +14,7 @@ type PossibleDuplicateResponse = {
     platform: MusicPlatform;
     platformId: string;
     message?: string;
+    canCreateSeparate?: boolean;
 };
 
 export default function AddArtistContent({ initialArtist }: { initialArtist: MusicPlatformArtist }) {
@@ -78,7 +79,11 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
     }
 
     async function handleCreateSeparate() {
-        if (!duplicateChoice || isCreatingSeparate) return;
+        if (
+            !duplicateChoice
+            || duplicateChoice.canCreateSeparate === false
+            || isCreatingSeparate
+        ) return;
 
         setIsCreatingSeparate(true);
         setError(null);
@@ -171,6 +176,7 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
                         platformId={duplicateChoice.platformId}
                         message={duplicateChoice.message}
                         isCreatingSeparate={isCreatingSeparate}
+                        canCreateSeparate={duplicateChoice.canCreateSeparate}
                         onCreateSeparate={handleCreateSeparate}
                     />
                 )}

--- a/src/app/api/directEditLink/__tests__/route.test.ts
+++ b/src/app/api/directEditLink/__tests__/route.test.ts
@@ -14,10 +14,20 @@ jest.mock("@/server/utils/queries/discord", () => ({
 jest.mock("@/server/utils/queries/dashboardQueries", () => ({
     getApprovedClaimForArtistByUserId: jest.fn(),
 }));
-jest.mock("@/server/utils/artistLinkService", () => ({
-    setArtistLink: jest.fn(),
-    clearArtistLink: jest.fn(),
-}));
+jest.mock("@/server/utils/artistLinkService", () => {
+    class ArtistLinkConflictError extends Error {
+        constructor(message) {
+            super(message);
+            this.name = "ArtistLinkConflictError";
+        }
+    }
+
+    return {
+        ArtistLinkConflictError,
+        setArtistLink: jest.fn(),
+        clearArtistLink: jest.fn(),
+    };
+});
 jest.mock("@/server/utils/services", () => ({
     extractArtistId: jest.fn(),
 }));
@@ -40,11 +50,12 @@ describe("POST /api/directEditLink", () => {
         const { getUserById } = await import("@/server/utils/queries/userQueries");
         const { sendDiscordMessage } = await import("@/server/utils/queries/discord");
         const { getApprovedClaimForArtistByUserId } = await import("@/server/utils/queries/dashboardQueries");
-        const { setArtistLink, clearArtistLink } = await import("@/server/utils/artistLinkService");
+        const { ArtistLinkConflictError, setArtistLink, clearArtistLink } = await import("@/server/utils/artistLinkService");
         const { extractArtistId } = await import("@/server/utils/services");
         const { POST } = await import("../route");
         return {
             POST,
+            ArtistLinkConflictError,
             requireAuth: requireAuth as jest.Mock,
             getUserById: getUserById as jest.Mock,
             sendDiscordMessage: sendDiscordMessage as jest.Mock,
@@ -169,6 +180,40 @@ describe("POST /api/directEditLink", () => {
         const res = await POST(makeRequest({ artistId: "a1", action: "set", url: "https://x.com/testuser" }));
 
         expect(res.status).toBe(500);
+        expect(sendDiscordMessage).not.toHaveBeenCalled();
+    });
+
+    it("returns 409 with a conflict message when the platform identity belongs elsewhere", async () => {
+        const {
+            POST,
+            ArtistLinkConflictError,
+            requireAuth,
+            getUserById,
+            sendDiscordMessage,
+            extractArtistId,
+            setArtistLink,
+        } = await setup();
+        requireAuth.mockResolvedValue({ authenticated: true, session: {}, userId: "u1" });
+        getUserById.mockResolvedValue({ id: "u1", username: "admin-user", isAdmin: true });
+        extractArtistId.mockResolvedValue({ siteName: "spotify", id: "spotify-123", cardPlatformName: "Spotify" });
+        setArtistLink.mockRejectedValue(
+            new ArtistLinkConflictError(
+                "That spotify artist ID is already linked to a different artist",
+            ),
+        );
+
+        const res = await POST(makeRequest({
+            artistId: "a1",
+            action: "set",
+            url: "https://open.spotify.com/artist/spotify-123",
+        }));
+        const data = await res.json();
+
+        expect(res.status).toBe(409);
+        expect(data).toEqual({
+            error: "That spotify artist ID is already linked to a different artist",
+            code: "CONFLICT",
+        });
         expect(sendDiscordMessage).not.toHaveBeenCalled();
     });
 

--- a/src/app/api/directEditLink/route.ts
+++ b/src/app/api/directEditLink/route.ts
@@ -1,7 +1,11 @@
 import { requireAuth } from "@/lib/auth-helpers";
 import { canEditArtist } from "@/server/utils/artistEditAuth";
 import { notifyDiscordOfArtistLinkAdded } from "@/server/utils/artistLinkDiscordNotifier";
-import { setArtistLink, clearArtistLink } from "@/server/utils/artistLinkService";
+import {
+    ArtistLinkConflictError,
+    setArtistLink,
+    clearArtistLink,
+} from "@/server/utils/artistLinkService";
 import { getUserById } from "@/server/utils/queries/userQueries";
 import { extractArtistId } from "@/server/utils/services";
 import { LINK_NOT_SUPPORTED_LONG } from "@/lib/linkSubmissionMessages";
@@ -64,6 +68,12 @@ export async function POST(req: Request) {
 
         return Response.json({ error: "Invalid action" }, { status: 400 });
     } catch (error) {
+        if (error instanceof ArtistLinkConflictError) {
+            return Response.json(
+                { error: error.message, code: "CONFLICT" },
+                { status: 409 },
+            );
+        }
         console.error("[directEditLink] Error:", error);
         return Response.json({ error: "Internal server error" }, { status: 500 });
     } finally {

--- a/src/app/api/mcp/__tests__/delete-artist-link.test.ts
+++ b/src/app/api/mcp/__tests__/delete-artist-link.test.ts
@@ -2,6 +2,7 @@
 import { jest } from "@jest/globals";
 
 jest.mock("@/server/utils/artistLinkService", () => ({
+  ArtistLinkConflictError: class ArtistLinkConflictError extends Error {},
   setArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
   clearArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
 }));

--- a/src/app/api/mcp/__tests__/exclude-artist-mapping.test.ts
+++ b/src/app/api/mcp/__tests__/exclude-artist-mapping.test.ts
@@ -30,6 +30,7 @@ jest.mock("@/server/utils/services", () => ({
   extractArtistId: jest.fn(),
 }));
 jest.mock("@/server/utils/artistLinkService", () => ({
+  ArtistLinkConflictError: class ArtistLinkConflictError extends Error {},
   setArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
   clearArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
 }));

--- a/src/app/api/mcp/__tests__/get-artist-mappings.test.ts
+++ b/src/app/api/mcp/__tests__/get-artist-mappings.test.ts
@@ -22,6 +22,7 @@ jest.mock("@/server/utils/services", () => ({
   extractArtistId: jest.fn(),
 }));
 jest.mock("@/server/utils/artistLinkService", () => ({
+  ArtistLinkConflictError: class ArtistLinkConflictError extends Error {},
   setArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
   clearArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
 }));

--- a/src/app/api/mcp/__tests__/get-mapping-stats.test.ts
+++ b/src/app/api/mcp/__tests__/get-mapping-stats.test.ts
@@ -18,6 +18,7 @@ jest.mock("@/server/utils/services", () => ({
   extractArtistId: jest.fn(),
 }));
 jest.mock("@/server/utils/artistLinkService", () => ({
+  ArtistLinkConflictError: class ArtistLinkConflictError extends Error {},
   setArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
   clearArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
 }));

--- a/src/app/api/mcp/__tests__/get-unmapped-artists.test.ts
+++ b/src/app/api/mcp/__tests__/get-unmapped-artists.test.ts
@@ -18,6 +18,7 @@ jest.mock("@/server/utils/services", () => ({
   extractArtistId: jest.fn(),
 }));
 jest.mock("@/server/utils/artistLinkService", () => ({
+  ArtistLinkConflictError: class ArtistLinkConflictError extends Error {},
   setArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
   clearArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
 }));

--- a/src/app/api/mcp/__tests__/resolve-artist-id.test.ts
+++ b/src/app/api/mcp/__tests__/resolve-artist-id.test.ts
@@ -38,6 +38,7 @@ jest.mock("@/server/utils/services", () => ({
   extractArtistId: jest.fn(),
 }));
 jest.mock("@/server/utils/artistLinkService", () => ({
+  ArtistLinkConflictError: class ArtistLinkConflictError extends Error {},
   setArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
   clearArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
 }));

--- a/src/app/api/mcp/__tests__/set-artist-link.test.ts
+++ b/src/app/api/mcp/__tests__/set-artist-link.test.ts
@@ -5,10 +5,20 @@ import { jest } from "@jest/globals";
 jest.mock("@/server/utils/services", () => ({
   extractArtistId: jest.fn(),
 }));
-jest.mock("@/server/utils/artistLinkService", () => ({
-  setArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
-  clearArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
-}));
+jest.mock("@/server/utils/artistLinkService", () => {
+  class ArtistLinkConflictError extends Error {
+    constructor(message) {
+      super(message);
+      this.name = "ArtistLinkConflictError";
+    }
+  }
+
+  return {
+    ArtistLinkConflictError,
+    setArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
+    clearArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
+  };
+});
 jest.mock("../audit", () => ({
   logMcpAudit: jest.fn().mockResolvedValue(undefined),
 }));
@@ -24,14 +34,14 @@ describe("set_artist_link MCP tool", () => {
 
   async function setup() {
     const { extractArtistId } = await import("@/server/utils/services");
-    const { setArtistLink } = await import("@/server/utils/artistLinkService");
+    const { ArtistLinkConflictError, setArtistLink } = await import("@/server/utils/artistLinkService");
     const { logMcpAudit } = await import("../audit");
     const { requireMcpAuth, McpAuthError } = await import("../auth");
 
     // Import server to get the registered tools
     const { server } = await import("../server");
 
-    return { extractArtistId, setArtistLink, logMcpAudit, requireMcpAuth, McpAuthError, server };
+    return { ArtistLinkConflictError, extractArtistId, setArtistLink, logMcpAudit, requireMcpAuth, McpAuthError, server };
   }
 
   // Helper to call the set_artist_link tool handler directly via _registeredTools
@@ -127,6 +137,34 @@ describe("set_artist_link MCP tool", () => {
     const result = await callSetArtistLink(s, { artistId: "00000000-0000-0000-0000-000000000001", url: "https://instagram.com/testuser" });
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.success).toBe(true);
+  });
+
+  it("returns a terminal conflict when the platform identity belongs elsewhere", async () => {
+    const s = await setup();
+    (s.requireMcpAuth as jest.Mock).mockReturnValue("test-hash");
+    (s.extractArtistId as jest.Mock).mockResolvedValue({
+      siteName: "spotify",
+      id: "spotify-123",
+      cardPlatformName: "Spotify",
+    });
+    (s.setArtistLink as jest.Mock).mockRejectedValue(
+      new s.ArtistLinkConflictError(
+        "That spotify artist ID is already linked to a different artist",
+      ),
+    );
+
+    const result = await callSetArtistLink(s, {
+      artistId: "00000000-0000-0000-0000-000000000001",
+      url: "https://open.spotify.com/artist/spotify-123",
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(parsed).toEqual({
+      error: "That spotify artist ID is already linked to a different artist",
+      code: "CONFLICT",
+    });
+    expect(s.logMcpAudit).not.toHaveBeenCalled();
   });
 
   it("returns error when no auth context", async () => {

--- a/src/app/api/mcp/server.ts
+++ b/src/app/api/mcp/server.ts
@@ -5,7 +5,11 @@ import { searchForArtistByName, getArtistById } from "@/server/utils/queries/art
 import { toArtistSummary } from "./transformers/artist-summary";
 import { toArtistDetail } from "./transformers/artist-detail";
 import { extractArtistId } from "@/server/utils/services";
-import { setArtistLink, clearArtistLink } from "@/server/utils/artistLinkService";
+import {
+  ArtistLinkConflictError,
+  setArtistLink,
+  clearArtistLink,
+} from "@/server/utils/artistLinkService";
 import { getUnmappedArtists, resolveArtistMapping, resolveArtistMappingBatch, getMappingStats, getArtistMappings, excludeArtistMapping, excludeArtistMappingBatch, getMappingExclusions, VALID_MAPPING_PLATFORMS, EXCLUSION_REASON_VALUES, MappingNotFoundError, MappingConflictError, MappingConcurrentWriteError, MappingValidationError } from "@/server/utils/idMappingService";
 
 import { requireMcpAuth, McpAuthError } from "./auth";
@@ -232,6 +236,12 @@ server.registerTool(
       if (error instanceof Error && error.message.startsWith("Artist not found")) {
         return {
           content: [{ type: "text" as const, text: JSON.stringify({ error: "Artist not found", code: "NOT_FOUND" }) }],
+          isError: true,
+        };
+      }
+      if (error instanceof ArtistLinkConflictError) {
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ error: error.message, code: "CONFLICT" }) }],
           isError: true,
         };
       }

--- a/src/app/artist/[id]/_components/AddArtistData.tsx
+++ b/src/app/artist/[id]/_components/AddArtistData.tsx
@@ -9,7 +9,7 @@ import {
     DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input"
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Artist } from "@/server/db/DbTypes";
 import { AspectRatio } from "@radix-ui/react-aspect-ratio";
 import { Label } from "@radix-ui/react-label";
@@ -34,23 +34,69 @@ import { Plus } from "lucide-react";
 import Link from "next/link";
 import { LINK_NOT_SUPPORTED, LINK_TWITTER_INVALID, TIPS_BUTTON_LABEL } from "@/lib/linkSubmissionMessages";
 
-export default function AddArtistData({ artist, spotifyImg, availableLinks, isOpenOnLoad = false, label, directEdit = false, autoApprove = false }: { artist: Artist, spotifyImg: string, availableLinks: UrlMap[], isOpenOnLoad: boolean, label?: string, directEdit?: boolean, autoApprove?: boolean }) {
+type AddArtistDataProps = {
+    artist: Artist;
+    spotifyImg: string;
+    availableLinks: UrlMap[];
+    isOpenOnLoad: boolean;
+    prefillUrl?: string;
+    label?: string;
+    directEdit?: boolean;
+    autoApprove?: boolean;
+};
+
+type PlatformRegexStatus = "loading" | "ready" | "error";
+
+function promptLogin() {
+    const loginBtn = document.getElementById("login-btn");
+    if (loginBtn) {
+        loginBtn.click();
+        return true;
+    }
+
+    if (process.env.NODE_ENV !== "production") {
+        console.warn("[AddArtistData] #login-btn not found — cannot prompt login");
+    }
+    return false;
+}
+
+export default function AddArtistData({ artist, spotifyImg, availableLinks, isOpenOnLoad = false, prefillUrl, label, directEdit = false, autoApprove = false }: AddArtistDataProps) {
     const { data: session, status } = useSession();
-    const [isModalOpen, setIsModalOpen] = useState(isOpenOnLoad);
+    const [isModalOpen, setIsModalOpen] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const [addArtistResp, setAddArtistResp] = useState<AddArtistDataResp | null>(null);
+    const handledAddLinkRef = useRef<string | null>(null);
+    const loginPromptedForAddLinkRef = useRef<string | null>(null);
     const router = useRouter();
     const { toast } = useToast();
 
     // State to hold platform regexes from the backend
     const [platformRegexes, setPlatformRegexes] = useState<{ siteName: string, regex: string }[]>([]);
+    const [platformRegexStatus, setPlatformRegexStatus] = useState<PlatformRegexStatus>("loading");
 
     // Fetch regexes from the backend on mount
     useEffect(() => {
+        let isMounted = true;
+
         fetch('/api/platformRegexes')
-            .then(res => res.json())
-            .then(data => setPlatformRegexes(data))
-            .catch(e => console.error('Failed to fetch platform regexes:', e));
+            .then(res => {
+                if (!res.ok) throw new Error(`Platform regex request failed with ${res.status}`);
+                return res.json();
+            })
+            .then(data => {
+                if (!Array.isArray(data)) throw new Error('Platform regex response was not an array');
+                if (!isMounted) return;
+                setPlatformRegexes(data);
+                setPlatformRegexStatus("ready");
+            })
+            .catch(e => {
+                console.error('Failed to fetch platform regexes:', e);
+                if (isMounted) setPlatformRegexStatus("error");
+            });
+
+        return () => {
+            isMounted = false;
+        };
     }, []);
 
     const formSchema = useMemo(() => z.object({
@@ -61,9 +107,52 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
         resolver: zodResolver(formSchema),
         mode: "onSubmit",
         defaultValues: {
-            artistDataUrl: "",
+            artistDataUrl: prefillUrl ?? "",
         },
     })
+
+    const { reset } = form;
+
+    // addLink is a one-shot handoff from search. It uses the same authentication
+    // gate as a manual open. Keep the URL intact while login is pending because
+    // Privy reloads the page after creating the NextAuth session; the authenticated
+    // mount can then open the dialog and consume the handoff without submitting it.
+    useEffect(() => {
+        if (!isOpenOnLoad || !prefillUrl) {
+            handledAddLinkRef.current = null;
+            loginPromptedForAddLinkRef.current = null;
+            return;
+        }
+
+        const addLinkKey = `${artist.id}:${prefillUrl}`;
+        if (handledAddLinkRef.current === addLinkKey) return;
+        if (status === "loading") return;
+
+        if (!session) {
+            setIsModalOpen(false);
+            if (
+                loginPromptedForAddLinkRef.current !== addLinkKey
+                && promptLogin()
+            ) {
+                loginPromptedForAddLinkRef.current = addLinkKey;
+            }
+            return;
+        }
+
+        handledAddLinkRef.current = addLinkKey;
+        setIsModalOpen(true);
+        reset({ artistDataUrl: prefillUrl });
+
+        const currentUrl = new URL(window.location.href);
+        if (!currentUrl.searchParams.has("addLink")) return;
+
+        currentUrl.searchParams.delete("addLink");
+        window.history.replaceState(
+            null,
+            "",
+            `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`,
+        );
+    }, [artist.id, isOpenOnLoad, prefillUrl, reset, session, status]);
 
     // Filter out ENS and wallets from display, but keep them in availableLinks for add options
     const displayLinks = availableLinks.filter(link => link.siteName !== 'ens' && link.siteName !== 'wallets');
@@ -84,6 +173,14 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
 
     // Add a function to call the backend validator
     async function validatePlatformLinkBackend(url: string): Promise<boolean> {
+        // The page only supplies prefillUrl after validating an exact Spotify or
+        // Deezer artist URL on the server. If the optional client regex lookup
+        // fails, let that untouched value reach the authoritative server write
+        // path rather than stranding the handoff.
+        if (platformRegexStatus === "error" && prefillUrl && url === prefillUrl) {
+            return true;
+        }
+
         // Determine which platform regex matches this URL
         let matchedPlatform: string | null = null;
         for (const { siteName, regex } of platformRegexes) {
@@ -137,6 +234,8 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
     }
 
     async function onSubmit(values: z.infer<typeof formSchema>) {
+        if (platformRegexStatus === "loading") return;
+
         setAddArtistResp(null);
         setIsLoading(true);
         let formattedUrl = values.artistDataUrl.trim();
@@ -192,14 +291,14 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
         }
         if (!isOpen) {
             setAddArtistResp(null);
+            reset({ artistDataUrl: "" });
         }
         setIsModalOpen(isOpen);
-        form.reset();
     }
 
     function checkInput() {
         if (addArtistResp?.status === "success") {
-            form.reset();
+            reset({ artistDataUrl: "" });
             setAddArtistResp(null);
         }
     }
@@ -208,10 +307,7 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
         // Session still resolving — don't flash a spurious login prompt at an authed user
         if (status === "loading") return;
         if (!session) {
-            // prompt login via nav button — same approach as ClaimButton
-            const loginBtn = document.getElementById("login-btn");
-            if (loginBtn) loginBtn.click();
-            else if (process.env.NODE_ENV !== "production") console.warn("[AddArtistData] #login-btn not found — cannot prompt login");
+            promptLogin();
             return;
         }
         setIsModalOpen(true);
@@ -225,8 +321,10 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
                     ? "text-white bg-pastypink flex items-center justify-center px-4 min-w-[60px]"
                     : "text-white bg-pastypink rounded-lg hover:bg-pastypink/90 w-8 h-8 p-0 flex items-center justify-center"}
                 onClick={handleClick}
+                aria-label={label ?? `Add a link for ${artist.name ?? "this artist"}`}
+                title={label ?? `Add a link for ${artist.name ?? "this artist"}`}
             >
-                {label ? <span className="whitespace-nowrap">{label}</span> : <Plus color="white" size={24} />}
+                {label ? <span className="whitespace-nowrap">{label}</span> : <Plus color="white" size={24} aria-hidden="true" />}
             </Button>
             <Dialog open={isModalOpen} onOpenChange={handleClose}>
                 <DialogContent className="sm:max-w-[425px] max-h-screen overflow-auto scrollbar-hide">
@@ -241,13 +339,13 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
                                 ? `Add a link for ${artist.name}`
                                 : `Suggest a link for ${artist.name}`}
                         </DialogTitle>
-                        {!directEdit && (
-                            <DialogDescription className="text-xs text-muted-foreground">
-                                {autoApprove
+                        <DialogDescription className="text-xs text-muted-foreground">
+                            {directEdit
+                                ? "This link will be saved directly to the artist profile."
+                                : autoApprove
                                     ? "This link will be added immediately and recorded as your contribution."
                                     : "An admin will review it before it’s added."}
-                            </DialogDescription>
-                        )}
+                        </DialogDescription>
                     </DialogHeader>
                     <Form {...form}>
                         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-3">
@@ -289,8 +387,16 @@ export default function AddArtistData({ artist, spotifyImg, availableLinks, isOp
                                         {addArtistResp.message}
                                     </Label>
                                 ) : null}
-                                <Button type="submit" className="bg-pastypink hover:bg-pastypink/90 text-white">
-                                    {isLoading ? (
+                                <Button
+                                    type="submit"
+                                    disabled={isLoading || platformRegexStatus === "loading"}
+                                    aria-busy={isLoading || platformRegexStatus === "loading"}
+                                    aria-label={directEdit ? "Save Link" : autoApprove ? "Add Link" : "Submit"}
+                                    className="bg-pastypink hover:bg-pastypink/90 text-white"
+                                >
+                                    {platformRegexStatus === "loading" ? (
+                                        <span>Loading supported links…</span>
+                                    ) : isLoading ? (
                                         <img className="max-h-6" src="/spinner.svg" alt="submitting" />
                                     ) : (
                                         <span>{directEdit ? "Save Link" : autoApprove ? "Add Link" : "Submit"}</span>

--- a/src/app/artist/[id]/page.tsx
+++ b/src/app/artist/[id]/page.tsx
@@ -20,9 +20,18 @@ import { getVaultSourcesByArtistId } from "@/server/utils/queries/dashboardQueri
 import AutoRefresh from "@/app/_components/AutoRefresh";
 import type { Metadata } from "next";
 import SeoArtistLinks from "./_components/SeoArtistLinks";
+import { buildCanonicalArtistUrl, parseSupportedArtistUrl } from "@/lib/artistProfileUrl";
 
 type ArtistProfileProps = {
     params: Promise<{ id: string }>;
+    searchParams?: Promise<{ addLink?: string | string[] }>;
+}
+
+function getAddLinkPrefill(addLink: string | string[] | undefined): string | undefined {
+    if (typeof addLink !== "string") return undefined;
+
+    const parsed = parseSupportedArtistUrl(addLink);
+    return parsed ? buildCanonicalArtistUrl(parsed.platform, parsed.id) ?? undefined : undefined;
 }
 
 export async function generateMetadata({ params }: ArtistProfileProps): Promise<Metadata> {
@@ -68,8 +77,10 @@ export async function generateMetadata({ params }: ArtistProfileProps): Promise<
     };
 }
 
-export default async function ArtistProfile({ params }: ArtistProfileProps) {
+export default async function ArtistProfile({ params, searchParams }: ArtistProfileProps) {
     const { id } = await params;
+    const resolvedSearchParams = searchParams ? await searchParams : undefined;
+    const addLinkPrefill = getAddLinkPrefill(resolvedSearchParams?.addLink);
     const session = await getServerAuthSession() ?? await getDevSession();
     const dbUser = session ? await getUserById(session.user.id) : null;
     const isAdmin = !!dbUser?.isAdmin;
@@ -165,7 +176,8 @@ export default async function ArtistProfile({ params }: ArtistProfileProps) {
                             artist={artist}
                             spotifyImg={platformImage ?? ""}
                             availableLinks={urlMapList}
-                            isOpenOnLoad={false}
+                            isOpenOnLoad={!!addLinkPrefill}
+                            prefillUrl={addLinkPrefill}
                             directEdit={directEditLinks}
                             autoApprove={autoApproveLinkSubmissions}
                         />

--- a/src/lib/__tests__/artistProfileUrl.test.ts
+++ b/src/lib/__tests__/artistProfileUrl.test.ts
@@ -1,0 +1,70 @@
+import {
+    buildCanonicalArtistUrl,
+    MAX_ARTIST_PROFILE_URL_LENGTH,
+    parseSupportedArtistUrl,
+    type SupportedArtistPlatform,
+} from "../artistProfileUrl";
+
+describe("parseSupportedArtistUrl", () => {
+    it.each([
+        [
+            "https://open.spotify.com/artist/2TNJWBi73MnkSRkZRPBqSW?si=tracking#popular",
+            { id: "2TNJWBi73MnkSRkZRPBqSW", platform: "spotify" },
+        ],
+        [
+            "  http://deezer.com/en-us/artist/12345/?utm_source=test#tracks  ",
+            { id: "12345", platform: "deezer" },
+        ],
+        [
+            "https://www.deezer.com/FR/artist/98765",
+            { id: "98765", platform: "deezer" },
+        ],
+    ])("parses a supported artist URL: %s", (url, expected) => {
+        expect(parseSupportedArtistUrl(url)).toEqual(expected);
+    });
+
+    it.each([
+        "https://open.spotify.com.evil.example/artist/abc123",
+        "https://www.open.spotify.com/artist/abc123",
+        "https://deezer.com.evil.example/artist/123",
+        "https://user@open.spotify.com/artist/abc123",
+        "https://open.spotify.com:8443/artist/abc123",
+        "http://open.spotify.com/artist/abc123",
+        "https://open.spotify.com/track/abc123",
+        "https://open.spotify.com/artist/abc123/albums",
+        "https://www.deezer.com/artist/not-numeric",
+        "https://www.deezer.com/en/artist/123/tracks",
+        "https://www.deezer.com/english/artist/123",
+    ])("rejects an unsupported host, authority, protocol, or path: %s", (url) => {
+        expect(parseSupportedArtistUrl(url)).toBeNull();
+    });
+
+    it("rejects an artist URL over the shared maximum length", () => {
+        const oversized = `https://open.spotify.com/artist/${"a".repeat(MAX_ARTIST_PROFILE_URL_LENGTH)}`;
+        expect(parseSupportedArtistUrl(oversized)).toBeNull();
+    });
+});
+
+describe("buildCanonicalArtistUrl", () => {
+    it.each([
+        ["spotify", "2TNJWBi73MnkSRkZRPBqSW", "https://open.spotify.com/artist/2TNJWBi73MnkSRkZRPBqSW"],
+        ["deezer", "12345", "https://www.deezer.com/artist/12345"],
+    ] as const)("builds a canonical %s artist URL", (platform, id, expected) => {
+        expect(buildCanonicalArtistUrl(platform, id)).toBe(expected);
+    });
+
+    it.each([
+        ["spotify", "id-with-punctuation"],
+        ["deezer", "dz123"],
+        ["youtube" as SupportedArtistPlatform, "123"],
+    ])("rejects an invalid %s artist ID", (platform, id) => {
+        expect(buildCanonicalArtistUrl(platform as SupportedArtistPlatform, id)).toBeNull();
+    });
+
+    it("does not construct a URL over the shared maximum length", () => {
+        expect(buildCanonicalArtistUrl(
+            "spotify",
+            "a".repeat(MAX_ARTIST_PROFILE_URL_LENGTH),
+        )).toBeNull();
+    });
+});

--- a/src/lib/artistProfileUrl.ts
+++ b/src/lib/artistProfileUrl.ts
@@ -1,0 +1,64 @@
+export const MAX_ARTIST_PROFILE_URL_LENGTH = 2048;
+
+export type SupportedArtistPlatform = "spotify" | "deezer";
+
+export type ParsedArtistProfileUrl = {
+    id: string;
+    platform: SupportedArtistPlatform;
+};
+
+const SPOTIFY_ARTIST_PATH = /^\/artist\/([a-zA-Z0-9]+)\/?$/;
+const DEEZER_ARTIST_PATH = /^\/(?:[a-z]{2}(?:-[a-z]{2})?\/)?artist\/(\d+)\/?$/i;
+const SPOTIFY_ARTIST_ID = /^[a-zA-Z0-9]+$/;
+const DEEZER_ARTIST_ID = /^\d+$/;
+
+/**
+ * Parses the exact Spotify and Deezer artist URL shapes supported by Music Nerd.
+ * Query strings and fragments are accepted but are not part of the returned ID.
+ */
+export function parseSupportedArtistUrl(value: string): ParsedArtistProfileUrl | null {
+    const candidate = value.trim();
+    if (!candidate || candidate.length > MAX_ARTIST_PROFILE_URL_LENGTH) return null;
+
+    try {
+        const url = new URL(candidate);
+        const hostname = url.hostname.toLowerCase();
+
+        if (url.username || url.password || url.port) return null;
+
+        if (url.protocol === "https:" && hostname === "open.spotify.com") {
+            const match = url.pathname.match(SPOTIFY_ARTIST_PATH);
+            return match ? { id: match[1], platform: "spotify" } : null;
+        }
+
+        if (
+            (url.protocol === "https:" || url.protocol === "http:")
+            && (hostname === "deezer.com" || hostname === "www.deezer.com")
+        ) {
+            const match = url.pathname.match(DEEZER_ARTIST_PATH);
+            return match ? { id: match[1], platform: "deezer" } : null;
+        }
+    } catch {
+        return null;
+    }
+
+    return null;
+}
+
+/** Builds the canonical public artist URL after validating the platform ID. */
+export function buildCanonicalArtistUrl(
+    platform: SupportedArtistPlatform,
+    platformId: string,
+): string | null {
+    const isValidId = platform === "spotify"
+        ? SPOTIFY_ARTIST_ID.test(platformId)
+        : platform === "deezer" && DEEZER_ARTIST_ID.test(platformId);
+
+    if (!isValidId) return null;
+
+    const url = platform === "spotify"
+        ? `https://open.spotify.com/artist/${platformId}`
+        : `https://www.deezer.com/artist/${platformId}`;
+
+    return url.length <= MAX_ARTIST_PROFILE_URL_LENGTH ? url : null;
+}

--- a/src/server/utils/__tests__/artistIdentityLocks.test.ts
+++ b/src/server/utils/__tests__/artistIdentityLocks.test.ts
@@ -1,0 +1,66 @@
+import { PgDialect } from "drizzle-orm/pg-core";
+import {
+  acquireArtistNameLock,
+  acquireArtistPlatformWriteLocks,
+  acquirePlatformIdentityLock,
+} from "../artistIdentityLocks";
+
+const dialect = new PgDialect();
+
+describe("artist identity advisory locks", () => {
+  it("uses a transaction-scoped lock keyed by platform and ID", async () => {
+    const execute = jest.fn().mockResolvedValue([]);
+
+    await acquirePlatformIdentityLock(
+      { execute } as never,
+      "spotify",
+      "spotify-123",
+    );
+
+    const query = dialect.sqlToQuery(execute.mock.calls[0][0]);
+    expect(query.sql).toContain("pg_advisory_xact_lock");
+    expect(query.params).toEqual([
+      "musicnerd:artist-platform:spotify:spotify-123",
+    ]);
+  });
+
+  it("uses a separate namespace for normalized artist names", async () => {
+    const execute = jest.fn().mockResolvedValue([]);
+
+    await acquireArtistNameLock({ execute } as never, "jonathan pape");
+
+    const query = dialect.sqlToQuery(execute.mock.calls[0][0]);
+    expect(query.sql).toContain("pg_advisory_xact_lock");
+    expect(query.params).toEqual([
+      "musicnerd:artist-name:jonathan pape",
+    ]);
+  });
+
+  it("locks the stable artist/platform slot before each external ID", async () => {
+    const execute = jest.fn().mockResolvedValue([]);
+    const database = { execute } as never;
+
+    await acquireArtistPlatformWriteLocks(
+      database,
+      "artist-123",
+      "spotify",
+      "spotify-first",
+    );
+    await acquireArtistPlatformWriteLocks(
+      database,
+      "artist-123",
+      "spotify",
+      "spotify-second",
+    );
+
+    const params = execute.mock.calls.map(([query]) =>
+      dialect.sqlToQuery(query).params[0]
+    );
+    expect(params).toEqual([
+      "musicnerd:artist-platform-slot:artist-123:spotify",
+      "musicnerd:artist-platform:spotify:spotify-first",
+      "musicnerd:artist-platform-slot:artist-123:spotify",
+      "musicnerd:artist-platform:spotify:spotify-second",
+    ]);
+  });
+});

--- a/src/server/utils/__tests__/artistLinkService.test.ts
+++ b/src/server/utils/__tests__/artistLinkService.test.ts
@@ -113,6 +113,7 @@ describe("artistLinkService", () => {
     const { db, clearArtistLink } = await setup();
     const result = await clearArtistLink("artist-123", "instagram");
     expect(db.execute).toHaveBeenCalled();
+    expect(db.transaction).not.toHaveBeenCalled();
     expect(result).toEqual({ oldValue: null });
   });
 
@@ -258,6 +259,35 @@ describe("artistLinkService", () => {
         setArtistLink("artist-123", platform, `${platform}-123`),
       ).resolves.toEqual({ oldValue: null, artistName: "Test Artist" });
       expect(db.execute).toHaveBeenCalledTimes(3);
+    },
+  );
+
+  it.each(["spotify", "deezer"])(
+    "serializes a %s clear under the artist/platform slot lock",
+    async (platform) => {
+      const { db, clearArtistLink } = await setup();
+      (db as any).query.artists.findFirst.mockResolvedValue({
+        id: "artist-123",
+        name: "Test Artist",
+        [platform]: `${platform}-123`,
+      });
+
+      await expect(
+        clearArtistLink("artist-123", platform),
+      ).resolves.toEqual({ oldValue: `${platform}-123` });
+
+      expect(db.transaction).toHaveBeenCalledTimes(1);
+      // Stable artist/platform slot lock, followed by the artist update.
+      expect(db.execute).toHaveBeenCalledTimes(2);
+      expect(dialect.sqlToQuery(db.execute.mock.calls[0][0]).params[0]).toBe(
+        `musicnerd:artist-platform-slot:artist-123:${platform}`,
+      );
+      expect(db.execute.mock.invocationCallOrder[0]).toBeLessThan(
+        (db as any).query.artists.findFirst.mock.invocationCallOrder[0],
+      );
+      expect(
+        (db as any).query.artistIdMappings.findFirst,
+      ).not.toHaveBeenCalled();
     },
   );
 

--- a/src/server/utils/__tests__/artistLinkService.test.ts
+++ b/src/server/utils/__tests__/artistLinkService.test.ts
@@ -1,5 +1,8 @@
 // @ts-nocheck
 import { jest } from "@jest/globals";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+const dialect = new PgDialect();
 
 // Mock regenerateArtistBio before any dynamic imports
 jest.mock("@/server/utils/queries/artistBioQuery", () => ({
@@ -14,11 +17,28 @@ describe("artistLinkService", () => {
   async function setup() {
     const { db } = await import("@/server/db/drizzle");
     db.execute = jest.fn().mockResolvedValue([]);
+    db.transaction = jest.fn(async (callback) => callback(db));
     // Mock artist existence check - return a found artist by default
     (db as any).query.artists.findFirst = jest.fn().mockResolvedValue({ id: "artist-123", name: "Test Artist" });
+    (db as any).query.artistIdMappings = {
+      findFirst: jest.fn().mockResolvedValue(null),
+      findMany: jest.fn(),
+    };
     const { regenerateArtistBio } = await import("@/server/utils/queries/artistBioQuery");
-    const { setArtistLink, clearArtistLink, sanitizeColumnName } = await import("../artistLinkService");
-    return { db, setArtistLink, clearArtistLink, sanitizeColumnName, regenerateArtistBio };
+    const {
+      ArtistLinkConflictError,
+      setArtistLink,
+      clearArtistLink,
+      sanitizeColumnName,
+    } = await import("../artistLinkService");
+    return {
+      db,
+      ArtistLinkConflictError,
+      setArtistLink,
+      clearArtistLink,
+      sanitizeColumnName,
+      regenerateArtistBio,
+    };
   }
 
   // 1. sanitizeColumnName strips non-alphanumeric/underscore
@@ -151,6 +171,95 @@ describe("artistLinkService", () => {
     const result = await setArtistLink("artist-123", "instagram", "new-user");
     expect(result).toEqual({ oldValue: "old-user", artistName: "Test Artist" });
   });
+
+  it("serializes a first-class ID write inside a transaction", async () => {
+    const { db, setArtistLink } = await setup();
+
+    await setArtistLink("artist-123", "spotify", "spotify-123");
+
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    // Stable artist/platform lock + external ID lock + artist update.
+    expect(db.execute).toHaveBeenCalledTimes(3);
+    expect(
+      db.execute.mock.calls.slice(0, 2).map(([query]) =>
+        dialect.sqlToQuery(query).params[0]
+      ),
+    ).toEqual([
+      "musicnerd:artist-platform-slot:artist-123:spotify",
+      "musicnerd:artist-platform:spotify:spotify-123",
+    ]);
+    expect(db.execute.mock.invocationCallOrder[1]).toBeLessThan(
+      (db as any).query.artists.findFirst.mock.invocationCallOrder[0],
+    );
+  });
+
+  it.each(["spotify", "deezer"])(
+    "rejects a %s ID directly owned by another artist",
+    async (platform) => {
+      const { db, ArtistLinkConflictError, setArtistLink } = await setup();
+      (db as any).query.artists.findFirst
+        .mockResolvedValueOnce({ id: "artist-123", name: "Test Artist" })
+        .mockResolvedValueOnce({ id: "other-artist" });
+
+      const result = setArtistLink(
+        "artist-123",
+        platform,
+        `${platform}-123`,
+      );
+      await expect(result).rejects.toBeInstanceOf(ArtistLinkConflictError);
+      await expect(result).rejects.toThrow(
+        `That ${platform} artist ID is already linked to a different artist`,
+      );
+      expect(db.execute).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("rejects a first-class ID mapped to another artist", async () => {
+    const { db, ArtistLinkConflictError, setArtistLink } = await setup();
+    (db as any).query.artistIdMappings.findFirst
+      .mockResolvedValueOnce({ artistId: "other-artist" })
+      .mockResolvedValueOnce(null);
+
+    const result = setArtistLink("artist-123", "spotify", "spotify-123");
+    await expect(result).rejects.toBeInstanceOf(ArtistLinkConflictError);
+    await expect(result).rejects.toThrow(
+      "That spotify artist ID conflicts with an existing artist mapping",
+    );
+    expect(db.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a direct ID that diverges from the artist's existing mapping", async () => {
+    const { db, ArtistLinkConflictError, setArtistLink } = await setup();
+    (db as any).query.artistIdMappings.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ platformId: "mapped-spotify-id" });
+
+    const result = setArtistLink(
+      "artist-123",
+      "spotify",
+      "different-spotify-id",
+    );
+    await expect(result).rejects.toBeInstanceOf(ArtistLinkConflictError);
+    await expect(result).rejects.toThrow(
+      "That spotify artist ID conflicts with an existing artist mapping",
+    );
+    expect(db.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["spotify", "deezer"])(
+    "allows a %s ID directly owned by the same artist",
+    async (platform) => {
+      const { db, setArtistLink } = await setup();
+      (db as any).query.artists.findFirst
+        .mockResolvedValueOnce({ id: "artist-123", name: "Test Artist" })
+        .mockResolvedValueOnce({ id: "artist-123" });
+
+      await expect(
+        setArtistLink("artist-123", platform, `${platform}-123`),
+      ).resolves.toEqual({ oldValue: null, artistName: "Test Artist" });
+      expect(db.execute).toHaveBeenCalledTimes(3);
+    },
+  );
 
   // 19. setArtistLink reads the aliased facebookID property
   it("setArtistLink returns the old value for facebookID", async () => {

--- a/src/server/utils/__tests__/idMappingService.test.ts
+++ b/src/server/utils/__tests__/idMappingService.test.ts
@@ -1,5 +1,8 @@
 // @ts-nocheck
 import { jest } from "@jest/globals";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+const dialect = new PgDialect();
 
 describe("idMappingService", () => {
   beforeEach(() => {
@@ -9,6 +12,7 @@ describe("idMappingService", () => {
   async function setup() {
     const { db } = await import("@/server/db/drizzle");
     db.execute = jest.fn().mockResolvedValue([]);
+    db.transaction = jest.fn(async (callback) => callback(db));
     (db as any).query.artists = {
       findFirst: jest.fn().mockResolvedValue({ id: "artist-123" }),
       findMany: jest.fn(),
@@ -88,12 +92,63 @@ describe("idMappingService", () => {
     ).rejects.toThrow("Artist not found");
   });
 
+  it("runs mapping resolution under the platform identity lock in a transaction", async () => {
+    const { db, resolveArtistMapping } = await setup();
+
+    await resolveArtistMapping({
+      artistId: "artist-123", platform: "deezer", platformId: "456",
+      confidence: "high", source: "manual",
+    });
+
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    // Stable artist/platform lock + external ID lock + mapping insert.
+    expect(db.execute).toHaveBeenCalledTimes(3);
+    expect(
+      db.execute.mock.calls.slice(0, 2).map(([query]) =>
+        dialect.sqlToQuery(query).params[0]
+      ),
+    ).toEqual([
+      "musicnerd:artist-platform-slot:artist-123:deezer",
+      "musicnerd:artist-platform:deezer:456",
+    ]);
+  });
+
+  it("rejects a first-class platform ID owned by another artist", async () => {
+    const { db, resolveArtistMapping } = await setup();
+    const { MappingConflictError } = await import("../idMappingService");
+    (db as any).query.artists.findFirst
+      .mockResolvedValueOnce({ id: "artist-123", spotify: null, deezer: null })
+      .mockResolvedValueOnce({ id: "other-artist" });
+
+    await expect(resolveArtistMapping({
+      artistId: "artist-123", platform: "deezer", platformId: "456",
+      confidence: "high", source: "manual",
+    })).rejects.toThrow(MappingConflictError);
+    expect((db as any).query.artistIdMappings.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("rejects a mapping that contradicts the target artist's first-class ID", async () => {
+    const { db, resolveArtistMapping } = await setup();
+    (db as any).query.artists.findFirst
+      .mockResolvedValueOnce({ id: "artist-123", spotify: null, deezer: "existing-deezer-id" })
+      .mockResolvedValueOnce(null);
+
+    await expect(resolveArtistMapping({
+      artistId: "artist-123", platform: "deezer", platformId: "different-deezer-id",
+      confidence: "high", source: "manual",
+    })).rejects.toThrow("already contains a different platform ID");
+    expect((db as any).query.artistIdMappings.findFirst).not.toHaveBeenCalled();
+  });
+
   it("reports cross-artist conflict when platform_id_uniq constraint is violated", async () => {
     const { db, resolveArtistMapping } = await setup();
     const dbError = new Error("duplicate key value violates unique constraint");
     (dbError as any).code = "23505";
     (dbError as any).constraint = "artist_id_mappings_platform_id_uniq";
-    db.execute = jest.fn().mockRejectedValue(dbError);
+    db.execute = jest.fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(dbError);
     await expect(
       resolveArtistMapping({ artistId: "artist-123", platform: "deezer", platformId: "456", confidence: "high", source: "manual" })
     ).rejects.toThrow("already mapped to a different artist");
@@ -105,7 +160,10 @@ describe("idMappingService", () => {
     const dbError = new Error("duplicate key value violates unique constraint");
     (dbError as any).code = "23505";
     (dbError as any).constraint = "artist_id_mappings_artist_platform_uniq";
-    db.execute = jest.fn().mockRejectedValue(dbError);
+    db.execute = jest.fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(dbError);
     await expect(
       resolveArtistMapping({ artistId: "artist-123", platform: "deezer", platformId: "456", confidence: "high", source: "manual" })
     ).rejects.toThrow(MappingConcurrentWriteError);
@@ -120,7 +178,10 @@ describe("idMappingService", () => {
     const dbError = new Error("duplicate key value violates unique constraint");
     (dbError as any).code = "23505";
     (dbError as any).constraint = "artist_id_mappings_platform_id_uniq";
-    db.execute = jest.fn().mockRejectedValue(dbError);
+    db.execute = jest.fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(dbError);
     await expect(
       resolveArtistMapping({ artistId: "artist-123", platform: "deezer", platformId: "taken-id", confidence: "high", source: "manual" })
     ).rejects.toThrow(MappingConflictError);
@@ -133,7 +194,10 @@ describe("idMappingService", () => {
     (pgError as any).constraint_name = "artist_id_mappings_platform_id_uniq";
     const wrapperError = new Error("Failed query");
     (wrapperError as any).cause = pgError;
-    db.execute = jest.fn().mockRejectedValue(wrapperError);
+    db.execute = jest.fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(wrapperError);
     await expect(
       resolveArtistMapping({ artistId: "artist-123", platform: "deezer", platformId: "456", confidence: "high", source: "manual" })
     ).rejects.toThrow("already mapped to a different artist");
@@ -356,13 +420,11 @@ describe("idMappingService", () => {
 
   it("batch continues on individual failures", async () => {
     const { db, resolveArtistMappingBatch } = await setup();
-    // First item: artist exists, second item: artist not found
-    let callCount = 0;
-    (db as any).query.artists.findFirst.mockImplementation(() => {
-      callCount++;
-      if (callCount === 2) return Promise.resolve(null);
-      return Promise.resolve({ id: "artist-123" });
-    });
+    // First item: target exists and the direct ID has no owner. Second target is absent.
+    (db as any).query.artists.findFirst
+      .mockResolvedValueOnce({ id: "artist-123" })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
 
     const result = await resolveArtistMappingBatch([
       { artistId: "artist-123", platform: "deezer", platformId: "456", confidence: "high", source: "wikidata" },

--- a/src/server/utils/__tests__/removeArtistData.test.ts
+++ b/src/server/utils/__tests__/removeArtistData.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 
 // Mock dependencies
 jest.mock('@/server/utils/artistLinkService', () => ({
+  ArtistLinkConflictError: class ArtistLinkConflictError extends Error {},
   setArtistLink: jest.fn().mockResolvedValue(undefined),
   clearArtistLink: jest.fn().mockResolvedValue(undefined),
 }));

--- a/src/server/utils/artistIdentityLocks.ts
+++ b/src/server/utils/artistIdentityLocks.ts
@@ -1,0 +1,70 @@
+import { sql } from "drizzle-orm";
+import type { db } from "@/server/db/drizzle";
+
+export type ArtistIdentityLockExecutor = Pick<typeof db, "execute">;
+
+async function acquireArtistIdentityLock(
+  database: ArtistIdentityLockExecutor,
+  key: string,
+): Promise<void> {
+  await database.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtextextended(${key}, 0))`,
+  );
+}
+
+/**
+ * Serializes ownership decisions for a single external platform identity.
+ * The executor must belong to the transaction that performs the protected
+ * ownership read/write; PostgreSQL releases the lock when that transaction ends.
+ */
+export async function acquirePlatformIdentityLock(
+  database: ArtistIdentityLockExecutor,
+  platform: string,
+  platformId: string,
+): Promise<void> {
+  await acquireArtistIdentityLock(
+    database,
+    `musicnerd:artist-platform:${platform}:${platformId}`,
+  );
+}
+
+/**
+ * Serializes every ID write for one artist/platform slot, even when competing
+ * writers propose different external IDs. This lock must be acquired before
+ * the external platform-ID lock to keep lock ordering consistent.
+ */
+export async function acquireArtistPlatformLock(
+  database: ArtistIdentityLockExecutor,
+  artistId: string,
+  platform: string,
+): Promise<void> {
+  await acquireArtistIdentityLock(
+    database,
+    `musicnerd:artist-platform-slot:${artistId}:${platform}`,
+  );
+}
+
+/**
+ * Acquires both locks needed to change an artist's platform identity. Keeping
+ * the ordering here prevents direct-link and mapping writers from drifting.
+ */
+export async function acquireArtistPlatformWriteLocks(
+  database: ArtistIdentityLockExecutor,
+  artistId: string,
+  platform: string,
+  platformId: string,
+): Promise<void> {
+  await acquireArtistPlatformLock(database, artistId, platform);
+  await acquirePlatformIdentityLock(database, platform, platformId);
+}
+
+/** Serializes the same-name candidate check and artist insert. */
+export async function acquireArtistNameLock(
+  database: ArtistIdentityLockExecutor,
+  normalisedName: string,
+): Promise<void> {
+  await acquireArtistIdentityLock(
+    database,
+    `musicnerd:artist-name:${normalisedName}`,
+  );
+}

--- a/src/server/utils/artistLinkService.ts
+++ b/src/server/utils/artistLinkService.ts
@@ -5,7 +5,10 @@
 import { db } from "@/server/db/drizzle";
 import { and, eq, sql } from "drizzle-orm";
 import { artists, artistIdMappings } from "@/server/db/schema";
-import { acquireArtistPlatformWriteLocks } from "./artistIdentityLocks";
+import {
+  acquireArtistPlatformLock,
+  acquireArtistPlatformWriteLocks,
+} from "./artistIdentityLocks";
 
 export class ArtistLinkConflictError extends Error {
   constructor(message: string) {
@@ -152,8 +155,23 @@ export async function clearArtistLink(
   const columnName = sanitizeColumnName(siteName);
   assertWritable(columnName);
 
+  if (columnName === "spotify" || columnName === "deezer") {
+    return db.transaction(async (transaction) => {
+      await acquireArtistPlatformLock(transaction, artistId, columnName);
+      return clearArtistLinkWithExecutor(transaction, artistId, columnName);
+    });
+  }
+
+  return clearArtistLinkWithExecutor(db, artistId, columnName);
+}
+
+async function clearArtistLinkWithExecutor(
+  database: ArtistLinkExecutor,
+  artistId: string,
+  columnName: string,
+): Promise<{ oldValue: string | null }> {
   // Fetch full row to capture oldValue for audit trail (MCP callers use the return value)
-  const artist = await db.query.artists.findFirst({
+  const artist = await database.query.artists.findFirst({
     where: eq(artists.id, artistId),
   });
   if (!artist) {
@@ -164,7 +182,7 @@ export async function clearArtistLink(
   const oldValue = getArtistLinkValue(artist, columnName);
 
   // See setArtistLink: link changes no longer null/regenerate the bio.
-  await db.execute(sql`UPDATE artists SET ${sql.identifier(columnName)} = NULL WHERE id = ${artistId}`);
+  await database.execute(sql`UPDATE artists SET ${sql.identifier(columnName)} = NULL WHERE id = ${artistId}`);
 
   return { oldValue };
 }

--- a/src/server/utils/artistLinkService.ts
+++ b/src/server/utils/artistLinkService.ts
@@ -3,8 +3,16 @@
  * Used by MCP tools and artistQueries.ts (approveUGC, removeArtistData).
  */
 import { db } from "@/server/db/drizzle";
-import { eq, sql } from "drizzle-orm";
-import { artists } from "@/server/db/schema";
+import { and, eq, sql } from "drizzle-orm";
+import { artists, artistIdMappings } from "@/server/db/schema";
+import { acquireArtistPlatformWriteLocks } from "./artistIdentityLocks";
+
+export class ArtistLinkConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ArtistLinkConflictError";
+  }
+}
 
 // Whitelist of platform columns that can be written via link helpers.
 // Derived from the artists table schema — only platform/social columns.
@@ -47,6 +55,69 @@ function getArtistLinkValue(artist: object, columnName: string): string | null {
   return ((artist as Record<string, unknown>)[propertyName] as string | null | undefined) ?? null;
 }
 
+type ArtistLinkExecutor = Pick<typeof db, "query" | "execute">;
+
+async function setArtistLinkWithExecutor(
+  database: ArtistLinkExecutor,
+  artistId: string,
+  columnName: string,
+  value: string,
+): Promise<{ oldValue: string | null; artistName: string | null }> {
+  // Fetch full row to capture oldValue for audit trail (MCP callers use the return value)
+  const artist = await database.query.artists.findFirst({
+    where: eq(artists.id, artistId),
+  });
+  if (!artist) {
+    throw new Error(`Artist not found: ${artistId}`);
+  }
+
+  const oldValue = getArtistLinkValue(artist, columnName);
+  if (columnName === "spotify" || columnName === "deezer") {
+    const directColumn = columnName === "spotify" ? artists.spotify : artists.deezer;
+    const [directOwner, mappingOwner, artistMapping] = await Promise.all([
+      database.query.artists.findFirst({
+        where: eq(directColumn, value),
+        columns: { id: true },
+      }),
+      database.query.artistIdMappings.findFirst({
+        where: and(
+          eq(artistIdMappings.platform, columnName),
+          eq(artistIdMappings.platformId, value),
+        ),
+        columns: { artistId: true },
+      }),
+      database.query.artistIdMappings.findFirst({
+        where: and(
+          eq(artistIdMappings.artistId, artistId),
+          eq(artistIdMappings.platform, columnName),
+        ),
+        columns: { platformId: true },
+      }),
+    ]);
+    if (directOwner && directOwner.id !== artistId) {
+      throw new ArtistLinkConflictError(
+        `That ${columnName} artist ID is already linked to a different artist`,
+      );
+    }
+    if (
+      (mappingOwner && mappingOwner.artistId !== artistId) ||
+      (artistMapping && artistMapping.platformId !== value)
+    ) {
+      throw new ArtistLinkConflictError(
+        `That ${columnName} artist ID conflicts with an existing artist mapping`,
+      );
+    }
+  }
+
+  // Update the link column only. We intentionally do NOT null or regenerate the
+  // bio on link changes — that overwrote artist edits and re-ran generation on
+  // every UGC/agent submission. The About refreshes on explicit regenerate, or
+  // lazily when it's absent (see the artistBio route).
+  await database.execute(sql`UPDATE artists SET ${sql.identifier(columnName)} = ${value} WHERE id = ${artistId}`);
+
+  return { oldValue, artistName: artist.name ?? null };
+}
+
 export async function setArtistLink(
   artistId: string,
   siteName: string,
@@ -55,28 +126,23 @@ export async function setArtistLink(
   const columnName = sanitizeColumnName(siteName);
   assertWritable(columnName);
 
-  // Fetch full row to capture oldValue for audit trail (MCP callers use the return value)
-  const artist = await db.query.artists.findFirst({
-    where: eq(artists.id, artistId),
-  });
-  if (!artist) {
-    throw new Error(`Artist not found: ${artistId}`);
-  }
-
   if (!value) {
     throw new Error("Value must not be empty");
   }
 
-  // Safe: assertWritable() above guarantees columnName is a known text column from the whitelist
-  const oldValue = getArtistLinkValue(artist, columnName);
+  if (columnName === "spotify" || columnName === "deezer") {
+    return db.transaction(async (transaction) => {
+      await acquireArtistPlatformWriteLocks(
+        transaction,
+        artistId,
+        columnName,
+        value,
+      );
+      return setArtistLinkWithExecutor(transaction, artistId, columnName, value);
+    });
+  }
 
-  // Update the link column only. We intentionally do NOT null or regenerate the
-  // bio on link changes — that overwrote artist edits and re-ran generation on
-  // every UGC/agent submission. The About refreshes on explicit regenerate, or
-  // lazily when it's absent (see the artistBio route).
-  await db.execute(sql`UPDATE artists SET ${sql.identifier(columnName)} = ${value} WHERE id = ${artistId}`);
-
-  return { oldValue, artistName: artist.name ?? null };
+  return setArtistLinkWithExecutor(db, artistId, columnName, value);
 }
 
 export async function clearArtistLink(

--- a/src/server/utils/idMappingService.ts
+++ b/src/server/utils/idMappingService.ts
@@ -5,6 +5,7 @@
 import { db } from "@/server/db/drizzle";
 import { eq, and, sql, asc } from "drizzle-orm";
 import { artists, artistIdMappings, artistMappingExclusions } from "@/server/db/schema";
+import { acquireArtistPlatformWriteLocks } from "./artistIdentityLocks";
 
 export class MappingNotFoundError extends Error {
   constructor(message: string) { super(message); this.name = "MappingNotFoundError"; }
@@ -145,68 +146,98 @@ export async function resolveArtistMapping(params: {
     throw new MappingValidationError("platformId cannot be empty");
   }
 
-  // Verify artist exists
-  const artist = await db.query.artists.findFirst({
-    where: eq(artists.id, artistId),
-    columns: { id: true },
-  });
-  if (!artist) {
-    throw new MappingNotFoundError(`Artist not found: ${artistId}`);
-  }
+  return db.transaction(async (transaction) => {
+    await acquireArtistPlatformWriteLocks(
+      transaction,
+      artistId,
+      platform,
+      platformId,
+    );
 
-  // Check for existing mapping on this artist+platform
-  const existing = await db.query.artistIdMappings.findFirst({
-    where: and(eq(artistIdMappings.artistId, artistId), eq(artistIdMappings.platform, platform)),
-  });
+    // Verify artist exists. First-class IDs are selected so a mapping cannot
+    // silently disagree with the canonical Spotify/Deezer column.
+    const artist = await transaction.query.artists.findFirst({
+      where: eq(artists.id, artistId),
+      columns: { id: true, spotify: true, deezer: true },
+    });
+    if (!artist) {
+      throw new MappingNotFoundError(`Artist not found: ${artistId}`);
+    }
 
-  if (existing) {
-    const existingPriority = CONFIDENCE_PRIORITY[existing.confidence] ?? 0;
-    const newPriority = CONFIDENCE_PRIORITY[confidence] ?? 0;
+    if (platform === "spotify" || platform === "deezer") {
+      const directColumn = platform === "spotify" ? artists.spotify : artists.deezer;
+      const directOwner = await transaction.query.artists.findFirst({
+        where: eq(directColumn, platformId),
+        columns: { id: true },
+      });
+      if (directOwner && directOwner.id !== artistId) {
+        throw new MappingConflictError(
+          `platformId ${platformId} on ${platform} is already owned by a different artist`,
+        );
+      }
 
-    // Equal confidence overwrites intentionally — latest submission wins at the same tier
-    if (newPriority < existingPriority) {
+      const firstClassValue = platform === "spotify" ? artist.spotify : artist.deezer;
+      if (firstClassValue?.trim() && firstClassValue !== platformId) {
+        throw new MappingConflictError(
+          `The artist's ${platform} field already contains a different platform ID`,
+        );
+      }
+    }
+
+    // Check for existing mapping on this artist+platform
+    const existing = await transaction.query.artistIdMappings.findFirst({
+      where: and(eq(artistIdMappings.artistId, artistId), eq(artistIdMappings.platform, platform)),
+    });
+
+    if (existing) {
+      const existingPriority = CONFIDENCE_PRIORITY[existing.confidence] ?? 0;
+      const newPriority = CONFIDENCE_PRIORITY[confidence] ?? 0;
+
+      // Equal confidence overwrites intentionally — latest submission wins at the same tier
+      if (newPriority < existingPriority) {
+        return {
+          created: false,
+          updated: false,
+          skipped: true,
+          previousMapping: { platformId: existing.platformId, confidence: existing.confidence },
+        };
+      }
+
+      try {
+        await transaction.execute(sql`
+          UPDATE artist_id_mappings
+          SET platform_id = ${platformId},
+              confidence = ${confidence}::confidence_level,
+              source = ${source},
+              reasoning = ${reasoning ?? null},
+              api_key_hash = ${apiKeyHash ?? null},
+              resolved_at = now(),
+              updated_at = now()
+          WHERE artist_id = ${artistId} AND platform = ${platform}
+        `);
+      } catch (err: unknown) {
+        handleUniqueViolation(err, platform, platformId);
+      }
+
       return {
         created: false,
-        updated: false,
-        skipped: true,
+        updated: true,
+        skipped: false,
         previousMapping: { platformId: existing.platformId, confidence: existing.confidence },
       };
     }
 
     try {
-      await db.execute(sql`
-        UPDATE artist_id_mappings
-        SET platform_id = ${platformId},
-            confidence = ${confidence}::confidence_level,
-            source = ${source},
-            reasoning = ${reasoning ?? null},
-            api_key_hash = ${apiKeyHash ?? null},
-            resolved_at = now(),
-            updated_at = now()
-        WHERE artist_id = ${artistId} AND platform = ${platform}
+      await transaction.execute(sql`
+        INSERT INTO artist_id_mappings (artist_id, platform, platform_id, confidence, source, reasoning, api_key_hash)
+        VALUES (${artistId}, ${platform}, ${platformId}, ${confidence}::confidence_level, ${source}, ${reasoning ?? null}, ${apiKeyHash ?? null})
       `);
     } catch (err: unknown) {
       handleUniqueViolation(err, platform, platformId);
     }
 
-    return {
-      created: false,
-      updated: true,
-      skipped: false,
-      previousMapping: { platformId: existing.platformId, confidence: existing.confidence },
-    };
-  }
-
-  try {
-    await db.execute(sql`
-      INSERT INTO artist_id_mappings (artist_id, platform, platform_id, confidence, source, reasoning, api_key_hash)
-      VALUES (${artistId}, ${platform}, ${platformId}, ${confidence}::confidence_level, ${source}, ${reasoning ?? null}, ${apiKeyHash ?? null})
-    `);
-  } catch (err: unknown) {
-    handleUniqueViolation(err, platform, platformId);
-  }
-
-  return { created: true, updated: false, skipped: false };
+    return { created: true, updated: false, skipped: false };
+  });
 }
 
 export async function getMappingStats(): Promise<{

--- a/src/server/utils/musicPlatform/__tests__/crossPlatformArtistResolver.test.ts
+++ b/src/server/utils/musicPlatform/__tests__/crossPlatformArtistResolver.test.ts
@@ -1,0 +1,206 @@
+// @ts-nocheck
+import { jest } from '@jest/globals';
+
+const mockDeezerGetArtist = jest.fn();
+const mockSpotifyGetArtist = jest.fn();
+
+jest.mock('../deezerProvider', () => ({
+    deezerProvider: { getArtist: mockDeezerGetArtist },
+}));
+
+jest.mock('../spotifyProvider', () => ({
+    spotifyProvider: { getArtist: mockSpotifyGetArtist },
+}));
+
+function wikidataResponse(rows: Array<{ entity: string; targetId: string }>) {
+    return {
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue({
+            results: {
+                bindings: rows.map(({ entity, targetId }) => ({
+                    item: { value: `http://www.wikidata.org/entity/${entity}` },
+                    targetId: { value: targetId },
+                })),
+            },
+        }),
+    };
+}
+
+describe('findReciprocalArtistIdentity', () => {
+    let findReciprocalArtistIdentity: typeof import('../crossPlatformArtistResolver').findReciprocalArtistIdentity;
+    let mockFetch: jest.Mock;
+
+    beforeEach(async () => {
+        jest.resetModules();
+        jest.clearAllMocks();
+        mockFetch = global.fetch as jest.Mock;
+        mockFetch.mockResolvedValue(wikidataResponse([]));
+        mockDeezerGetArtist.mockResolvedValue(null);
+        mockSpotifyGetArtist.mockResolvedValue(null);
+        ({ findReciprocalArtistIdentity } = await import('../crossPlatformArtistResolver'));
+    });
+
+    it('resolves a Deezer artist to Spotify through one Wikidata entity and verifies its name', async () => {
+        mockFetch.mockResolvedValue(wikidataResponse([{
+            entity: 'Q36153',
+            targetId: '6vWDO969PvNqNYHIOW5v0m',
+        }]));
+        mockSpotifyGetArtist.mockResolvedValue({
+            platform: 'spotify',
+            platformId: '6vWDO969PvNqNYHIOW5v0m',
+            name: 'Beyoncé',
+        });
+
+        await expect(findReciprocalArtistIdentity({
+            platform: 'deezer',
+            platformId: '145',
+            name: 'Beyonce',
+        })).resolves.toEqual({
+            platform: 'spotify',
+            platformId: '6vWDO969PvNqNYHIOW5v0m',
+            source: 'wikidata',
+            wikidataId: 'Q36153',
+        });
+        expect(mockSpotifyGetArtist).toHaveBeenCalledWith('6vWDO969PvNqNYHIOW5v0m');
+        expect(mockDeezerGetArtist).not.toHaveBeenCalled();
+        expect(mockFetch).toHaveBeenCalledWith(
+            'https://query.wikidata.org/sparql',
+            expect.objectContaining({
+                method: 'POST',
+                body: expect.stringContaining('query='),
+            }),
+        );
+        const requestBody = mockFetch.mock.calls[0][1].body as string;
+        expect(decodeURIComponent(requestBody)).toContain('wdt:P2722 "145"');
+        expect(decodeURIComponent(requestBody)).toContain('wdt:P1902 ?targetId');
+    });
+
+    it('resolves a Spotify artist to Deezer and verifies the target profile', async () => {
+        mockFetch.mockResolvedValue(wikidataResponse([{
+            entity: 'Q36153',
+            targetId: '145',
+        }]));
+        mockDeezerGetArtist.mockResolvedValue({
+            platform: 'deezer',
+            platformId: '145',
+            name: 'Beyoncé',
+        });
+
+        await expect(findReciprocalArtistIdentity({
+            platform: 'spotify',
+            platformId: '6vWDO969PvNqNYHIOW5v0m',
+            name: 'Beyonce',
+        })).resolves.toEqual({
+            platform: 'deezer',
+            platformId: '145',
+            source: 'wikidata',
+            wikidataId: 'Q36153',
+        });
+        expect(mockDeezerGetArtist).toHaveBeenCalledWith('145');
+        const requestBody = mockFetch.mock.calls[0][1].body as string;
+        expect(decodeURIComponent(requestBody)).toContain('wdt:P1902 "6vWDO969PvNqNYHIOW5v0m"');
+        expect(decodeURIComponent(requestBody)).toContain('wdt:P2722 ?targetId');
+    });
+
+    it('rejects malformed source IDs before querying Wikidata', async () => {
+        await expect(findReciprocalArtistIdentity({
+            platform: 'spotify',
+            platformId: 'bad-id-with-punctuation',
+            name: 'Artist',
+        })).resolves.toBeNull();
+        expect(mockFetch).not.toHaveBeenCalled();
+        expect(mockDeezerGetArtist).not.toHaveBeenCalled();
+    });
+
+    it('returns null when a source ID is attached to multiple Wikidata entities', async () => {
+        mockFetch.mockResolvedValue(wikidataResponse([
+            { entity: 'Q1', targetId: '123' },
+            { entity: 'Q2', targetId: '123' },
+        ]));
+
+        await expect(findReciprocalArtistIdentity({
+            platform: 'spotify',
+            platformId: 'spotify123',
+            name: 'Artist',
+        })).resolves.toBeNull();
+        expect(mockDeezerGetArtist).not.toHaveBeenCalled();
+    });
+
+    it('returns null when Wikidata has multiple target IDs for one entity', async () => {
+        mockFetch.mockResolvedValue(wikidataResponse([
+            { entity: 'Q1', targetId: '123' },
+            { entity: 'Q1', targetId: '456' },
+        ]));
+
+        await expect(findReciprocalArtistIdentity({
+            platform: 'spotify',
+            platformId: 'spotify123',
+            name: 'Artist',
+        })).resolves.toBeNull();
+        expect(mockDeezerGetArtist).not.toHaveBeenCalled();
+    });
+
+    it('rejects a Wikidata counterpart whose target-platform name does not match', async () => {
+        mockFetch.mockResolvedValue(wikidataResponse([{
+            entity: 'Q1',
+            targetId: '123',
+        }]));
+        mockDeezerGetArtist.mockResolvedValue({
+            platform: 'deezer',
+            platformId: '123',
+            name: 'Different Artist',
+        });
+
+        await expect(findReciprocalArtistIdentity({
+            platform: 'spotify',
+            platformId: 'spotify123',
+            name: 'Artist',
+        })).resolves.toBeNull();
+    });
+
+    it('logs Wikidata failures and returns null', async () => {
+        const error = new Error('Wikidata unavailable');
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        mockFetch.mockRejectedValue(error);
+
+        try {
+            await expect(findReciprocalArtistIdentity({
+                platform: 'deezer',
+                platformId: '145',
+                name: 'Artist',
+            })).resolves.toBeNull();
+            expect(consoleError).toHaveBeenCalledWith(
+                '[CrossPlatformArtistResolver] Failed to resolve deezer:145:',
+                error,
+            );
+        } finally {
+            consoleError.mockRestore();
+        }
+    });
+
+    it('bounds target-provider verification time and falls back to no counterpart', async () => {
+        jest.useFakeTimers();
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+        mockFetch.mockResolvedValue(wikidataResponse([{
+            entity: 'Q1',
+            targetId: '123',
+        }]));
+        mockDeezerGetArtist.mockReturnValue(new Promise(() => undefined));
+
+        try {
+            const result = findReciprocalArtistIdentity({
+                platform: 'spotify',
+                platformId: 'spotify123',
+                name: 'Artist',
+            });
+            await Promise.resolve();
+            await Promise.resolve();
+            await jest.advanceTimersByTimeAsync(5000);
+            await expect(result).resolves.toBeNull();
+        } finally {
+            consoleError.mockRestore();
+            jest.useRealTimers();
+        }
+    });
+});

--- a/src/server/utils/musicPlatform/__tests__/crossPlatformArtistResolver.test.ts
+++ b/src/server/utils/musicPlatform/__tests__/crossPlatformArtistResolver.test.ts
@@ -103,6 +103,79 @@ describe('findReciprocalArtistIdentity', () => {
         expect(decodeURIComponent(requestBody)).toContain('wdt:P2722 ?targetId');
     });
 
+    it.each([
+        {
+            sourcePlatform: 'spotify' as const,
+            sourcePlatformId: 'spotify123',
+            sourceProperty: 'P1902',
+            targetProperty: 'P2722',
+        },
+        {
+            sourcePlatform: 'deezer' as const,
+            sourcePlatformId: '145',
+            sourceProperty: 'P2722',
+            targetProperty: 'P1902',
+        },
+    ])(
+        'requires unique Wikidata ownership in both directions for $sourcePlatform',
+        async ({ sourcePlatform, sourcePlatformId, sourceProperty, targetProperty }) => {
+            mockFetch.mockResolvedValue(wikidataResponse([]));
+
+            await findReciprocalArtistIdentity({
+                platform: sourcePlatform,
+                platformId: sourcePlatformId,
+                name: 'Artist',
+            });
+
+            const requestBody = mockFetch.mock.calls[0][1].body as string;
+            const query = decodeURIComponent(requestBody);
+            expect(query).toContain(
+                `?otherSource wdt:${sourceProperty} "${sourcePlatformId}"`,
+            );
+            expect(query).toContain(
+                `?otherTarget wdt:${targetProperty} ?targetId`,
+            );
+            expect(query).toContain('FILTER (?otherSource != ?item)');
+            expect(query).toContain('FILTER (?otherTarget != ?item)');
+        },
+    );
+
+    it('returns null without provider verification when uniqueness filtering leaves no match', async () => {
+        mockFetch.mockResolvedValue(wikidataResponse([]));
+
+        await expect(findReciprocalArtistIdentity({
+            platform: 'spotify',
+            platformId: 'spotify123',
+            name: 'Artist',
+        })).resolves.toBeNull();
+        expect(mockDeezerGetArtist).not.toHaveBeenCalled();
+        expect(mockSpotifyGetArtist).not.toHaveBeenCalled();
+    });
+
+    it('returns the target provider canonical ID after verification', async () => {
+        mockFetch.mockResolvedValue(wikidataResponse([{
+            entity: 'Q36153',
+            targetId: '000145',
+        }]));
+        mockDeezerGetArtist.mockResolvedValue({
+            platform: 'deezer',
+            platformId: '145',
+            name: 'Beyonce',
+        });
+
+        await expect(findReciprocalArtistIdentity({
+            platform: 'spotify',
+            platformId: 'spotify123',
+            name: 'Beyonce',
+        })).resolves.toEqual({
+            platform: 'deezer',
+            platformId: '145',
+            source: 'wikidata',
+            wikidataId: 'Q36153',
+        });
+        expect(mockDeezerGetArtist).toHaveBeenCalledWith('000145');
+    });
+
     it('rejects malformed source IDs before querying Wikidata', async () => {
         await expect(findReciprocalArtistIdentity({
             platform: 'spotify',

--- a/src/server/utils/musicPlatform/crossPlatformArtistResolver.ts
+++ b/src/server/utils/musicPlatform/crossPlatformArtistResolver.ts
@@ -76,6 +76,14 @@ async function findWikidataCounterpart(
 SELECT ?item ?targetId WHERE {
   ?item wdt:${sourceProperty} "${sourcePlatformId}" .
   ?item wdt:${targetProperty} ?targetId .
+  FILTER NOT EXISTS {
+    ?otherSource wdt:${sourceProperty} "${sourcePlatformId}" .
+    FILTER (?otherSource != ?item)
+  }
+  FILTER NOT EXISTS {
+    ?otherTarget wdt:${targetProperty} ?targetId .
+    FILTER (?otherTarget != ?item)
+  }
 }
 LIMIT 10`;
     const response = await fetch(WIKIDATA_ENDPOINT, {
@@ -144,8 +152,11 @@ export async function findReciprocalArtistIdentity(
             PROVIDER_VERIFICATION_TIMEOUT_MS,
             `${targetPlatform} artist verification`,
         );
+        const verifiedPlatformId = verifiedArtist?.platformId?.trim();
         if (
             !verifiedArtist
+            || !verifiedPlatformId
+            || !isValidPlatformId(targetPlatform, verifiedPlatformId)
             || normalizeArtistName(verifiedArtist.name) !== normalizedName
         ) {
             return null;
@@ -153,7 +164,7 @@ export async function findReciprocalArtistIdentity(
 
         return {
             platform: targetPlatform,
-            platformId: counterpart.platformId,
+            platformId: verifiedPlatformId,
             source: 'wikidata',
             wikidataId: counterpart.wikidataId,
         };

--- a/src/server/utils/musicPlatform/crossPlatformArtistResolver.ts
+++ b/src/server/utils/musicPlatform/crossPlatformArtistResolver.ts
@@ -1,0 +1,167 @@
+import { deezerProvider } from './deezerProvider';
+import { spotifyProvider } from './spotifyProvider';
+import type { MusicPlatform, MusicPlatformArtist } from './types';
+
+export type ReciprocalArtistIdentity = {
+    platform: MusicPlatform;
+    platformId: string;
+    source: 'wikidata';
+    wikidataId: string;
+};
+
+const WIKIDATA_ENDPOINT = 'https://query.wikidata.org/sparql';
+const WIKIDATA_TIMEOUT_MS = 4000;
+const PROVIDER_VERIFICATION_TIMEOUT_MS = 5000;
+const USER_AGENT = 'MusicNerdWeb/1.0 (https://musicnerd.xyz; contact@musicnerd.xyz)';
+
+const WIKIDATA_PLATFORM_PROPERTY: Record<MusicPlatform, string> = {
+    spotify: 'P1902',
+    deezer: 'P2722',
+};
+
+type WikidataBinding = {
+    item?: { value?: string };
+    targetId?: { value?: string };
+};
+
+function normalizeArtistName(name: string): string {
+    return name
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .replace(/^the\s+/, '')
+        .replace(/\s+(?:feat|ft|featuring)\s+.*/, '')
+        .trim();
+}
+
+function isValidPlatformId(platform: MusicPlatform, platformId: string): boolean {
+    return platform === 'deezer'
+        ? /^\d+$/.test(platformId)
+        : /^[A-Za-z0-9]+$/.test(platformId);
+}
+
+async function withTimeout<T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+    label: string,
+): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+            () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+            timeoutMs,
+        );
+    });
+
+    try {
+        return await Promise.race([promise, timeout]);
+    } finally {
+        if (timeoutId) clearTimeout(timeoutId);
+    }
+}
+
+async function findWikidataCounterpart(
+    sourcePlatform: MusicPlatform,
+    sourcePlatformId: string,
+    targetPlatform: MusicPlatform,
+): Promise<{ platformId: string; wikidataId: string } | null> {
+    if (!isValidPlatformId(sourcePlatform, sourcePlatformId)) return null;
+
+    const sourceProperty = WIKIDATA_PLATFORM_PROPERTY[sourcePlatform];
+    const targetProperty = WIKIDATA_PLATFORM_PROPERTY[targetPlatform];
+    const sparql = `
+SELECT ?item ?targetId WHERE {
+  ?item wdt:${sourceProperty} "${sourcePlatformId}" .
+  ?item wdt:${targetProperty} ?targetId .
+}
+LIMIT 10`;
+    const response = await fetch(WIKIDATA_ENDPOINT, {
+        method: 'POST',
+        headers: {
+            Accept: 'application/sparql-results+json',
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'User-Agent': USER_AGENT,
+        },
+        body: `query=${encodeURIComponent(sparql)}`,
+        signal: AbortSignal.timeout(WIKIDATA_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+        throw new Error(`Wikidata SPARQL returned ${response.status}`);
+    }
+
+    const data = await response.json() as {
+        results?: { bindings?: WikidataBinding[] };
+    };
+    const entityIds = new Set<string>();
+    const targetIds = new Set<string>();
+
+    for (const binding of data.results?.bindings ?? []) {
+        const entityId = binding.item?.value?.split('/').pop()?.trim();
+        const targetId = binding.targetId?.value?.trim();
+        if (
+            !entityId
+            || !/^Q\d+$/.test(entityId)
+            || !targetId
+            || !isValidPlatformId(targetPlatform, targetId)
+        ) {
+            continue;
+        }
+        entityIds.add(entityId);
+        targetIds.add(targetId);
+    }
+
+    if (entityIds.size !== 1 || targetIds.size !== 1) return null;
+
+    return {
+        platformId: targetIds.values().next().value!,
+        wikidataId: entityIds.values().next().value!,
+    };
+}
+
+export async function findReciprocalArtistIdentity(
+    artist: Pick<MusicPlatformArtist, 'platform' | 'platformId' | 'name'>,
+): Promise<ReciprocalArtistIdentity | null> {
+    const normalizedName = normalizeArtistName(artist.name);
+    if (!normalizedName) return null;
+
+    const targetPlatform: MusicPlatform = artist.platform === 'deezer' ? 'spotify' : 'deezer';
+    const targetProvider = targetPlatform === 'spotify' ? spotifyProvider : deezerProvider;
+
+    try {
+        const counterpart = await findWikidataCounterpart(
+            artist.platform,
+            artist.platformId,
+            targetPlatform,
+        );
+        if (!counterpart) return null;
+
+        const verifiedArtist = await withTimeout(
+            targetProvider.getArtist(counterpart.platformId),
+            PROVIDER_VERIFICATION_TIMEOUT_MS,
+            `${targetPlatform} artist verification`,
+        );
+        if (
+            !verifiedArtist
+            || normalizeArtistName(verifiedArtist.name) !== normalizedName
+        ) {
+            return null;
+        }
+
+        return {
+            platform: targetPlatform,
+            platformId: counterpart.platformId,
+            source: 'wikidata',
+            wikidataId: counterpart.wikidataId,
+        };
+    } catch (error) {
+        console.error(
+            `[CrossPlatformArtistResolver] Failed to resolve ${artist.platform}:${artist.platformId}:`,
+            error,
+        );
+        return null;
+    }
+}

--- a/src/server/utils/musicPlatform/index.ts
+++ b/src/server/utils/musicPlatform/index.ts
@@ -2,6 +2,8 @@ export type { MusicPlatform, MusicPlatformArtist, MusicPlatformProvider } from '
 export { SpotifyProvider, spotifyProvider } from './spotifyProvider';
 export { DeezerProvider, deezerProvider } from './deezerProvider';
 export { ArtistMusicPlatformDataProvider } from './artistMusicPlatformDataProvider';
+export { findReciprocalArtistIdentity } from './crossPlatformArtistResolver';
+export type { ReciprocalArtistIdentity } from './crossPlatformArtistResolver';
 
 import { deezerProvider } from './deezerProvider';
 import { spotifyProvider } from './spotifyProvider';

--- a/src/server/utils/queries/__tests__/addArtistIdentity.test.ts
+++ b/src/server/utils/queries/__tests__/addArtistIdentity.test.ts
@@ -1,0 +1,262 @@
+// @ts-nocheck
+import { jest } from "@jest/globals";
+
+const mockSpotifyGetArtist = jest.fn();
+const mockDeezerGetArtist = jest.fn();
+
+jest.mock("@/server/auth", () => ({ getServerAuthSession: jest.fn() }));
+jest.mock("@/server/utils/musicPlatform", () => ({
+    spotifyProvider: { getArtist: mockSpotifyGetArtist },
+    deezerProvider: { getArtist: mockDeezerGetArtist },
+}));
+jest.mock("@/server/utils/queries/userQueries", () => ({
+    getUserById: jest.fn(),
+    getUserDisplayName: jest.fn(),
+}));
+jest.mock("@/server/utils/queries/discord", () => ({ sendDiscordMessage: jest.fn() }));
+jest.mock("@/server/utils/artistLinkService", () => ({
+    ArtistLinkConflictError: class ArtistLinkConflictError extends Error {},
+    setArtistLink: jest.fn(),
+    clearArtistLink: jest.fn(),
+}));
+jest.mock("@/server/utils/queries/artistBioQuery", () => ({ regenerateArtistBio: jest.fn() }));
+jest.mock("@/server/utils/ugcDiscordNotifier", () => ({ maybePingDiscordForPendingUGC: jest.fn() }));
+jest.mock("@/server/utils/artistLinkDiscordNotifier", () => ({ notifyDiscordOfArtistLinkAdded: jest.fn() }));
+jest.mock("next/headers", () => ({
+    headers: jest.fn().mockResolvedValue({ get: jest.fn().mockReturnValue(null) }),
+}));
+
+function artist(overrides: Record<string, unknown> = {}) {
+    return {
+        id: "artist-1",
+        name: "Jonathan Pape",
+        spotify: null,
+        deezer: null,
+        ...overrides,
+    };
+}
+
+function mockInsertReturning(mockDb: any, rows: unknown[]) {
+    const returning = jest.fn().mockResolvedValue(rows);
+    const onConflictDoNothing = jest.fn().mockReturnValue({ returning });
+    const values = jest.fn().mockReturnValue({ onConflictDoNothing });
+    mockDb.insert.mockReturnValue({ values });
+    return { values, onConflictDoNothing, returning };
+}
+
+describe("addArtist identity resolution", () => {
+    beforeEach(() => {
+        jest.resetModules();
+        jest.clearAllMocks();
+    });
+
+    async function setup() {
+        const { db } = await import("@/server/db/drizzle");
+        const { getServerAuthSession } = await import("@/server/auth");
+        const { getUserById, getUserDisplayName } = await import("@/server/utils/queries/userQueries");
+        const { sendDiscordMessage } = await import("@/server/utils/queries/discord");
+        const { addArtist } = await import("../artistQueries");
+        const mockDb = db as any;
+        const mockGetServerAuthSession = getServerAuthSession as jest.Mock;
+        const mockGetUserById = getUserById as jest.Mock;
+        const mockGetUserDisplayName = getUserDisplayName as jest.Mock;
+        const mockSendDiscordMessage = sendDiscordMessage as jest.Mock;
+
+        mockDb.query.artists.findFirst.mockReset();
+        mockDb.query.artists.findMany.mockReset();
+        mockDb.query.artistIdMappings.findFirst.mockReset();
+        mockDb.insert.mockReset();
+        mockDb.execute = jest.fn().mockResolvedValue([]);
+        mockDb.transaction = jest.fn(async (callback) => callback(mockDb));
+
+        mockGetServerAuthSession.mockResolvedValue({ user: { id: "user-1" } });
+        mockGetUserById.mockResolvedValue(null);
+        mockGetUserDisplayName.mockReturnValue("tester");
+        mockSendDiscordMessage.mockResolvedValue(undefined);
+        mockSpotifyGetArtist.mockResolvedValue({ name: "Jonathan Pape" });
+        mockDeezerGetArtist.mockResolvedValue({ name: "Jonathan Pape" });
+        mockDb.query.artists.findFirst.mockResolvedValue(null);
+        mockDb.query.artists.findMany.mockResolvedValue([]);
+        mockDb.query.artistIdMappings.findFirst.mockResolvedValue(null);
+
+        return {
+            addArtist,
+            mockDb,
+            mockGetServerAuthSession,
+            mockGetUserById,
+            mockSendDiscordMessage,
+        };
+    }
+
+    it("returns a typed unauthenticated response before provider or database work", async () => {
+        const { addArtist, mockDb, mockGetServerAuthSession } = await setup();
+        mockGetServerAuthSession.mockResolvedValue(null);
+
+        await expect(addArtist("spotify-123", "spotify")).resolves.toEqual({
+            status: "error",
+            code: "UNAUTHENTICATED",
+            message: "Please log in to add artists",
+        });
+        expect(mockSpotifyGetArtist).not.toHaveBeenCalled();
+        expect(mockDb.transaction).not.toHaveBeenCalled();
+    });
+
+    it("offers a Deezer-only exact-name record before creating a Spotify duplicate", async () => {
+        const { addArtist, mockDb } = await setup();
+        const deezerOnly = artist({ id: "deezer-owner", deezer: "815939" });
+        mockDb.query.artists.findMany.mockResolvedValue([deezerOnly]);
+
+        const result = await addArtist("spotify-123", "spotify");
+
+        expect(result).toEqual({
+            status: "possible_duplicate",
+            candidates: [deezerOnly],
+            platform: "spotify",
+            platformId: "spotify-123",
+            message: expect.stringContaining("same name"),
+        });
+        expect(mockDb.query.artists.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                limit: 10,
+                orderBy: expect.arrayContaining([expect.anything(), expect.anything()]),
+            }),
+        );
+        expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("returns a conflict when a mapping owner has a different first-class platform ID", async () => {
+        const { addArtist, mockDb } = await setup();
+        const contradictoryOwner = artist({
+            id: "mapped-owner",
+            spotify: "different-spotify-id",
+            deezer: "815939",
+        });
+        mockDb.query.artistIdMappings.findFirst.mockResolvedValue({ artistId: "mapped-owner" });
+        mockDb.query.artists.findFirst
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(contradictoryOwner);
+
+        const result = await addArtist("spotify-123", "spotify");
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "conflict",
+            candidates: [contradictoryOwner],
+            platform: "spotify",
+            platformId: "spotify-123",
+        }));
+        expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("returns the canonical artist when the platform ID is owned by a mapping", async () => {
+        const { addArtist, mockDb } = await setup();
+        const mappedOwner = artist({ id: "mapped-owner", deezer: "815939" });
+        mockDb.query.artistIdMappings.findFirst.mockResolvedValue({ artistId: "mapped-owner" });
+        mockDb.query.artists.findFirst
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(mappedOwner);
+
+        const result = await addArtist("spotify-123", "spotify");
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "exists",
+            artistId: "mapped-owner",
+            artistName: "Jonathan Pape",
+        }));
+        expect(mockDb.query.artists.findMany).not.toHaveBeenCalled();
+        expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("returns a conflict without writing when direct and mapped owners disagree", async () => {
+        const { addArtist, mockDb } = await setup();
+        const directOwner = artist({ id: "direct-owner", spotify: "spotify-123" });
+        const mappedOwner = artist({ id: "mapped-owner", deezer: "815939" });
+        mockDb.query.artistIdMappings.findFirst.mockResolvedValue({ artistId: "mapped-owner" });
+        mockDb.query.artists.findFirst
+            .mockResolvedValueOnce(directOwner)
+            .mockResolvedValueOnce(mappedOwner);
+
+        const result = await addArtist("spotify-123", "spotify");
+
+        expect(result).toEqual({
+            status: "conflict",
+            candidates: [directOwner, mappedOwner],
+            platform: "spotify",
+            platformId: "spotify-123",
+            message: expect.stringContaining("conflicting"),
+        });
+        expect(mockDb.query.artists.findMany).not.toHaveBeenCalled();
+        expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("creates a separate homonymous artist only when forceCreate is set", async () => {
+        const { addArtist, mockDb } = await setup();
+        const inserted = artist({ id: "new-artist", spotify: "spotify-123" });
+        const insert = mockInsertReturning(mockDb, [inserted]);
+
+        const result = await addArtist("spotify-123", "spotify", { forceCreate: true });
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "success",
+            artistId: "new-artist",
+        }));
+        expect(mockDb.query.artists.findMany).not.toHaveBeenCalled();
+        expect(insert.values).toHaveBeenCalledWith(expect.objectContaining({
+            spotify: "spotify-123",
+            lcname: "jonathan pape",
+            name: "Jonathan Pape",
+        }));
+        expect(insert.onConflictDoNothing).toHaveBeenCalledWith();
+    });
+
+    it("returns the race winner when a conflict-safe insert creates no row", async () => {
+        const { addArtist, mockDb } = await setup();
+        const raceWinner = artist({ id: "race-winner", spotify: "spotify-123" });
+        mockInsertReturning(mockDb, []);
+        mockDb.query.artists.findFirst
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(raceWinner);
+        mockDb.query.artistIdMappings.findFirst
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(null);
+
+        const result = await addArtist("spotify-123", "spotify", { forceCreate: true });
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "exists",
+            artistId: "race-winner",
+            artistName: "Jonathan Pape",
+        }));
+    });
+
+    it("keeps a committed insert successful when notification lookup fails", async () => {
+        const { addArtist, mockDb, mockGetUserById } = await setup();
+        const inserted = artist({ id: "new-artist", spotify: "spotify-123" });
+        mockInsertReturning(mockDb, [inserted]);
+        mockGetUserById.mockRejectedValue(new Error("notification lookup failed"));
+
+        const result = await addArtist("spotify-123", "spotify", { forceCreate: true });
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "success",
+            artistId: "new-artist",
+        }));
+    });
+
+    it("preserves the created-at timestamp in the artist-added notification", async () => {
+        const { addArtist, mockDb, mockGetUserById, mockSendDiscordMessage } = await setup();
+        const createdAt = "2026-08-19T20:00:00.000Z";
+        const inserted = artist({
+            id: "new-artist",
+            spotify: "spotify-123",
+            createdAt,
+        });
+        mockInsertReturning(mockDb, [inserted]);
+        mockGetUserById.mockResolvedValue({ id: "user-1" });
+
+        await addArtist("spotify-123", "spotify", { forceCreate: true });
+
+        expect(mockSendDiscordMessage).toHaveBeenCalledWith(
+            `tester added new artist named: Jonathan Pape (Submitted spotifyId: spotify-123) ${createdAt}`,
+        );
+    });
+});

--- a/src/server/utils/queries/__tests__/addArtistIdentity.test.ts
+++ b/src/server/utils/queries/__tests__/addArtistIdentity.test.ts
@@ -94,8 +94,16 @@ describe("addArtist identity resolution", () => {
         mockGetUserById.mockResolvedValue(null);
         mockGetUserDisplayName.mockReturnValue("tester");
         mockSendDiscordMessage.mockResolvedValue(undefined);
-        mockSpotifyGetArtist.mockResolvedValue({ name: "Jonathan Pape" });
-        mockDeezerGetArtist.mockResolvedValue({ name: "Jonathan Pape" });
+        mockSpotifyGetArtist.mockResolvedValue({
+            platform: "spotify",
+            platformId: "spotify-123",
+            name: "Jonathan Pape",
+        });
+        mockDeezerGetArtist.mockResolvedValue({
+            platform: "deezer",
+            platformId: "815939",
+            name: "Jonathan Pape",
+        });
         mockFindReciprocalArtistIdentity.mockResolvedValue(null);
         mockAcquirePlatformIdentityLock.mockResolvedValue(undefined);
         mockAcquireArtistNameLock.mockResolvedValue(undefined);
@@ -304,6 +312,59 @@ describe("addArtist identity resolution", () => {
             deezer: expect.anything(),
         }));
         expect(mockAcquirePlatformIdentityLock).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses the provider's canonical Deezer ID for resolution, locking, and insertion", async () => {
+        const { addArtist, mockDb } = await setup();
+        mockDeezerGetArtist.mockResolvedValue({
+            platform: "deezer",
+            platformId: "6251",
+            name: "Jonathan Pape",
+        });
+        const insert = mockInsertReturning(mockDb, [
+            artist({ id: "new-artist", deezer: "6251" }),
+        ]);
+
+        const result = await addArtist("0006251", "deezer", { forceCreate: true });
+
+        expect(result.status).toBe("success");
+        expect(mockFindReciprocalArtistIdentity).toHaveBeenCalledWith({
+            platform: "deezer",
+            platformId: "6251",
+            name: "Jonathan Pape",
+        });
+        expect(mockAcquirePlatformIdentityLock).toHaveBeenCalledWith(
+            mockDb,
+            "deezer",
+            "6251",
+        );
+        expect(insert.values).toHaveBeenCalledWith(expect.objectContaining({
+            deezer: "6251",
+        }));
+    });
+
+    it("finds a canonical Deezer owner when the submitted URL uses a zero-padded alias", async () => {
+        const { addArtist, mockDb } = await setup();
+        const existing = artist({ id: "deezer-owner", deezer: "6251" });
+        mockDeezerGetArtist.mockResolvedValue({
+            platform: "deezer",
+            platformId: "6251",
+            name: "Jonathan Pape",
+        });
+        mockDb.query.artists.findFirst.mockResolvedValueOnce(existing);
+
+        const result = await addArtist("0006251", "deezer");
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "exists",
+            artistId: "deezer-owner",
+        }));
+        expect(mockAcquirePlatformIdentityLock).toHaveBeenCalledWith(
+            mockDb,
+            "deezer",
+            "6251",
+        );
+        expect(mockDb.insert).not.toHaveBeenCalled();
     });
 
     it("offers the owner of a discovered reciprocal ID instead of creating a duplicate", async () => {

--- a/src/server/utils/queries/__tests__/addArtistIdentity.test.ts
+++ b/src/server/utils/queries/__tests__/addArtistIdentity.test.ts
@@ -3,11 +3,23 @@ import { jest } from "@jest/globals";
 
 const mockSpotifyGetArtist = jest.fn();
 const mockDeezerGetArtist = jest.fn();
+const mockFindReciprocalArtistIdentity = jest.fn();
+const mockAcquirePlatformIdentityLock = jest.fn();
+const mockAcquireArtistNameLock = jest.fn();
 
 jest.mock("@/server/auth", () => ({ getServerAuthSession: jest.fn() }));
 jest.mock("@/server/utils/musicPlatform", () => ({
-    spotifyProvider: { getArtist: mockSpotifyGetArtist },
-    deezerProvider: { getArtist: mockDeezerGetArtist },
+    spotifyProvider: {
+        getArtist: mockSpotifyGetArtist,
+    },
+    deezerProvider: {
+        getArtist: mockDeezerGetArtist,
+    },
+    findReciprocalArtistIdentity: mockFindReciprocalArtistIdentity,
+}));
+jest.mock("@/server/utils/artistIdentityLocks", () => ({
+    acquirePlatformIdentityLock: mockAcquirePlatformIdentityLock,
+    acquireArtistNameLock: mockAcquireArtistNameLock,
 }));
 jest.mock("@/server/utils/queries/userQueries", () => ({
     getUserById: jest.fn(),
@@ -33,6 +45,15 @@ function artist(overrides: Record<string, unknown> = {}) {
         spotify: null,
         deezer: null,
         ...overrides,
+    };
+}
+
+function reciprocalIdentity(platform: "spotify" | "deezer", platformId: string) {
+    return {
+        platform,
+        platformId,
+        source: "wikidata",
+        wikidataId: "Q123",
     };
 }
 
@@ -75,6 +96,9 @@ describe("addArtist identity resolution", () => {
         mockSendDiscordMessage.mockResolvedValue(undefined);
         mockSpotifyGetArtist.mockResolvedValue({ name: "Jonathan Pape" });
         mockDeezerGetArtist.mockResolvedValue({ name: "Jonathan Pape" });
+        mockFindReciprocalArtistIdentity.mockResolvedValue(null);
+        mockAcquirePlatformIdentityLock.mockResolvedValue(undefined);
+        mockAcquireArtistNameLock.mockResolvedValue(undefined);
         mockDb.query.artists.findFirst.mockResolvedValue(null);
         mockDb.query.artists.findMany.mockResolvedValue([]);
         mockDb.query.artistIdMappings.findFirst.mockResolvedValue(null);
@@ -208,6 +232,195 @@ describe("addArtist identity resolution", () => {
         expect(insert.onConflictDoNothing).toHaveBeenCalledWith();
     });
 
+    it.each([
+        {
+            submittedPlatform: "spotify",
+            submittedId: "spotify-123",
+            reciprocalPlatform: "deezer",
+            reciprocalId: "815939",
+        },
+        {
+            submittedPlatform: "deezer",
+            submittedId: "815939",
+            reciprocalPlatform: "spotify",
+            reciprocalId: "spotify-123",
+        },
+    ])(
+        "adds the $reciprocalPlatform ID when creating an artist from $submittedPlatform",
+        async ({ submittedPlatform, submittedId, reciprocalPlatform, reciprocalId }) => {
+            const { addArtist, mockDb } = await setup();
+            mockFindReciprocalArtistIdentity.mockResolvedValue(
+                reciprocalIdentity(reciprocalPlatform, reciprocalId),
+            );
+            const inserted = artist({
+                id: "new-artist",
+                spotify: "spotify-123",
+                deezer: "815939",
+            });
+            const insert = mockInsertReturning(mockDb, [inserted]);
+
+            const result = await addArtist(
+                submittedId,
+                submittedPlatform,
+                { forceCreate: true },
+            );
+
+            expect(result).toEqual(expect.objectContaining({
+                status: "success",
+                artistId: "new-artist",
+            }));
+            expect(mockFindReciprocalArtistIdentity).toHaveBeenCalledWith({
+                platform: submittedPlatform,
+                platformId: submittedId,
+                name: "Jonathan Pape",
+            });
+            expect(insert.values).toHaveBeenCalledWith(expect.objectContaining({
+                spotify: "spotify-123",
+                deezer: "815939",
+            }));
+            expect(mockDb.execute).toHaveBeenCalledTimes(1);
+            expect(mockAcquirePlatformIdentityLock.mock.calls.map(([, lockedPlatform, lockedId]) => (
+                [lockedPlatform, lockedId]
+            ))).toEqual([
+                ["deezer", "815939"],
+                ["spotify", "spotify-123"],
+            ]);
+        },
+    );
+
+    it("creates with only the submitted ID when no reciprocal identity is resolved", async () => {
+        const { addArtist, mockDb } = await setup();
+        const insert = mockInsertReturning(mockDb, [
+            artist({ id: "new-artist", spotify: "spotify-123" }),
+        ]);
+
+        const result = await addArtist("spotify-123", "spotify", { forceCreate: true });
+
+        expect(result.status).toBe("success");
+        expect(insert.values).toHaveBeenCalledWith(expect.objectContaining({
+            spotify: "spotify-123",
+        }));
+        expect(insert.values).not.toHaveBeenCalledWith(expect.objectContaining({
+            deezer: expect.anything(),
+        }));
+        expect(mockAcquirePlatformIdentityLock).toHaveBeenCalledTimes(1);
+    });
+
+    it("offers the owner of a discovered reciprocal ID instead of creating a duplicate", async () => {
+        const { addArtist, mockDb } = await setup();
+        const reciprocalOwner = artist({
+            id: "deezer-owner",
+            spotify: null,
+            deezer: "815939",
+        });
+        mockFindReciprocalArtistIdentity.mockResolvedValue(
+            reciprocalIdentity("deezer", "815939"),
+        );
+        mockDb.query.artists.findFirst
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(reciprocalOwner);
+
+        const result = await addArtist("spotify-123", "spotify");
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "possible_duplicate",
+            candidates: [reciprocalOwner],
+            platform: "spotify",
+            platformId: "spotify-123",
+            canCreateSeparate: false,
+        }));
+        expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("recognizes a reciprocal ID owner recorded only in the mapping table", async () => {
+        const { addArtist, mockDb } = await setup();
+        const reciprocalOwner = artist({
+            id: "mapped-owner",
+            spotify: null,
+            deezer: null,
+        });
+        mockFindReciprocalArtistIdentity.mockResolvedValue(
+            reciprocalIdentity("deezer", "815939"),
+        );
+        mockDb.query.artists.findFirst
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(reciprocalOwner);
+        mockDb.query.artistIdMappings.findFirst
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({ artistId: "mapped-owner" });
+
+        const result = await addArtist("spotify-123", "spotify");
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "possible_duplicate",
+            candidates: [reciprocalOwner],
+        }));
+        expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("returns a conflict when submitted and reciprocal IDs have different owners", async () => {
+        const { addArtist, mockDb } = await setup();
+        const spotifyOwner = artist({ id: "spotify-owner", spotify: "spotify-123" });
+        const deezerOwner = artist({ id: "deezer-owner", deezer: "815939" });
+        mockFindReciprocalArtistIdentity.mockResolvedValue(
+            reciprocalIdentity("deezer", "815939"),
+        );
+        mockDb.query.artists.findFirst
+            .mockResolvedValueOnce(spotifyOwner)
+            .mockResolvedValueOnce(deezerOwner);
+
+        const result = await addArtist("spotify-123", "spotify");
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "conflict",
+            candidates: [spotifyOwner, deezerOwner],
+        }));
+        expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("returns the existing artist when both platform IDs have the same owner", async () => {
+        const { addArtist, mockDb } = await setup();
+        const existing = artist({
+            id: "existing-owner",
+            spotify: "spotify-123",
+            deezer: "815939",
+        });
+        mockFindReciprocalArtistIdentity.mockResolvedValue(
+            reciprocalIdentity("deezer", "815939"),
+        );
+        mockDb.query.artists.findFirst
+            .mockResolvedValueOnce(existing)
+            .mockResolvedValueOnce(existing);
+
+        const result = await addArtist("spotify-123", "spotify");
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "exists",
+            artistId: "existing-owner",
+        }));
+        expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("does not let forceCreate bypass reciprocal platform ownership", async () => {
+        const { addArtist, mockDb } = await setup();
+        const reciprocalOwner = artist({ id: "deezer-owner", deezer: "815939" });
+        mockFindReciprocalArtistIdentity.mockResolvedValue(
+            reciprocalIdentity("deezer", "815939"),
+        );
+        mockDb.query.artists.findFirst
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(reciprocalOwner);
+
+        const result = await addArtist("spotify-123", "spotify", { forceCreate: true });
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "conflict",
+            candidates: [reciprocalOwner],
+        }));
+        expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
     it("returns the race winner when a conflict-safe insert creates no row", async () => {
         const { addArtist, mockDb } = await setup();
         const raceWinner = artist({ id: "race-winner", spotify: "spotify-123" });
@@ -225,6 +438,35 @@ describe("addArtist identity resolution", () => {
             status: "exists",
             artistId: "race-winner",
             artistName: "Jonathan Pape",
+        }));
+    });
+
+    it("re-resolves the reciprocal ID when a dual-ID insert loses a race", async () => {
+        const { addArtist, mockDb } = await setup();
+        const reciprocalRaceWinner = artist({
+            id: "reciprocal-race-winner",
+            deezer: "815939",
+        });
+        mockFindReciprocalArtistIdentity.mockResolvedValue(
+            reciprocalIdentity("deezer", "815939"),
+        );
+        mockInsertReturning(mockDb, []);
+        mockDb.query.artists.findFirst
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(reciprocalRaceWinner);
+        mockDb.query.artistIdMappings.findFirst
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(null);
+
+        const result = await addArtist("spotify-123", "spotify");
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "possible_duplicate",
+            candidates: [reciprocalRaceWinner],
         }));
     });
 

--- a/src/server/utils/queries/__tests__/artistQueries.test.ts
+++ b/src/server/utils/queries/__tests__/artistQueries.test.ts
@@ -7,10 +7,20 @@ jest.mock("@/server/utils/queries/userQueries", () => ({
   getUserById: jest.fn(),
   getUserDisplayName: jest.fn(),
 }));
-jest.mock("@/server/utils/artistLinkService", () => ({
-  setArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
-  clearArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
-}));
+jest.mock("@/server/utils/artistLinkService", () => {
+  class ArtistLinkConflictError extends Error {
+    constructor(message) {
+      super(message);
+      this.name = "ArtistLinkConflictError";
+    }
+  }
+
+  return {
+    ArtistLinkConflictError,
+    setArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
+    clearArtistLink: jest.fn().mockResolvedValue({ oldValue: null }),
+  };
+});
 jest.mock("@/server/utils/queries/discord", () => ({
   sendDiscordMessage: jest.fn(),
 }));
@@ -55,10 +65,11 @@ describe("artistQueries", () => {
     const { getUserById } = await import(
       "@/server/utils/queries/userQueries"
     );
-    const { setArtistLink, clearArtistLink } = await import(
+    const { extractArtistId } = await import("@/server/utils/services");
+    const { ArtistLinkConflictError, setArtistLink, clearArtistLink } = await import(
       "@/server/utils/artistLinkService"
     );
-    const { approveUGC, removeArtistData } = await import(
+    const { addArtistData, approveUgcAdmin, approveUGC, removeArtistData } = await import(
       "../artistQueries"
     );
 
@@ -72,8 +83,12 @@ describe("artistQueries", () => {
       db,
       getServerAuthSession: getServerAuthSession as jest.Mock,
       getUserById: getUserById as jest.Mock,
+      extractArtistId: extractArtistId as jest.Mock,
+      ArtistLinkConflictError,
       setArtistLink: setArtistLink as jest.Mock,
       clearArtistLink: clearArtistLink as jest.Mock,
+      addArtistData,
+      approveUgcAdmin,
       approveUGC,
       removeArtistData,
       mockSet,
@@ -227,6 +242,24 @@ describe("artistQueries", () => {
       ).rejects.toThrow("Error approving UGC");
     });
 
+    it("preserves typed artist-link conflicts and does not accept the UGC", async () => {
+      const {
+        approveUGC,
+        ArtistLinkConflictError,
+        setArtistLink,
+        db,
+      } = await setup();
+      const conflict = new ArtistLinkConflictError(
+        "That spotify artist ID is already linked to a different artist",
+      );
+      setArtistLink.mockRejectedValue(conflict);
+
+      await expect(
+        approveUGC("ugc-1", "artist-1", "spotify", "spotify-123")
+      ).rejects.toBe(conflict);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
     it("throws when db.update for UGC accepted flag fails", async () => {
       const { approveUGC, db } = await setup();
       const mockWhereFail = jest
@@ -240,6 +273,96 @@ describe("artistQueries", () => {
       await expect(
         approveUGC("ugc-1", "artist-1", "instagram", "testuser")
       ).rejects.toThrow("Error approving UGC");
+    });
+  });
+
+  describe("approveUgcAdmin", () => {
+    it("waits for every item and reports per-ID partial failures", async () => {
+      const {
+        approveUgcAdmin,
+        ArtistLinkConflictError,
+        getServerAuthSession,
+        getUserById,
+        setArtistLink,
+        db,
+      } = await setup();
+      getServerAuthSession.mockResolvedValue({ user: { id: "admin-1" } });
+      getUserById.mockResolvedValue({ id: "admin-1", isAdmin: true });
+      db.query.ugcresearch.findMany.mockResolvedValue([
+        {
+          id: "ugc-conflict",
+          artistId: "artist-1",
+          siteName: "spotify",
+          siteUsername: "spotify-taken",
+        },
+        {
+          id: "ugc-success",
+          artistId: "artist-2",
+          siteName: "instagram",
+          siteUsername: "available",
+        },
+      ]);
+      setArtistLink
+        .mockRejectedValueOnce(new ArtistLinkConflictError(
+          "That spotify artist ID is already linked to a different artist",
+        ))
+        .mockResolvedValueOnce({ oldValue: null });
+
+      const result = await approveUgcAdmin(["ugc-conflict", "ugc-success"]);
+
+      expect(setArtistLink).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({
+        status: "error",
+        message:
+          "Approved 1 of 2 UGC items. Failed: ugc-conflict (That spotify artist ID is already linked to a different artist)",
+      });
+    });
+  });
+
+  describe("addArtistData", () => {
+    it("returns the typed conflict message for an immediately approved link", async () => {
+      const {
+        addArtistData,
+        ArtistLinkConflictError,
+        getServerAuthSession,
+        getUserById,
+        extractArtistId,
+        setArtistLink,
+        db,
+      } = await setup();
+      getServerAuthSession.mockResolvedValue({ user: { id: "editor-1" } });
+      getUserById.mockResolvedValue({
+        id: "editor-1",
+        isAdmin: false,
+        isWhiteListed: true,
+      });
+      extractArtistId.mockResolvedValue({
+        siteName: "spotify",
+        id: "spotify-taken",
+        cardPlatformName: "Spotify",
+      });
+      db.query.ugcresearch.findFirst.mockResolvedValue(null);
+      const returning = jest.fn().mockResolvedValue([{
+        id: "ugc-conflict",
+        createdAt: "2026-08-20T00:00:00.000Z",
+      }]);
+      db.insert = jest.fn().mockReturnValue({
+        values: jest.fn().mockReturnValue({ returning }),
+      });
+      setArtistLink.mockRejectedValue(new ArtistLinkConflictError(
+        "That spotify artist ID is already linked to a different artist",
+      ));
+
+      const result = await addArtistData(
+        "https://open.spotify.com/artist/spotify-taken",
+        { id: "artist-1", name: "Test Artist", spotify: null },
+      );
+
+      expect(result).toEqual({
+        status: "error",
+        message: "That spotify artist ID is already linked to a different artist",
+      });
+      expect(db.update).not.toHaveBeenCalled();
     });
   });
 

--- a/src/server/utils/queries/artistQueries.ts
+++ b/src/server/utils/queries/artistQueries.ts
@@ -1,6 +1,10 @@
 import { db } from "@/server/db/drizzle";
 import { getSpotifyHeaders, getSpotifyArtist } from "@/server/utils/queries/externalApiQueries";
-import { deezerProvider, spotifyProvider } from "@/server/utils/musicPlatform";
+import {
+    deezerProvider,
+    findReciprocalArtistIdentity,
+    spotifyProvider,
+} from "@/server/utils/musicPlatform";
 import type { MusicPlatform } from "@/server/utils/musicPlatform";
 import { eq, sql, inArray, and, arrayContains, asc } from "drizzle-orm";
 import { artists, artistIdMappings, ugcresearch } from "@/server/db/schema";
@@ -79,6 +83,7 @@ export type AddArtistResp =
         candidates: AddArtistCandidate[];
         platform: MusicPlatform;
         platformId: string;
+        canCreateSeparate?: boolean;
     })
     | (AddArtistRespCommon & {
         status: "conflict";
@@ -361,6 +366,11 @@ type ArtistCreationExecutor = Pick<typeof db, "query" | "execute" | "insert">;
 
 const ADD_ARTIST_CANDIDATE_LIMIT = 10;
 
+type ArtistPlatformIdentity = {
+    platform: MusicPlatform;
+    platformId: string;
+};
+
 function toAddArtistCandidate(artist: Pick<Artist, "id" | "name" | "spotify" | "deezer">): AddArtistCandidate {
     return {
         id: artist.id,
@@ -427,6 +437,104 @@ async function resolvePlatformIdOwner(
     return { status: "owner", owner: mappedCandidate };
 }
 
+function sortArtistPlatformIdentities(
+    identities: ArtistPlatformIdentity[],
+): ArtistPlatformIdentity[] {
+    return [...identities].sort((left, right) => {
+        const platformOrder = left.platform.localeCompare(right.platform);
+        return platformOrder !== 0
+            ? platformOrder
+            : left.platformId.localeCompare(right.platformId);
+    });
+}
+
+function dedupeAddArtistCandidates(
+    candidates: AddArtistCandidate[],
+): AddArtistCandidate[] {
+    return [...new Map(candidates.map((candidate) => [candidate.id, candidate])).values()];
+}
+
+function getIdentityOwnershipResponse(params: {
+    submittedIdentity: ArtistPlatformIdentity;
+    submittedOwnership: PlatformIdOwnerResolution;
+    reciprocalIdentity: ArtistPlatformIdentity | null;
+    reciprocalOwnership: PlatformIdOwnerResolution;
+    forceCreate: boolean;
+}): AddArtistResp | null {
+    const {
+        submittedIdentity,
+        submittedOwnership,
+        reciprocalIdentity,
+        reciprocalOwnership,
+        forceCreate,
+    } = params;
+    const ownershipConflicts = [submittedOwnership, reciprocalOwnership]
+        .filter((ownership): ownership is Extract<PlatformIdOwnerResolution, { status: "conflict" }> => (
+            ownership.status === "conflict"
+        ));
+
+    if (ownershipConflicts.length > 0) {
+        return {
+            status: "conflict",
+            candidates: dedupeAddArtistCandidates(
+                ownershipConflicts.flatMap((ownership) => ownership.candidates),
+            ),
+            platform: submittedIdentity.platform,
+            platformId: submittedIdentity.platformId,
+            message: "Those platform profiles are assigned to conflicting artist records",
+        };
+    }
+
+    const submittedOwner = submittedOwnership.status === "owner"
+        ? submittedOwnership.owner
+        : null;
+    const reciprocalOwner = reciprocalOwnership.status === "owner"
+        ? reciprocalOwnership.owner
+        : null;
+
+    if (submittedOwner && reciprocalOwner && submittedOwner.id !== reciprocalOwner.id) {
+        return {
+            status: "conflict",
+            candidates: dedupeAddArtistCandidates([submittedOwner, reciprocalOwner]),
+            platform: submittedIdentity.platform,
+            platformId: submittedIdentity.platformId,
+            message: "The matching Spotify and Deezer profiles belong to different artist records",
+        };
+    }
+
+    if (submittedOwner) {
+        return {
+            status: "exists",
+            artistId: submittedOwner.id,
+            artistName: submittedOwner.name ?? "",
+            message: "That artist is already in our database",
+        };
+    }
+
+    if (reciprocalOwner && reciprocalIdentity) {
+        if (forceCreate) {
+            return {
+                status: "conflict",
+                candidates: [reciprocalOwner],
+                platform: submittedIdentity.platform,
+                platformId: submittedIdentity.platformId,
+                message: `The matching ${reciprocalIdentity.platform} profile already belongs to another artist`,
+            };
+        }
+
+        return {
+            status: "possible_duplicate",
+            candidates: [reciprocalOwner],
+            platform: submittedIdentity.platform,
+            platformId: submittedIdentity.platformId,
+            canCreateSeparate: false,
+            message: `Wikidata links this profile to an existing artist's ${reciprocalIdentity.platform} profile. Add the submitted link to that artist.`,
+        };
+    }
+
+    return null;
+}
+
 export async function addArtist(
     platformId: string,
     platform: MusicPlatform = 'spotify',
@@ -463,35 +571,60 @@ export async function addArtist(
             return { status: "error", message: `Could not find artist on ${platform}` };
         }
 
+        const reciprocalIdentity = await findReciprocalArtistIdentity({
+            platform,
+            platformId,
+            name: platformArtist.name,
+        });
+        const submittedIdentity = { platform, platformId } satisfies ArtistPlatformIdentity;
+        const identities = sortArtistPlatformIdentities([
+            submittedIdentity,
+            ...(reciprocalIdentity ? [reciprocalIdentity] : []),
+        ]);
         const normalisedName = normaliseText(platformArtist.name);
         let notificationCreatedAt: string | null | undefined;
         const result = await db.transaction(async (transaction): Promise<AddArtistResp> => {
             const database = transaction as ArtistCreationExecutor;
-            await acquirePlatformIdentityLock(database, platform, platformId);
+            for (const identity of identities) {
+                await acquirePlatformIdentityLock(
+                    database,
+                    identity.platform,
+                    identity.platformId,
+                );
+            }
             if (!options?.forceCreate) {
                 await acquireArtistNameLock(database, normalisedName);
             }
 
+            const readIdentityOwnership = async () => {
+                const [submittedOwnership, reciprocalOwnership] = await Promise.all([
+                    resolvePlatformIdOwner(
+                        database,
+                        submittedIdentity.platform,
+                        submittedIdentity.platformId,
+                    ),
+                    reciprocalIdentity
+                        ? resolvePlatformIdOwner(
+                            database,
+                            reciprocalIdentity.platform,
+                            reciprocalIdentity.platformId,
+                        )
+                        : Promise.resolve<PlatformIdOwnerResolution>({ status: "none" }),
+                ]);
+
+                return { submittedOwnership, reciprocalOwnership };
+            };
+
             console.debug("[Server] Checking platform ID ownership...");
-            const ownership = await resolvePlatformIdOwner(database, platform, platformId);
-            if (ownership.status === "conflict") {
-                console.error("[Server] Conflicting platform ID owners:", ownership.candidates);
-                return {
-                    status: "conflict",
-                    candidates: ownership.candidates,
-                    platform,
-                    platformId,
-                    message: "That platform profile is assigned to conflicting artist records",
-                };
-            }
-            if (ownership.status === "owner") {
-                console.debug("[Server] Artist already exists:", ownership.owner);
-                return {
-                    status: "exists",
-                    artistId: ownership.owner.id,
-                    artistName: ownership.owner.name ?? "",
-                    message: "That artist is already in our database",
-                };
+            const initialOwnership = await readIdentityOwnership();
+            const ownershipResponse = getIdentityOwnershipResponse({
+                submittedIdentity,
+                ...initialOwnership,
+                reciprocalIdentity,
+                forceCreate: options?.forceCreate === true,
+            });
+            if (ownershipResponse) {
+                return ownershipResponse;
             }
 
             if (!options?.forceCreate) {
@@ -513,8 +646,14 @@ export async function addArtist(
             }
 
             console.debug("[Server] Inserting new artist into database...");
+            const platformIds: Partial<Record<MusicPlatform, string>> = {
+                [submittedIdentity.platform]: submittedIdentity.platformId,
+            };
+            if (reciprocalIdentity) {
+                platformIds[reciprocalIdentity.platform] = reciprocalIdentity.platformId;
+            }
             const artistData = {
-                [platform]: platformId,
+                ...platformIds,
                 lcname: normalisedName,
                 name: platformArtist.name,
                 addedBy: session.user?.id || undefined,
@@ -527,28 +666,42 @@ export async function addArtist(
                 .returning();
 
             if (!newArtist) {
-                const raceWinner = await resolvePlatformIdOwner(database, platform, platformId);
-                if (raceWinner.status === "conflict") {
-                    return {
-                        status: "conflict",
-                        candidates: raceWinner.candidates,
-                        platform,
-                        platformId,
-                        message: "That platform profile is assigned to conflicting artist records",
-                    };
-                }
-                if (raceWinner.status === "owner") {
-                    return {
-                        status: "exists",
-                        artistId: raceWinner.owner.id,
-                        artistName: raceWinner.owner.name ?? "",
-                        message: "That artist is already in our database",
-                    };
+                const raceOwnership = await readIdentityOwnership();
+                const raceResponse = getIdentityOwnershipResponse({
+                    submittedIdentity,
+                    ...raceOwnership,
+                    reciprocalIdentity,
+                    forceCreate: options?.forceCreate === true,
+                });
+                if (raceResponse) {
+                    return raceResponse;
                 }
                 return {
                     status: "error",
                     message: "The artist could not be created because another record changed at the same time. Please try again.",
                 };
+            }
+
+            const mappedDeezerId = platformIds.deezer;
+            if (reciprocalIdentity && mappedDeezerId) {
+                const reasoning = `Wikidata ${reciprocalIdentity.wikidataId} links Spotify and Deezer for ${platformArtist.name}`;
+                await database.execute(sql`
+                    INSERT INTO artist_id_mappings (
+                        artist_id,
+                        platform,
+                        platform_id,
+                        confidence,
+                        source,
+                        reasoning
+                    ) VALUES (
+                        ${newArtist.id},
+                        'deezer',
+                        ${mappedDeezerId},
+                        'high'::confidence_level,
+                        ${reciprocalIdentity.source},
+                        ${reasoning}
+                    )
+                `);
             }
             console.debug("[Server] New artist created:", newArtist);
             notificationCreatedAt = newArtist.createdAt;

--- a/src/server/utils/queries/artistQueries.ts
+++ b/src/server/utils/queries/artistQueries.ts
@@ -565,18 +565,22 @@ export async function addArtist(
         const provider = platform === 'deezer' ? deezerProvider : spotifyProvider;
         console.debug(`[Server] Validating ${platform} artist...`);
         const platformArtist = await provider.getArtist(platformId);
+        const canonicalPlatformId = platformArtist?.platformId?.trim();
 
-        if (!platformArtist?.name) {
+        if (!platformArtist?.name || !canonicalPlatformId) {
             console.error(`[Server] Invalid artist data from ${platform}`);
             return { status: "error", message: `Could not find artist on ${platform}` };
         }
 
         const reciprocalIdentity = await findReciprocalArtistIdentity({
             platform,
-            platformId,
+            platformId: canonicalPlatformId,
             name: platformArtist.name,
         });
-        const submittedIdentity = { platform, platformId } satisfies ArtistPlatformIdentity;
+        const submittedIdentity = {
+            platform,
+            platformId: canonicalPlatformId,
+        } satisfies ArtistPlatformIdentity;
         const identities = sortArtistPlatformIdentities([
             submittedIdentity,
             ...(reciprocalIdentity ? [reciprocalIdentity] : []),
@@ -638,8 +642,8 @@ export async function addArtist(
                     return {
                         status: "possible_duplicate",
                         candidates: possibleDuplicates.map(toAddArtistCandidate),
-                        platform,
-                        platformId,
+                        platform: submittedIdentity.platform,
+                        platformId: submittedIdentity.platformId,
                         message: "We found an artist with the same name. Choose the existing artist or confirm this is a different artist.",
                     };
                 }
@@ -682,6 +686,8 @@ export async function addArtist(
                 };
             }
 
+            // Mappings are Spotify-anchored, so provenance always records the
+            // Deezer side of a verified pair, even when Deezer was submitted.
             const mappedDeezerId = platformIds.deezer;
             if (reciprocalIdentity && mappedDeezerId) {
                 const reasoning = `Wikidata ${reciprocalIdentity.wikidataId} links Spotify and Deezer for ${platformArtist.name}`;
@@ -719,7 +725,7 @@ export async function addArtist(
                 const user = await getUserById(session.user.id);
                 if (user) {
                     await sendDiscordMessage(
-                        `${getUserDisplayName(user)} added new artist named: ${result.artistName ?? ""} (Submitted ${platform}Id: ${platformId}) ${notificationCreatedAt ?? ""}`
+                        `${getUserDisplayName(user)} added new artist named: ${result.artistName ?? ""} (Submitted ${platform}Id: ${canonicalPlatformId}) ${notificationCreatedAt ?? ""}`
                     );
                 }
             } catch (notificationError) {

--- a/src/server/utils/queries/artistQueries.ts
+++ b/src/server/utils/queries/artistQueries.ts
@@ -2,22 +2,29 @@ import { db } from "@/server/db/drizzle";
 import { getSpotifyHeaders, getSpotifyArtist } from "@/server/utils/queries/externalApiQueries";
 import { deezerProvider, spotifyProvider } from "@/server/utils/musicPlatform";
 import type { MusicPlatform } from "@/server/utils/musicPlatform";
-import { eq, sql, inArray, and, arrayContains } from "drizzle-orm";
-import { artists, ugcresearch } from "@/server/db/schema";
+import { eq, sql, inArray, and, arrayContains, asc } from "drizzle-orm";
+import { artists, artistIdMappings, ugcresearch } from "@/server/db/schema";
 import { Artist, UrlMap } from "@/server/db/DbTypes";
 import { isObjKey, extractArtistId } from "@/server/utils/services";
 import { getServerAuthSession } from "@/server/auth";
 import { PgColumn } from "drizzle-orm/pg-core";
-import { headers } from "next/headers";
 
 import { getUserById, getUserDisplayName } from "@/server/utils/queries/userQueries";
 import { sendDiscordMessage } from "@/server/utils/queries/discord";
 import { maybePingDiscordForPendingUGC } from "@/server/utils/ugcDiscordNotifier";
 import { notifyDiscordOfArtistLinkAdded } from "@/server/utils/artistLinkDiscordNotifier";
-import { setArtistLink, clearArtistLink } from "@/server/utils/artistLinkService";
+import {
+    ArtistLinkConflictError,
+    setArtistLink,
+    clearArtistLink,
+} from "@/server/utils/artistLinkService";
 import { regenerateArtistBio } from "@/server/utils/queries/artistBioQuery";
 import { isAboutEmptyState } from "@/lib/bioConstants";
 import { LINK_NOT_SUPPORTED_LONG } from "@/lib/linkSubmissionMessages";
+import {
+    acquireArtistNameLock,
+    acquirePlatformIdentityLock,
+} from "@/server/utils/artistIdentityLocks";
 
 // ----------------------------------
 // Types
@@ -34,12 +41,51 @@ export type ArtistLink = UrlMap & {
     artistUrl: string;
 };
 
-export type AddArtistResp = {
-    status: "success" | "error" | "exists";
+export type AddArtistCandidate = {
+    id: string;
+    name: string | null;
+    spotify: string | null;
+    deezer: string | null;
+};
+
+export type AddArtistOptions = {
+    forceCreate?: boolean;
+};
+
+type AddArtistRespCommon = {
     artistId?: string;
     message?: string;
     artistName?: string;
 };
+
+export type AddArtistErrorCode = "UNAUTHENTICATED";
+
+export type AddArtistResp =
+    | (AddArtistRespCommon & {
+        status: "success" | "exists";
+        candidates?: AddArtistCandidate[];
+        platform?: MusicPlatform;
+        platformId?: string;
+    })
+    | (AddArtistRespCommon & {
+        status: "error";
+        code?: AddArtistErrorCode;
+        candidates?: AddArtistCandidate[];
+        platform?: MusicPlatform;
+        platformId?: string;
+    })
+    | (AddArtistRespCommon & {
+        status: "possible_duplicate";
+        candidates: AddArtistCandidate[];
+        platform: MusicPlatform;
+        platformId: string;
+    })
+    | (AddArtistRespCommon & {
+        status: "conflict";
+        candidates: AddArtistCandidate[];
+        platform: MusicPlatform;
+        platformId: string;
+    });
 
 export type AddArtistDataResp = {
     status: "success" | "error";
@@ -306,18 +352,91 @@ export async function getArtistLinks(artist: Artist): Promise<ArtistLink[]> {
 // Artist creation & mutation
 // ----------------------------------
 
-export async function addArtist(platformId: string, platform: MusicPlatform = 'spotify'): Promise<AddArtistResp> {
+type PlatformIdOwnerResolution =
+    | { status: "none" }
+    | { status: "owner"; owner: AddArtistCandidate }
+    | { status: "conflict"; candidates: AddArtistCandidate[] };
+
+type ArtistCreationExecutor = Pick<typeof db, "query" | "execute" | "insert">;
+
+const ADD_ARTIST_CANDIDATE_LIMIT = 10;
+
+function toAddArtistCandidate(artist: Pick<Artist, "id" | "name" | "spotify" | "deezer">): AddArtistCandidate {
+    return {
+        id: artist.id,
+        name: artist.name,
+        spotify: artist.spotify,
+        deezer: artist.deezer,
+    };
+}
+
+async function resolvePlatformIdOwner(
+    database: Pick<ArtistCreationExecutor, "query">,
+    platform: MusicPlatform,
+    platformId: string,
+): Promise<PlatformIdOwnerResolution> {
+    const directColumn = platform === "deezer" ? artists.deezer : artists.spotify;
+    const [directOwner, mapping] = await Promise.all([
+        database.query.artists.findFirst({
+            where: eq(directColumn, platformId),
+            columns: { id: true, name: true, spotify: true, deezer: true },
+        }),
+        database.query.artistIdMappings.findFirst({
+            where: and(
+                eq(artistIdMappings.platform, platform),
+                eq(artistIdMappings.platformId, platformId),
+            ),
+            columns: { artistId: true },
+        }),
+    ]);
+
+    if (!mapping) {
+        return directOwner
+            ? { status: "owner", owner: toAddArtistCandidate(directOwner) }
+            : { status: "none" };
+    }
+
+    if (directOwner?.id === mapping.artistId) {
+        return { status: "owner", owner: toAddArtistCandidate(directOwner) };
+    }
+
+    const mappedOwner = await database.query.artists.findFirst({
+        where: eq(artists.id, mapping.artistId),
+        columns: { id: true, name: true, spotify: true, deezer: true },
+    });
+    const mappedCandidate = mappedOwner
+        ? toAddArtistCandidate(mappedOwner)
+        : { id: mapping.artistId, name: null, spotify: null, deezer: null };
+
+    const mappedOwnerPlatformId = platform === "deezer"
+        ? mappedCandidate.deezer
+        : mappedCandidate.spotify;
+    const mappedOwnerContradictsMapping = Boolean(
+        mappedOwnerPlatformId?.trim() && mappedOwnerPlatformId !== platformId,
+    );
+
+    if (directOwner || mappedOwnerContradictsMapping) {
+        return {
+            status: "conflict",
+            candidates: directOwner
+                ? [toAddArtistCandidate(directOwner), mappedCandidate]
+                : [mappedCandidate],
+        };
+    }
+
+    return { status: "owner", owner: mappedCandidate };
+}
+
+export async function addArtist(
+    platformId: string,
+    platform: MusicPlatform = 'spotify',
+    options?: AddArtistOptions,
+): Promise<AddArtistResp> {
     if (platform !== 'deezer' && platform !== 'spotify') {
         return { status: "error", message: "Invalid platform" };
     }
     try {
         console.debug(`[Server] Starting addArtist for ${platform}Id:`, platformId);
-
-        const headersList = await headers();
-        console.debug("[Server] Request headers:", {
-            cookie: headersList.get("cookie"),
-            authorization: headersList.get("authorization"),
-        });
 
         const session = await getServerAuthSession();
         console.debug("[Server] Session state:", {
@@ -327,7 +446,11 @@ export async function addArtist(platformId: string, platform: MusicPlatform = 's
 
         if (!session) {
             console.debug("[Server] No session found - authentication failed");
-            throw new Error("Not authenticated");
+            return {
+                status: "error",
+                code: "UNAUTHENTICATED",
+                message: "Please log in to add artists",
+            };
         }
 
         // Validate via platform provider
@@ -340,51 +463,127 @@ export async function addArtist(platformId: string, platform: MusicPlatform = 's
             return { status: "error", message: `Could not find artist on ${platform}` };
         }
 
-        // Dedup check on the appropriate column
-        const column = platform === 'deezer' ? artists.deezer : artists.spotify;
-        console.debug("[Server] Checking if artist exists in database...");
-        const artist = await db.query.artists.findFirst({ where: eq(column, platformId) });
-        if (artist) {
-            console.debug("[Server] Artist already exists:", artist);
-            return {
-                status: "exists",
-                artistId: artist.id,
-                artistName: artist.name ?? "",
-                message: "That artist is already in our database",
+        const normalisedName = normaliseText(platformArtist.name);
+        let notificationCreatedAt: string | null | undefined;
+        const result = await db.transaction(async (transaction): Promise<AddArtistResp> => {
+            const database = transaction as ArtistCreationExecutor;
+            await acquirePlatformIdentityLock(database, platform, platformId);
+            if (!options?.forceCreate) {
+                await acquireArtistNameLock(database, normalisedName);
+            }
+
+            console.debug("[Server] Checking platform ID ownership...");
+            const ownership = await resolvePlatformIdOwner(database, platform, platformId);
+            if (ownership.status === "conflict") {
+                console.error("[Server] Conflicting platform ID owners:", ownership.candidates);
+                return {
+                    status: "conflict",
+                    candidates: ownership.candidates,
+                    platform,
+                    platformId,
+                    message: "That platform profile is assigned to conflicting artist records",
+                };
+            }
+            if (ownership.status === "owner") {
+                console.debug("[Server] Artist already exists:", ownership.owner);
+                return {
+                    status: "exists",
+                    artistId: ownership.owner.id,
+                    artistName: ownership.owner.name ?? "",
+                    message: "That artist is already in our database",
+                };
+            }
+
+            if (!options?.forceCreate) {
+                const possibleDuplicates = await database.query.artists.findMany({
+                    where: eq(artists.lcname, normalisedName),
+                    orderBy: [asc(artists.createdAt), asc(artists.id)],
+                    limit: ADD_ARTIST_CANDIDATE_LIMIT,
+                    columns: { id: true, name: true, spotify: true, deezer: true },
+                });
+                if (possibleDuplicates.length > 0) {
+                    return {
+                        status: "possible_duplicate",
+                        candidates: possibleDuplicates.map(toAddArtistCandidate),
+                        platform,
+                        platformId,
+                        message: "We found an artist with the same name. Choose the existing artist or confirm this is a different artist.",
+                    };
+                }
+            }
+
+            console.debug("[Server] Inserting new artist into database...");
+            const artistData = {
+                [platform]: platformId,
+                lcname: normalisedName,
+                name: platformArtist.name,
+                addedBy: session.user?.id || undefined,
             };
-        }
 
-        console.debug("[Server] Inserting new artist into database...");
-        const artistData = {
-            [platform]: platformId,
-            lcname: normaliseText(platformArtist.name),
-            name: platformArtist.name,
-            addedBy: session?.user?.id || undefined,
-        };
+            const [newArtist] = await database
+                .insert(artists)
+                .values(artistData)
+                .onConflictDoNothing()
+                .returning();
 
-        const [newArtist] = await db.insert(artists).values(artistData).returning();
-        console.debug("[Server] New artist created:", newArtist);
+            if (!newArtist) {
+                const raceWinner = await resolvePlatformIdOwner(database, platform, platformId);
+                if (raceWinner.status === "conflict") {
+                    return {
+                        status: "conflict",
+                        candidates: raceWinner.candidates,
+                        platform,
+                        platformId,
+                        message: "That platform profile is assigned to conflicting artist records",
+                    };
+                }
+                if (raceWinner.status === "owner") {
+                    return {
+                        status: "exists",
+                        artistId: raceWinner.owner.id,
+                        artistName: raceWinner.owner.name ?? "",
+                        message: "That artist is already in our database",
+                    };
+                }
+                return {
+                    status: "error",
+                    message: "The artist could not be created because another record changed at the same time. Please try again.",
+                };
+            }
+            console.debug("[Server] New artist created:", newArtist);
+            notificationCreatedAt = newArtist.createdAt;
 
-        if (session?.user?.id) {
-            const user = await getUserById(session.user.id);
-            if (user) {
-                await sendDiscordMessage(
-                    `${getUserDisplayName(user)} added new artist named: ${newArtist.name} (Submitted ${platform}Id: ${platformId}) ${newArtist.createdAt}`
-                );
+            return {
+                status: "success",
+                artistId: newArtist.id,
+                artistName: newArtist.name ?? "",
+                message: "Success! You can now find this artist in our directory",
+            };
+        });
+
+        if (result.status === "success" && session.user?.id) {
+            try {
+                const user = await getUserById(session.user.id);
+                if (user) {
+                    await sendDiscordMessage(
+                        `${getUserDisplayName(user)} added new artist named: ${result.artistName ?? ""} (Submitted ${platform}Id: ${platformId}) ${notificationCreatedAt ?? ""}`
+                    );
+                }
+            } catch (notificationError) {
+                console.error("[Server] Failed to send artist-added notification:", notificationError);
             }
         }
 
-        return {
-            status: "success",
-            artistId: newArtist.id,
-            artistName: newArtist.name ?? "",
-            message: "Success! You can now find this artist in our directory",
-        };
+        return result;
     } catch (e) {
         console.error("[Server] Error in addArtist:", e);
         if (e instanceof Error) {
             if (e.message.includes("auth")) {
-                return { status: "error", message: "Please log in to add artists" };
+                return {
+                    status: "error",
+                    code: "UNAUTHENTICATED",
+                    message: "Please log in to add artists",
+                };
             }
             if (e.message.includes("duplicate")) {
                 return { status: "error", message: "This artist is already in our database" };
@@ -406,11 +605,30 @@ export async function approveUgcAdmin(ugcIds: string[]) {
 
     try {
         const ugcData = await db.query.ugcresearch.findMany({ where: inArray(ugcresearch.id, ugcIds) });
-        await Promise.all(
+        const approvalResults = await Promise.allSettled(
             ugcData.map(async (ugc) => {
                 await approveUGC(ugc.id, ugc.artistId ?? "", ugc.siteName ?? "", ugc.siteUsername ?? "");
             })
         );
+
+        const failures = approvalResults.flatMap((result, index) => {
+            if (result.status === "fulfilled") return [];
+
+            const reason = result.reason instanceof Error
+                ? result.reason.message
+                : String(result.reason);
+            return [{ ugcId: ugcData[index]?.id ?? "unknown", reason }];
+        });
+
+        if (failures.length > 0) {
+            const approvedCount = approvalResults.length - failures.length;
+            return {
+                status: "error",
+                message: `Approved ${approvedCount} of ${approvalResults.length} UGC items. Failed: ${failures
+                    .map(({ ugcId, reason }) => `${ugcId} (${reason})`)
+                    .join("; ")}`,
+            };
+        }
     } catch (e) {
         console.error("error approving ugc:", e);
         return { status: "error", message: "Error approving UGC" };
@@ -475,6 +693,9 @@ export async function approveUGC(
         await db.update(ugcresearch).set({ accepted: true, dateProcessed: new Date().toISOString() }).where(eq(ugcresearch.id, ugcId));
     } catch (e) {
         console.error(`Error approving ugc`, e);
+        if (e instanceof ArtistLinkConflictError) {
+            throw e;
+        }
         throw new Error(e instanceof Error ? `Error approving UGC: ${e.message}` : "Error approving UGC");
     }
 }
@@ -558,6 +779,9 @@ export async function addArtistData(artistUrl: string, artist: Artist): Promise<
         };
     } catch (e) {
         console.error("error adding artist data", e);
+        if (e instanceof ArtistLinkConflictError) {
+            return { status: "error", message: e.message };
+        }
         return { status: "error", message: "Error adding artist data, please try again" };
     }
 }


### PR DESCRIPTION
## Summary

- Prevent duplicate and conflicting artist records across Spotify, Deezer, canonical artist columns, and ID mappings
- Add safe same-name duplicate handling across artist-add flows
- Resolve verified reciprocal Spotify/Deezer IDs through Wikidata and destination-provider validation
- Persist both platform IDs atomically with deterministic identity locking and Deezer mapping provenance
- Harden artist-link writes, race handling, MCP behavior, and UI handoff

## Included PRs

- #1170
- #1171

## Validation

- Type-check, lint, test, build, automated review, and Vercel preview checks passed on both staging PRs
- Manual acceptance testing passed on staging against Music Nerd Dev:
  - Deezer → Spotify: Destroyalldreamers
  - Spotify → Deezer: Hotel Lights
  - Both platform links rendered and both IDs were persisted
  - Reciprocal re-adds returned the existing artist without creating duplicates
  - Directory search worked with no application console errors

No database migration is required.