### PR TITLE
fix: harden reciprocal artist identity review findings

### DIFF
--- a/src/__tests__/components/AddArtistContent.test.tsx
+++ b/src/__tests__/components/AddArtistContent.test.tsx
@@ -128,6 +128,85 @@ describe('AddArtistContent duplicate choice', () => {
         });
     });
 
+    it('submits the initial add only once when activated twice before state settles', async () => {
+        let resolveAdd!: (value: unknown) => void;
+        mockAddArtist.mockReturnValueOnce(new Promise(resolve => { resolveAdd = resolve; }));
+        const { container } = render(<AddArtistContent initialArtist={initialArtist} />);
+        const addButton = screen.getByRole('button', { name: 'Add Artist' });
+
+        act(() => {
+            addButton.click();
+            addButton.click();
+        });
+
+        expect(mockAddArtist).toHaveBeenCalledTimes(1);
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+        expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+
+        await act(async () => {
+            resolveAdd({ status: 'error', message: 'Try again.' });
+        });
+    });
+
+    it('submits force creation only once when activated twice before state settles', async () => {
+        await submitWithDuplicate();
+        let resolveCreate!: (value: unknown) => void;
+        mockAddArtist.mockReturnValueOnce(new Promise(resolve => { resolveCreate = resolve; }));
+        const createButton = screen.getByRole('button', { name: 'Create separate artist' });
+
+        act(() => {
+            createButton.click();
+            createButton.click();
+        });
+
+        expect(mockAddArtist).toHaveBeenCalledTimes(2);
+
+        await act(async () => {
+            resolveCreate({ status: 'success', artistId: 'new-id', artistName: 'Same Name' });
+        });
+
+        expect(mockPush).toHaveBeenCalledTimes(1);
+        expect(mockPush).toHaveBeenCalledWith('/artist/new-id');
+    });
+
+    it('ignores a pending response when cancellation wins the same render turn', async () => {
+        let resolveAdd!: (value: unknown) => void;
+        mockAddArtist.mockReturnValueOnce(new Promise(resolve => { resolveAdd = resolve; }));
+        render(<AddArtistContent initialArtist={initialArtist} />);
+        const addButton = screen.getByRole('button', { name: 'Add Artist' });
+        const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+
+        act(() => {
+            addButton.click();
+            cancelButton.click();
+        });
+
+        expect(mockBack).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            resolveAdd({ status: 'success', artistId: 'late-id', artistName: 'Same Name' });
+        });
+
+        expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it('ignores a pending add response after navigation unmounts the page', async () => {
+        let resolveAdd!: (value: unknown) => void;
+        mockAddArtist.mockReturnValueOnce(new Promise(resolve => { resolveAdd = resolve; }));
+        const { unmount } = render(<AddArtistContent initialArtist={initialArtist} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add Artist' }));
+
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+        unmount();
+
+        await act(async () => {
+            resolveAdd({ status: 'success', artistId: 'late-id', artistName: 'Same Name' });
+        });
+
+        expect(mockPush).not.toHaveBeenCalled();
+    });
+
     it('blocks candidate navigation and cancellation while force creation is pending', async () => {
         const candidateLink = await submitWithDuplicate();
         let resolveCreate!: (value: unknown) => void;

--- a/src/app/add-artist/_components/AddArtistContent.tsx
+++ b/src/app/add-artist/_components/AddArtistContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { addArtist } from "../../actions/addArtist";
@@ -24,6 +24,13 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
     const [error, setError] = useState<string | null>(null);
     const [duplicateChoice, setDuplicateChoice] = useState<PossibleDuplicateResponse | null>(null);
     const { data: session, status } = useSession();
+    const requestGenerationRef = useRef(0);
+    const requestInFlightRef = useRef(false);
+
+    useEffect(() => () => {
+        requestGenerationRef.current += 1;
+        requestInFlightRef.current = false;
+    }, []);
 
     function promptLogin() {
         const loginBtn = document.getElementById("login-btn");
@@ -55,7 +62,7 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
     }
 
     async function handleAddArtist() {
-        if (status === "loading") {
+        if (status === "loading" || requestInFlightRef.current) {
             return;
         }
 
@@ -64,17 +71,26 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
             return;
         }
 
+        const requestGeneration = ++requestGenerationRef.current;
+        requestInFlightRef.current = true;
         setAdding(true);
         setError(null);
 
         try {
             const result = await addArtist(initialArtist.platformId, initialArtist.platform);
-            handleResult(result);
+            if (requestGenerationRef.current === requestGeneration) {
+                handleResult(result);
+            }
         } catch (err) {
             console.error("Error in handleAddArtist:", err);
-            setError("Failed to add artist - please try again");
+            if (requestGenerationRef.current === requestGeneration) {
+                setError("Failed to add artist - please try again");
+            }
         } finally {
-            setAdding(false);
+            if (requestGenerationRef.current === requestGeneration) {
+                requestInFlightRef.current = false;
+                setAdding(false);
+            }
         }
     }
 
@@ -82,30 +98,48 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
         if (
             !duplicateChoice
             || duplicateChoice.canCreateSeparate === false
-            || isCreatingSeparate
+            || requestInFlightRef.current
         ) return;
 
+        const response = duplicateChoice;
+        const requestGeneration = ++requestGenerationRef.current;
+        requestInFlightRef.current = true;
         setIsCreatingSeparate(true);
         setError(null);
         try {
             const result = await addArtist(
-                duplicateChoice.platformId,
-                duplicateChoice.platform,
+                response.platformId,
+                response.platform,
                 { forceCreate: true },
             );
-            handleResult(result);
+            if (requestGenerationRef.current === requestGeneration) {
+                handleResult(result);
+            }
         } catch (err) {
             console.error("Error creating separate artist:", err);
-            setError("Failed to add artist - please try again");
+            if (requestGenerationRef.current === requestGeneration) {
+                setError("Failed to add artist - please try again");
+            }
         } finally {
-            setIsCreatingSeparate(false);
+            if (requestGenerationRef.current === requestGeneration) {
+                requestInFlightRef.current = false;
+                setIsCreatingSeparate(false);
+            }
         }
     }
+
+    function handleCancel() {
+        requestGenerationRef.current += 1;
+        requestInFlightRef.current = false;
+        router.back();
+    }
+
+    const isRequestInFlight = adding || isCreatingSeparate;
 
     return (
         <div className="min-h-screen flex items-center justify-center bg-gray-50">
             <div
-                aria-busy={isCreatingSeparate}
+                aria-busy={isRequestInFlight}
                 className="bg-white p-8 rounded-xl shadow-lg max-w-2xl w-full mx-4"
             >
                 {status === "loading" ? (
@@ -160,9 +194,9 @@ export default function AddArtistContent({ initialArtist }: { initialArtist: Mus
                                 {adding ? "Adding..." : "Add Artist"}
                             </Button>
                             <Button
-                                onClick={() => router.back()}
+                                onClick={handleCancel}
                                 variant="outline"
-                                disabled={isCreatingSeparate}
+                                disabled={isRequestInFlight}
                             >
                                 Cancel
                             </Button>

--- a/src/server/utils/__tests__/artistLinkService.test.ts
+++ b/src/server/utils/__tests__/artistLinkService.test.ts
@@ -113,6 +113,7 @@ describe("artistLinkService", () => {
     const { db, clearArtistLink } = await setup();
     const result = await clearArtistLink("artist-123", "instagram");
     expect(db.execute).toHaveBeenCalled();
+    expect(db.transaction).not.toHaveBeenCalled();
     expect(result).toEqual({ oldValue: null });
   });
 
@@ -258,6 +259,35 @@ describe("artistLinkService", () => {
         setArtistLink("artist-123", platform, `${platform}-123`),
       ).resolves.toEqual({ oldValue: null, artistName: "Test Artist" });
       expect(db.execute).toHaveBeenCalledTimes(3);
+    },
+  );
+
+  it.each(["spotify", "deezer"])(
+    "serializes a %s clear under the artist/platform slot lock",
+    async (platform) => {
+      const { db, clearArtistLink } = await setup();
+      (db as any).query.artists.findFirst.mockResolvedValue({
+        id: "artist-123",
+        name: "Test Artist",
+        [platform]: `${platform}-123`,
+      });
+
+      await expect(
+        clearArtistLink("artist-123", platform),
+      ).resolves.toEqual({ oldValue: `${platform}-123` });
+
+      expect(db.transaction).toHaveBeenCalledTimes(1);
+      // Stable artist/platform slot lock, followed by the artist update.
+      expect(db.execute).toHaveBeenCalledTimes(2);
+      expect(dialect.sqlToQuery(db.execute.mock.calls[0][0]).params[0]).toBe(
+        `musicnerd:artist-platform-slot:artist-123:${platform}`,
+      );
+      expect(db.execute.mock.invocationCallOrder[0]).toBeLessThan(
+        (db as any).query.artists.findFirst.mock.invocationCallOrder[0],
+      );
+      expect(
+        (db as any).query.artistIdMappings.findFirst,
+      ).not.toHaveBeenCalled();
     },
   );
 

--- a/src/server/utils/artistLinkService.ts
+++ b/src/server/utils/artistLinkService.ts
@@ -5,7 +5,10 @@
 import { db } from "@/server/db/drizzle";
 import { and, eq, sql } from "drizzle-orm";
 import { artists, artistIdMappings } from "@/server/db/schema";
-import { acquireArtistPlatformWriteLocks } from "./artistIdentityLocks";
+import {
+  acquireArtistPlatformLock,
+  acquireArtistPlatformWriteLocks,
+} from "./artistIdentityLocks";
 
 export class ArtistLinkConflictError extends Error {
   constructor(message: string) {
@@ -152,8 +155,23 @@ export async function clearArtistLink(
   const columnName = sanitizeColumnName(siteName);
   assertWritable(columnName);
 
+  if (columnName === "spotify" || columnName === "deezer") {
+    return db.transaction(async (transaction) => {
+      await acquireArtistPlatformLock(transaction, artistId, columnName);
+      return clearArtistLinkWithExecutor(transaction, artistId, columnName);
+    });
+  }
+
+  return clearArtistLinkWithExecutor(db, artistId, columnName);
+}
+
+async function clearArtistLinkWithExecutor(
+  database: ArtistLinkExecutor,
+  artistId: string,
+  columnName: string,
+): Promise<{ oldValue: string | null }> {
   // Fetch full row to capture oldValue for audit trail (MCP callers use the return value)
-  const artist = await db.query.artists.findFirst({
+  const artist = await database.query.artists.findFirst({
     where: eq(artists.id, artistId),
   });
   if (!artist) {
@@ -164,7 +182,7 @@ export async function clearArtistLink(
   const oldValue = getArtistLinkValue(artist, columnName);
 
   // See setArtistLink: link changes no longer null/regenerate the bio.
-  await db.execute(sql`UPDATE artists SET ${sql.identifier(columnName)} = NULL WHERE id = ${artistId}`);
+  await database.execute(sql`UPDATE artists SET ${sql.identifier(columnName)} = NULL WHERE id = ${artistId}`);
 
   return { oldValue };
 }

--- a/src/server/utils/musicPlatform/__tests__/crossPlatformArtistResolver.test.ts
+++ b/src/server/utils/musicPlatform/__tests__/crossPlatformArtistResolver.test.ts
@@ -103,6 +103,79 @@ describe('findReciprocalArtistIdentity', () => {
         expect(decodeURIComponent(requestBody)).toContain('wdt:P2722 ?targetId');
     });
 
+    it.each([
+        {
+            sourcePlatform: 'spotify' as const,
+            sourcePlatformId: 'spotify123',
+            sourceProperty: 'P1902',
+            targetProperty: 'P2722',
+        },
+        {
+            sourcePlatform: 'deezer' as const,
+            sourcePlatformId: '145',
+            sourceProperty: 'P2722',
+            targetProperty: 'P1902',
+        },
+    ])(
+        'requires unique Wikidata ownership in both directions for $sourcePlatform',
+        async ({ sourcePlatform, sourcePlatformId, sourceProperty, targetProperty }) => {
+            mockFetch.mockResolvedValue(wikidataResponse([]));
+
+            await findReciprocalArtistIdentity({
+                platform: sourcePlatform,
+                platformId: sourcePlatformId,
+                name: 'Artist',
+            });
+
+            const requestBody = mockFetch.mock.calls[0][1].body as string;
+            const query = decodeURIComponent(requestBody);
+            expect(query).toContain(
+                `?otherSource wdt:${sourceProperty} "${sourcePlatformId}"`,
+            );
+            expect(query).toContain(
+                `?otherTarget wdt:${targetProperty} ?targetId`,
+            );
+            expect(query).toContain('FILTER (?otherSource != ?item)');
+            expect(query).toContain('FILTER (?otherTarget != ?item)');
+        },
+    );
+
+    it('returns null without provider verification when uniqueness filtering leaves no match', async () => {
+        mockFetch.mockResolvedValue(wikidataResponse([]));
+
+        await expect(findReciprocalArtistIdentity({
+            platform: 'spotify',
+            platformId: 'spotify123',
+            name: 'Artist',
+        })).resolves.toBeNull();
+        expect(mockDeezerGetArtist).not.toHaveBeenCalled();
+        expect(mockSpotifyGetArtist).not.toHaveBeenCalled();
+    });
+
+    it('returns the target provider canonical ID after verification', async () => {
+        mockFetch.mockResolvedValue(wikidataResponse([{
+            entity: 'Q36153',
+            targetId: '000145',
+        }]));
+        mockDeezerGetArtist.mockResolvedValue({
+            platform: 'deezer',
+            platformId: '145',
+            name: 'Beyonce',
+        });
+
+        await expect(findReciprocalArtistIdentity({
+            platform: 'spotify',
+            platformId: 'spotify123',
+            name: 'Beyonce',
+        })).resolves.toEqual({
+            platform: 'deezer',
+            platformId: '145',
+            source: 'wikidata',
+            wikidataId: 'Q36153',
+        });
+        expect(mockDeezerGetArtist).toHaveBeenCalledWith('000145');
+    });
+
     it('rejects malformed source IDs before querying Wikidata', async () => {
         await expect(findReciprocalArtistIdentity({
             platform: 'spotify',

--- a/src/server/utils/musicPlatform/crossPlatformArtistResolver.ts
+++ b/src/server/utils/musicPlatform/crossPlatformArtistResolver.ts
@@ -76,6 +76,14 @@ async function findWikidataCounterpart(
 SELECT ?item ?targetId WHERE {
   ?item wdt:${sourceProperty} "${sourcePlatformId}" .
   ?item wdt:${targetProperty} ?targetId .
+  FILTER NOT EXISTS {
+    ?otherSource wdt:${sourceProperty} "${sourcePlatformId}" .
+    FILTER (?otherSource != ?item)
+  }
+  FILTER NOT EXISTS {
+    ?otherTarget wdt:${targetProperty} ?targetId .
+    FILTER (?otherTarget != ?item)
+  }
 }
 LIMIT 10`;
     const response = await fetch(WIKIDATA_ENDPOINT, {
@@ -144,8 +152,11 @@ export async function findReciprocalArtistIdentity(
             PROVIDER_VERIFICATION_TIMEOUT_MS,
             `${targetPlatform} artist verification`,
         );
+        const verifiedPlatformId = verifiedArtist?.platformId?.trim();
         if (
             !verifiedArtist
+            || !verifiedPlatformId
+            || !isValidPlatformId(targetPlatform, verifiedPlatformId)
             || normalizeArtistName(verifiedArtist.name) !== normalizedName
         ) {
             return null;
@@ -153,7 +164,7 @@ export async function findReciprocalArtistIdentity(
 
         return {
             platform: targetPlatform,
-            platformId: counterpart.platformId,
+            platformId: verifiedPlatformId,
             source: 'wikidata',
             wikidataId: counterpart.wikidataId,
         };

--- a/src/server/utils/queries/__tests__/addArtistIdentity.test.ts
+++ b/src/server/utils/queries/__tests__/addArtistIdentity.test.ts
@@ -94,8 +94,16 @@ describe("addArtist identity resolution", () => {
         mockGetUserById.mockResolvedValue(null);
         mockGetUserDisplayName.mockReturnValue("tester");
         mockSendDiscordMessage.mockResolvedValue(undefined);
-        mockSpotifyGetArtist.mockResolvedValue({ name: "Jonathan Pape" });
-        mockDeezerGetArtist.mockResolvedValue({ name: "Jonathan Pape" });
+        mockSpotifyGetArtist.mockResolvedValue({
+            platform: "spotify",
+            platformId: "spotify-123",
+            name: "Jonathan Pape",
+        });
+        mockDeezerGetArtist.mockResolvedValue({
+            platform: "deezer",
+            platformId: "815939",
+            name: "Jonathan Pape",
+        });
         mockFindReciprocalArtistIdentity.mockResolvedValue(null);
         mockAcquirePlatformIdentityLock.mockResolvedValue(undefined);
         mockAcquireArtistNameLock.mockResolvedValue(undefined);
@@ -304,6 +312,59 @@ describe("addArtist identity resolution", () => {
             deezer: expect.anything(),
         }));
         expect(mockAcquirePlatformIdentityLock).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses the provider's canonical Deezer ID for resolution, locking, and insertion", async () => {
+        const { addArtist, mockDb } = await setup();
+        mockDeezerGetArtist.mockResolvedValue({
+            platform: "deezer",
+            platformId: "6251",
+            name: "Jonathan Pape",
+        });
+        const insert = mockInsertReturning(mockDb, [
+            artist({ id: "new-artist", deezer: "6251" }),
+        ]);
+
+        const result = await addArtist("0006251", "deezer", { forceCreate: true });
+
+        expect(result.status).toBe("success");
+        expect(mockFindReciprocalArtistIdentity).toHaveBeenCalledWith({
+            platform: "deezer",
+            platformId: "6251",
+            name: "Jonathan Pape",
+        });
+        expect(mockAcquirePlatformIdentityLock).toHaveBeenCalledWith(
+            mockDb,
+            "deezer",
+            "6251",
+        );
+        expect(insert.values).toHaveBeenCalledWith(expect.objectContaining({
+            deezer: "6251",
+        }));
+    });
+
+    it("finds a canonical Deezer owner when the submitted URL uses a zero-padded alias", async () => {
+        const { addArtist, mockDb } = await setup();
+        const existing = artist({ id: "deezer-owner", deezer: "6251" });
+        mockDeezerGetArtist.mockResolvedValue({
+            platform: "deezer",
+            platformId: "6251",
+            name: "Jonathan Pape",
+        });
+        mockDb.query.artists.findFirst.mockResolvedValueOnce(existing);
+
+        const result = await addArtist("0006251", "deezer");
+
+        expect(result).toEqual(expect.objectContaining({
+            status: "exists",
+            artistId: "deezer-owner",
+        }));
+        expect(mockAcquirePlatformIdentityLock).toHaveBeenCalledWith(
+            mockDb,
+            "deezer",
+            "6251",
+        );
+        expect(mockDb.insert).not.toHaveBeenCalled();
     });
 
     it("offers the owner of a discovered reciprocal ID instead of creating a duplicate", async () => {

--- a/src/server/utils/queries/artistQueries.ts
+++ b/src/server/utils/queries/artistQueries.ts
@@ -565,18 +565,22 @@ export async function addArtist(
         const provider = platform === 'deezer' ? deezerProvider : spotifyProvider;
         console.debug(`[Server] Validating ${platform} artist...`);
         const platformArtist = await provider.getArtist(platformId);
+        const canonicalPlatformId = platformArtist?.platformId?.trim();
 
-        if (!platformArtist?.name) {
+        if (!platformArtist?.name || !canonicalPlatformId) {
             console.error(`[Server] Invalid artist data from ${platform}`);
             return { status: "error", message: `Could not find artist on ${platform}` };
         }
 
         const reciprocalIdentity = await findReciprocalArtistIdentity({
             platform,
-            platformId,
+            platformId: canonicalPlatformId,
             name: platformArtist.name,
         });
-        const submittedIdentity = { platform, platformId } satisfies ArtistPlatformIdentity;
+        const submittedIdentity = {
+            platform,
+            platformId: canonicalPlatformId,
+        } satisfies ArtistPlatformIdentity;
         const identities = sortArtistPlatformIdentities([
             submittedIdentity,
             ...(reciprocalIdentity ? [reciprocalIdentity] : []),
@@ -638,8 +642,8 @@ export async function addArtist(
                     return {
                         status: "possible_duplicate",
                         candidates: possibleDuplicates.map(toAddArtistCandidate),
-                        platform,
-                        platformId,
+                        platform: submittedIdentity.platform,
+                        platformId: submittedIdentity.platformId,
                         message: "We found an artist with the same name. Choose the existing artist or confirm this is a different artist.",
                     };
                 }
@@ -682,6 +686,8 @@ export async function addArtist(
                 };
             }
 
+            // Mappings are Spotify-anchored, so provenance always records the
+            // Deezer side of a verified pair, even when Deezer was submitted.
             const mappedDeezerId = platformIds.deezer;
             if (reciprocalIdentity && mappedDeezerId) {
                 const reasoning = `Wikidata ${reciprocalIdentity.wikidataId} links Spotify and Deezer for ${platformArtist.name}`;
@@ -719,7 +725,7 @@ export async function addArtist(
                 const user = await getUserById(session.user.id);
                 if (user) {
                     await sendDiscordMessage(
-                        `${getUserDisplayName(user)} added new artist named: ${result.artistName ?? ""} (Submitted ${platform}Id: ${platformId}) ${notificationCreatedAt ?? ""}`
+                        `${getUserDisplayName(user)} added new artist named: ${result.artistName ?? ""} (Submitted ${platform}Id: ${canonicalPlatformId}) ${notificationCreatedAt ?? ""}`
                     );
                 }
             } catch (notificationError) {


### PR DESCRIPTION
## Summary

- prevent stale add-artist responses and rapid duplicate submissions in the standalone add flow
- require reciprocal Wikidata IDs to be uniquely owned in both directions
- canonicalize provider-returned Spotify/Deezer IDs before locking, lookup, and persistence
- serialize Spotify/Deezer clears with concurrent identity writes
- clarify that reciprocal mapping provenance is intentionally Spotify-anchored and records the Deezer side

## Review context

Addresses the actionable request-safety finding from #1172 and two additional identity-integrity issues found during release review.

The review suggestion to store `reciprocalIdentity.platform` in `artist_id_mappings` was not applied: Spotify is the anchor identity, `spotify` is intentionally not a valid mapping target, and Deezer provenance is recorded regardless of add direction.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run test -- --runInBand`
- `npm run build`
- focused regression suites: 73 tests passed